### PR TITLE
Add option for using http compression on udfs

### DIFF
--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -111,7 +111,15 @@ def parse_ranges(ranges, builder):
 
 
 class CloudArray(object):
-    def apply(self, func, subarray, attrs=None, layout=None, image_name=None):
+    def apply(
+        self,
+        func,
+        subarray,
+        attrs=None,
+        layout=None,
+        image_name=None,
+        http_compressor="deflate",
+    ):
         """
     Apply a user defined function to a udf
 
@@ -183,6 +191,7 @@ class CloudArray(object):
                     ),
                     image_name=image_name,
                 ),
+                accept_encoding=http_compressor,
                 _preload_content=False,
             )
             response = rest.RESTResponse(response)

--- a/tiledb/cloud/rest_api/api/udf_api.py
+++ b/tiledb/cloud/rest_api/api/udf_api.py
@@ -47,6 +47,7 @@ class UdfApi(object):
         :param str array: name/uri of array that is url-encoded (required)
         :param UDF udf: udf to run (required)
         :param str x_payer: Name of organization or user who should be charged for this request
+        :param str accept_encoding: Encoding to use
         :param _preload_content: if False, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Default is True.
@@ -77,6 +78,7 @@ class UdfApi(object):
         :param str array: name/uri of array that is url-encoded (required)
         :param UDF udf: udf to run (required)
         :param str x_payer: Name of organization or user who should be charged for this request
+        :param str accept_encoding: Encoding to use
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -93,7 +95,13 @@ class UdfApi(object):
 
         local_var_params = locals()
 
-        all_params = ["namespace", "array", "udf", "x_payer"]  # noqa: E501
+        all_params = [
+            "namespace",
+            "array",
+            "udf",
+            "x_payer",
+            "accept_encoding",
+        ]  # noqa: E501
         all_params.append("async_req")
         all_params.append("_return_http_data_only")
         all_params.append("_preload_content")
@@ -136,6 +144,10 @@ class UdfApi(object):
         header_params = {}
         if "x_payer" in local_var_params:
             header_params["X-Payer"] = local_var_params["x_payer"]  # noqa: E501
+        if "accept_encoding" in local_var_params:
+            header_params["Accept-Encoding"] = local_var_params[
+                "accept_encoding"
+            ]  # noqa: E501
 
         form_params = []
         local_var_files = {}

--- a/tiledb/cloud/rest_api/docs/UdfApi.md
+++ b/tiledb/cloud/rest_api/docs/UdfApi.md
@@ -8,7 +8,7 @@ Method | HTTP request | Description
 
 
 # **submit_udf**
-> file submit_udf(namespace, array, udf, x_payer=x_payer)
+> file submit_udf(namespace, array, udf, x_payer=x_payer, accept_encoding=accept_encoding)
 
 
 
@@ -41,9 +41,10 @@ namespace = 'namespace_example' # str | namespace array is in (an organization n
 array = 'array_example' # str | name/uri of array that is url-encoded
 udf = rest_api.UDF() # UDF | udf to run
 x_payer = 'x_payer_example' # str | Name of organization or user who should be charged for this request (optional)
+accept_encoding = 'accept_encoding_example' # str | Encoding to use (optional)
 
 try:
-    api_response = api_instance.submit_udf(namespace, array, udf, x_payer=x_payer)
+    api_response = api_instance.submit_udf(namespace, array, udf, x_payer=x_payer, accept_encoding=accept_encoding)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling UdfApi->submit_udf: %s\n" % e)
@@ -74,9 +75,10 @@ namespace = 'namespace_example' # str | namespace array is in (an organization n
 array = 'array_example' # str | name/uri of array that is url-encoded
 udf = rest_api.UDF() # UDF | udf to run
 x_payer = 'x_payer_example' # str | Name of organization or user who should be charged for this request (optional)
+accept_encoding = 'accept_encoding_example' # str | Encoding to use (optional)
 
 try:
-    api_response = api_instance.submit_udf(namespace, array, udf, x_payer=x_payer)
+    api_response = api_instance.submit_udf(namespace, array, udf, x_payer=x_payer, accept_encoding=accept_encoding)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling UdfApi->submit_udf: %s\n" % e)
@@ -90,6 +92,7 @@ Name | Type | Description  | Notes
  **array** | **str**| name/uri of array that is url-encoded | 
  **udf** | [**UDF**](UDF.md)| udf to run | 
  **x_payer** | **str**| Name of organization or user who should be charged for this request | [optional] 
+ **accept_encoding** | **str**| Encoding to use | [optional] 
 
 ### Return type
 


### PR DESCRIPTION
Add option for using http compression on udfs. We default to `deflate` but `gzip` and `None` is also supported.