### PR TITLE
Add CloudArray (sub)-class definitions

### DIFF
--- a/tiledb/cloud/__init__.py
+++ b/tiledb/cloud/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 
 from . import client
+from .cloudarray import DenseCloudArray, SparseCloudArray

--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -1,0 +1,28 @@
+import tiledb
+import urllib
+
+def split_uri(uri):
+  parsed = urllib.parse.urlparse(uri)
+  if not parsed.scheme == "tiledb":
+    raise Exception("Incorrect array uri, must be in tiledb:// scheme")
+  return parsed.netloc, parsed.path[1:]
+
+class CloudArray(object):
+  def array_sharing_list(self):
+    """Return array metadata"""
+    (namespace, array_name) = split_uri(self.uri)
+    if not isinstance(config.logged_in, bool):
+      raise Exception(config.logged_in)
+    api_instance = rest_api.ArrayApi(rest_api.ApiClient(config.config))
+
+    return api_instance.get_array_sharing_policies(namespace=namespace, array=array_name)
+
+class DenseCloudArray(CloudArray, tiledb.DenseArray):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+class SparseCloudArray(CloudArray, tiledb.SparseArray):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+


### PR DESCRIPTION
As discussed, here's a little mock-up of subclassing -- only tested on a local array, but it works how we discussed (existing functionality is forwarded), and the added list function (from #3) is correctly called:

```
from tiledb.cloud import DenseCloudArray
a = DenseCloudArray("/tmp/a2")
a.nonempty_domain()
Out[4]: ((0, 9),)
a[:]
Out[5]: array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
a.array_sharing_list()
Traceback (most recent call last):
  File "/cmn/condaenvs/tiledb/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3326, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-12f084fe445d>", line 1, in <module>
    a.array_sharing_list()
  File "/Users/inorton/work/git/TileDB-Cloud-Py/tiledb/cloud/cloudarray.py", line 13, in array_sharing_list
    (namespace, array_name) = split_uri(self.uri)
  File "/Users/inorton/work/git/TileDB-Cloud-Py/tiledb/cloud/cloudarray.py", line 7, in split_uri
    raise Exception("Incorrect array uri, must be in tiledb:// scheme")
Exception: Incorrect array uri, must be in tiledb:// scheme
```