### PR TITLE
Add support for env variables to read configuration

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -98,7 +98,7 @@ def login(
     :return:
     """
     if host is None:
-        host = "https://api.tiledb.com"
+        host = config.default_host
     elif host.endswith("/v1"):
         host = host[: -len("/v1")]
     elif host.endswith("/v1/"):


### PR DESCRIPTION
Add support for env variables to read configuration for authentication and host details. Variables take precedence over config file.