### PR TITLE
Add task fetch functions

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -57,6 +57,12 @@ def get_udf_api():
     return rest_api.UdfApi(rest_api.ApiClient(config.config))
 
 
+def get_tasks_api():
+    if not isinstance(config.logged_in, bool):
+        raise Exception(config.logged_in)
+    return rest_api.TasksApi(rest_api.ApiClient(config.config))
+
+
 def get_sql_api():
     if not isinstance(config.logged_in, bool):
         raise Exception(config.logged_in)

--- a/tiledb/cloud/tasks.py
+++ b/tiledb/cloud/tasks.py
@@ -1,0 +1,55 @@
+from . import client
+from . import tiledb_cloud_error
+from . import cloudarray
+from .rest_api import ApiException as GenApiException
+
+import datetime
+
+def Task(id=None):
+  """
+
+  :param id:
+  :return:
+  """
+  api_instance = client.get_tasks_api()
+
+  try:
+    return api_instance.task_id_get(id=id)
+
+  except GenApiException as exc:
+    raise tiledb_cloud_error.check_exc(exc) from None
+
+
+def Tasks(namespace=None, array=None, start=None, end=datetime.datetime.utcnow(), status=None):
+  """
+  Fetch all tasks a user has access too
+  :param str namespace: optional filter by namespace
+  :param str array: optional limit tasks to specific array
+  :param datetime start: optional start time for listing of tasks, defaults to 7 days ago
+  :param datetime end: optional end time for listing of tasks defaults to now
+  :param str status: optional filter on status can be one of ['FAILED', 'RUNNING', 'COMPLETED']
+  :return:
+  """
+  api_instance = client.get_tasks_api()
+
+  if end is not None:
+    if not isinstance(end, datetime.datetime):
+      raise Exception("end must be datetime object")
+    end = datetime.datetime.timestamp(end)
+
+  if start is not None:
+    if not isinstance(start, datetime.datetime):
+      raise Exception("start must be datetime object")
+    start = datetime.datetime.timestamp(start)
+
+  if status is not None and status != "FAILED" and status != "RUNNING" and status != "COMPLETED":
+    raise Exception("status must be one of ['FAILED', 'RUNNING', 'COMPLETED']")
+
+  if array is not None:
+    (namespace, array) = cloudarray.split_uri(array)
+
+  try:
+    return api_instance.tasks_get(namespace=namespace, array=array, start=start, end=end, status=status)
+
+  except GenApiException as exc:
+    raise tiledb_cloud_error.check_exc(exc) from None

--- a/tiledb/cloud/tiledb_cloud_error.py
+++ b/tiledb/cloud/tiledb_cloud_error.py
@@ -1,3 +1,5 @@
+import json
+
 class TileDBClientError(BaseException):
   pass
 


### PR DESCRIPTION
This adds basic task fetching functionality. We need a smoother way to handle fetching the last task that was run. Right now when you run a udf/sql you don't get the ID returned so you can't easily fetch the array task object to get the logs. We will handle this in a follow up.