### PR TITLE
Remove OSX python3.5 since we don't have wheels

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,9 +12,6 @@ jobs:
 - job: Build
   strategy:
     matrix:
-      mac_35:
-        imageName: 'macOS-10.13'
-        python.version: '3.5'
       mac_36:
         imageName: 'macOS-10.13'
         python.version: '3.6'


### PR DESCRIPTION
Will add back if we have users wanting to use 3.5 on OSX