### PR TITLE
Add retry for urllib3 for 503s

### DIFF
--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -2,6 +2,7 @@ import os.path, sys
 from pathlib import Path
 import json
 from . import rest_api
+from urllib3 import Retry
 
 config = rest_api.configuration.Configuration()
 default_config_file = Path.joinpath(Path.home(), ".tiledb", "cloud.json")
@@ -68,6 +69,13 @@ def setup_configuration(api_key, host, username="", password="", verify_ssl=True
     config.username = username
     config.password = password
     config.verify_ssl = verify_ssl
+    config.retries = Retry(
+        total=10,
+        backoff_factor=0.25,
+        status_forcelist=[503],
+        method_whitelist=False,
+        raise_on_status=False,
+    )
 
 
 # Load default config file if it exists


### PR DESCRIPTION
This will enable automatic retries for cases where the server doesn't
have enough resources.

We retry 10 times for a total of 127 seconds. 127 seconds was selected
because in worst case scenarios it takes up to 2 minutes to launch resources from cold starts

Backoff retry times (seconds):
0.25
0.5
1.0
2.0
4.0
8.0
16.0
32.0
64.0