### PR TITLE
Adjust generic UDF to support multiple args/kwargs

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -194,9 +194,7 @@ class DAGCloudApplyTest(unittest.TestCase):
 
         d = dag.DAG()
 
-        node = d.add_node(
-            tiledb.cloud.udf.exec, lambda x: numpy.sum(x), arguments=[1, 4, 10, 40]
-        )
+        node = d.add_node(tiledb.cloud.udf.exec, lambda x: numpy.sum(x), [1, 4, 10, 40])
         node.name = "node"
 
         d.exec()
@@ -267,10 +265,7 @@ class DAGCloudApplyTest(unittest.TestCase):
             return numpy.mean(args)
 
         node_exec = d.add_node(
-            tiledb.cloud.udf.exec,
-            func=mean,
-            arguments=[node_array_apply, node_sql],
-            name="node_exec",
+            tiledb.cloud.udf.exec, mean, [node_array_apply, node_sql], name="node_exec",
         )
 
         d.exec()
@@ -323,9 +318,7 @@ class DAGCloudApplyTest(unittest.TestCase):
 
             return numpy.mean(args)
 
-        node_exec = d.submit_udf(
-            func=mean, arguments=[node_array_apply, node_sql], name="node_exec",
-        )
+        node_exec = d.submit_udf(mean, [node_array_apply, node_sql], name="node_exec")
 
         d.exec()
 

--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+import numpy as np
+from tiledb.cloud import udf
+import tiledb.cloud
+
+tiledb.cloud.login(
+    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
+    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
+)
+
+
+class GenericUDFTest(unittest.TestCase):
+    def test_simple_generic_udf(self):
+        res = udf.exec(lambda x: np.sum(x), [1, 4, 10, 40])
+        self.assertEqual(res, 55)
+
+    def test_kwargs(self):
+        def test_func(kw1=None, kw2=None):
+            return [kw1, kw2]
+
+        res = udf.exec(test_func, kw1="test")
+        self.assertEqual(res, ["test", None])
+
+    def test_positional_args(self):
+        def test_func(pos1, pos2, kw1=None, kw2=None):
+            return [pos1, pos2, kw1, kw2]
+
+        res = udf.exec(test_func, 1, [2, 2])
+        self.assertEqual(res, [1, [2, 2], None, None])
+
+    def test_positional_args_and_kwargs(self):
+        def test_func(pos1, pos2, kw1=None, kw2=None):
+            return [pos1, pos2, kw1, kw2]
+
+        res = udf.exec(test_func, pos1=1, pos2=[2, 2], kw1=dict(test=1), kw2=[1, 2, 3])
+        self.assertEqual(res, [1, [2, 2], {"test": 1}, [1, 2, 3]])

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -27,14 +27,14 @@ def handle_complete_node(node, future):
 
 
 class Node:
-    def __init__(self, func, args, name=None, dag=None, kwargs=None):
+    def __init__(self, func, *args, name=None, dag=None, **kwargs):
         """
         Node is a class that represents a function to run in a DAG
         :param func: function to run
         :param args: tuple of arguments to run
         :param name: optional name of dag
         :param dag: dag this node is associated with
-        :param kwards: dictionary for keyword arguments
+        :param kwargs: dictionary for keyword arguments
         """
         self.id = uuid.uuid4()
         self.error = None
@@ -423,7 +423,7 @@ class DAG:
         :param name: name
         :return: Node that is created
         """
-        node = Node(func_exec, args, dag=self, name=name, kwargs=kwargs)
+        node = Node(func_exec, *args, dag=self, name=name, **kwargs)
         return self.__add_node(node)
 
     def submit_array_udf(self, *args, **kwargs):

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -17,24 +17,26 @@ last_udf_task_id = None
 
 
 def exec_async(
-    func=None,
-    arguments=None,
+    func,
+    *args,
     name=None,
     namespace=None,
     image_name=None,
     http_compressor="deflate",
     include_source_lines=True,
+    **kwargs
 ):
     """
      Run a user defined function
 
 
     :param func: user function to run
-    :param arguments: arguments to pass to function
+    :param args: arguments to pass to function
     :param namespace: namespace to run udf under
     :param image_name: udf image name to use, useful for testing beta features
     :param http_compressor: set http compressor for results
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param kwargs: named arguments to pass to function
     :return: UDFResult object which is a future containing the results of the UDF
     """
 
@@ -59,7 +61,14 @@ def exec_async(
         pickledUDF = cloudpickle.dumps(func, protocol=tiledb_cloud_protocol)
         pickledUDF = base64.b64encode(pickledUDF).decode("ascii")
 
-    if arguments != None:
+    arguments = None
+    if (args is not None and len(args) > 0) or (kwargs is not None and len(kwargs) > 0):
+        arguments = []
+        if len(args) > 0:
+            arguments.append(args)
+        if len(kwargs) > 0:
+            arguments.append(kwargs)
+        arguments = tuple(arguments)
         arguments = cloudpickle.dumps(arguments, protocol=tiledb_cloud_protocol)
         arguments = base64.b64encode(arguments).decode("ascii")
 
@@ -101,34 +110,37 @@ def exec_async(
 
 
 def exec(
-    func=None,
+    func,
+    *args,
     name=None,
-    arguments=None,
     namespace=None,
     image_name=None,
     http_compressor="deflate",
     include_source_lines=True,
+    **kwargs
 ):
     """
      Run a user defined function
 
 
     :param func: user function to run
-    :param arguments: arguments to pass to function
+    :param args: arguments to pass to function
     :param namespace: namespace to run udf under
     :param image_name: udf image name to use, useful for testing beta features
     :param http_compressor: set http compressor for results
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param kwargs: named arguments to pass to function
     :return: UDFResult object which is a future containing the results of the UDF
     """
     return exec_async(
-        func=func,
+        func,
+        *args,
         name=name,
-        arguments=arguments,
         namespace=namespace,
         image_name=image_name,
         http_compressor=http_compressor,
         include_source_lines=include_source_lines,
+        **kwargs,
     ).get()
 
 


### PR DESCRIPTION
Adjust generic UDF to support multiple args/kwargs. A new unit tests is added and the DAG tests are updated.