### PR TITLE
Add missing setting of logged_in on setup_config

### DIFF
--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -76,6 +76,9 @@ def setup_configuration(api_key, host, username="", password="", verify_ssl=True
         method_whitelist=False,
         raise_on_status=False,
     )
+    # Set logged in at this point
+    global logged_in
+    logged_in = True
 
 
 # Load default config file if it exists


### PR DESCRIPTION
Without setting logged_in then users get a exception about needing to login first but its a catch 22 because the login function first calls the setup_configuration, then it fetches the user model so we can save details like username. The fetch of the user model was gated on the logged_in variable so we could have a friendly message.

The original problem stems from:
https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/c5a0bacf7c7ce69a4e70257e938aa15b8fb31345/tiledb/cloud/client.py#L121
and exception thrown:
https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/c5a0bacf7c7ce69a4e70257e938aa15b8fb31345/tiledb/cloud/client.py#L59

