### PR TITLE
Async API for sql exec and udf apply

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -49,42 +49,6 @@ def Ctx(config=None):
     return tiledb.Ctx(Config(config))
 
 
-def get_array_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.ArrayApi(rest_api.ApiClient(config.config))
-
-
-def get_user_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.UserApi(rest_api.ApiClient(config.config))
-
-
-def get_organization_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.OrganizationApi(rest_api.ApiClient(config.config))
-
-
-def get_udf_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.UdfApi(rest_api.ApiClient(config.config))
-
-
-def get_tasks_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.TasksApi(rest_api.ApiClient(config.config))
-
-
-def get_sql_api():
-    if not isinstance(config.logged_in, bool):
-        raise Exception(config.logged_in)
-    return rest_api.SqlApi(rest_api.ApiClient(config.config))
-
-
 def login(
     token="", username="", password="", host=None, verify_ssl=True, no_session=False
 ):
@@ -118,7 +82,7 @@ def login(
             host=host,
             verify_ssl=verify_ssl,
         )
-        user_api = get_user_api()
+        user_api = client.user_api
         session = user_api.get_session(remember_me=True)
         token = session.token
         username = ""
@@ -145,7 +109,7 @@ def list_arrays(include_public=False, namespace=None, permissions=None):
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
-    api_instance = get_array_api()
+    api_instance = client.array_api
 
     public_share = None
     if not include_public:
@@ -185,7 +149,7 @@ def user_profile():
     :return: your user profile
     """
 
-    api_instance = get_user_api()
+    api_instance = client.user_api
 
     try:
         return api_instance.get_user()
@@ -199,7 +163,7 @@ def organizations():
     :return: list of all organizations user is part of
     """
 
-    api_instance = get_organization_api()
+    api_instance = client.organization_api
 
     try:
         return api_instance.get_all_organizations()
@@ -214,9 +178,40 @@ def organization(organization):
     :return: details about organization
     """
 
-    api_instance = get_organization_api()
+    api_instance = client.organization_api
 
     try:
         return api_instance.get_organization(organization=organization)
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
+
+
+class Client:
+    def __init__(self):
+        self.array_api = self.__get_array_api()
+        self.organization_api = self.__get_organization_api()
+        self.sql_api = self.__get_sql_api()
+        self.tasks_api = self.__get_tasks_api()
+        self.udf_api = self.__get_udf_api()
+        self.user_api = self.__get_user_api()
+
+    def __get_array_api(self):
+        return rest_api.ArrayApi(rest_api.ApiClient(config.config))
+
+    def __get_user_api(self):
+        return rest_api.UserApi(rest_api.ApiClient(config.config))
+
+    def __get_organization_api(self):
+        return rest_api.OrganizationApi(rest_api.ApiClient(config.config))
+
+    def __get_udf_api(self):
+        return rest_api.UdfApi(rest_api.ApiClient(config.config))
+
+    def __get_tasks_api(self):
+        return rest_api.TasksApi(rest_api.ApiClient(config.config))
+
+    def __get_sql_api(self):
+        return rest_api.SqlApi(rest_api.ApiClient(config.config))
+
+
+client = Client()

--- a/tiledb/cloud/tasks.py
+++ b/tiledb/cloud/tasks.py
@@ -17,7 +17,7 @@ def task(id):
     if id is None:
         raise Exception("id parameter can not be empty")
 
-    api_instance = client.get_tasks_api()
+    api_instance = client.client.tasks_api
 
     try:
         return api_instance.task_id_get(id=id)
@@ -46,7 +46,7 @@ def tasks(
   :param int per_page: optional records to return per page
   :return:
   """
-    api_instance = client.get_tasks_api()
+    api_instance = client.client.tasks_api
 
     if end is not None:
         if not isinstance(end, datetime.datetime):


### PR DESCRIPTION
Add async functions and api for sql/udfs

New functions are `tiledb.cloud.sql.exec_async` and  `tiledb.cloud.CloudArray.apply_async`

This reworks the client to use one global object for storing the api classes. This is needed to avoid error with deleting the code generated api clients (i.e. `rest_api.SqlApi`) when an async request is still going.

This also adds new wrapper classes of `SQLResult` and `UDFResult` which implements a single function `get`, so we can handle the deserialization. The classes are derived from the multiprocessing.pool.ApplyResult, which is what the code generated async request returns.

TODOs:
-    [x] Support setting worker pool size
-    [x] Support async UDFs

Example usage:

```
result = tiledb.cloud.sql.exec_async(query="select * from `tiledb://TileDB-Inc/quickstart_dense`")
print(result.get())
```


```
def median(df):
    import numpy
    return numpy.median(df["a"])

with tiledb.DenseArray("tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.Ctx()) as A:
  res = A.apply_async(median, [(1,4), (1,4)])

print(res.get())
```

Users can set the urllib3/request worker pool size with `tiledb.cloud.config.config.connection_pool_maxsize=x`. Default pool size is `multiprocessing.cpu_count() * 5`