### PR TITLE
Add delayed API for cloud compute

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -23,7 +23,7 @@ class DAGClassTest(unittest.TestCase):
         node_3 = d.add_node(lambda x: x * 2, node_2)
         node_3.name = "node_3"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -62,7 +62,7 @@ class DAGClassTest(unittest.TestCase):
         node_3 = d.add_node(string_multi, node_2, str="a")
         node_3.name = "node_3"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -89,7 +89,7 @@ class DAGClassTest(unittest.TestCase):
         node_6 = d.add_node(lambda *x: np.sum(x), node_3, node_4, node_5)
         node_6.name = "multi_node_6"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -110,7 +110,7 @@ class DAGFailureTest(unittest.TestCase):
             node = d.add_node(lambda x: x * 2, np.median)
             node.name = "node"
 
-            d.exec()
+            d.compute()
 
             # Wait for dag to complete
             d.wait(30)
@@ -133,7 +133,7 @@ class DAGFailureTest(unittest.TestCase):
             node2.name = "node2"
             node2.depends_on(node)
 
-            d.exec()
+            d.compute()
 
             # Wait for dag to complete
             d.wait(30)
@@ -156,7 +156,7 @@ class DAGCancelTest(unittest.TestCase):
         node = d.add_node(time.sleep, 1)
         node_2 = d.add_node(np.mean, [1, 1])
 
-        d.exec()
+        d.compute()
 
         # Cancel DAG
         d.cancel()
@@ -182,7 +182,7 @@ class DAGCloudApplyTest(unittest.TestCase):
         )
         node.name = "node"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -197,7 +197,7 @@ class DAGCloudApplyTest(unittest.TestCase):
         node = d.add_node(tiledb.cloud.udf.exec, lambda x: numpy.sum(x), [1, 4, 10, 40])
         node.name = "node"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -219,7 +219,7 @@ class DAGCloudApplyTest(unittest.TestCase):
         )
         node.name = "node"
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -268,7 +268,7 @@ class DAGCloudApplyTest(unittest.TestCase):
             tiledb.cloud.udf.exec, mean, [node_array_apply, node_sql], name="node_exec",
         )
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -320,7 +320,7 @@ class DAGCloudApplyTest(unittest.TestCase):
 
         node_exec = d.submit_udf(mean, [node_array_apply, node_sql], name="node_exec")
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)
@@ -357,7 +357,7 @@ class DAGCallbackTest(unittest.TestCase):
         node_2 = d.add_node(lambda x: x * 2, node_1, name="node_2")
         node_3 = d.add_node(lambda x: x * 2, node_2, name="node_3")
 
-        d.exec()
+        d.compute()
 
         # Wait for dag to complete
         d.wait(30)

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -1,0 +1,247 @@
+import time
+import unittest
+import os
+
+import numpy as np
+from tiledb.cloud.compute import Delayed, DelayedSQL, DelayedArray, Status
+import tiledb.cloud
+
+tiledb.cloud.login(
+    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
+    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
+)
+
+
+class DelayedClassTest(unittest.TestCase):
+    def test_simple_local_delayed(self):
+
+        node_1 = Delayed(np.median, name="node_1", local=True)
+        node_1([1, 2, 3])
+        node_2 = Delayed(lambda x: x * 2, name="node_2", local=True)(node_1)
+        node_3 = Delayed(lambda x: x * 2, name="node_3", local=True)(node_2)
+
+        node_3.compute()
+
+        self.assertEqual(node_1.result(), 2)
+        self.assertEqual(node_2.result(), 4)
+        self.assertEqual(node_3.result(), 8)
+
+    def test_kwargs(self):
+        def string_multi(multiplier, str=None):
+            return int(multiplier) * str
+
+        node_1 = Delayed(np.median, local=True, name="node_1")([1, 2, 3])
+        node_2 = Delayed(lambda x: x * 2, name="node_2")(node_1)
+        node_3 = Delayed(string_multi, local=True, name="node_3")(node_2, str="a")
+
+        node_3.compute()
+
+        self.assertEqual(node_1.result(), 2)
+        self.assertEqual(node_2.result(), 4)
+        self.assertEqual(node_3.result(), "aaaa")
+
+    def test_multi_dependencies(self):
+        node_1 = Delayed(np.median, name="multi_node_1", local=True)([1, 2, 3])
+        l = lambda x: x * 2
+        node_2 = Delayed(l, local=True, name="multi_node_2")(node_1)
+        node_3 = Delayed(l, local=True, name="multi_node_3")(node_2)
+        node_4 = Delayed(l, local=True, name="multi_node_4")(node_2)
+        node_5 = Delayed(l, local=True, name="multi_node_5")(node_2)
+
+        node_6 = Delayed(lambda *x: np.sum(x), local=True, name="multi_node_6")(
+            node_3, node_4, node_5
+        )
+
+        node_6.compute()
+
+        self.assertEqual(node_1.result(), 2)
+        self.assertEqual(node_2.result(), 4)
+        self.assertEqual(node_3.result(), 8)
+        self.assertEqual(node_4.result(), 8)
+        self.assertEqual(node_5.result(), 8)
+        self.assertEqual(node_6.result(), 24)
+
+
+class DelayedFailureTest(unittest.TestCase):
+    def test_failure(self):
+        with self.assertRaises(TypeError):
+            node = Delayed(lambda x: x * 2, local=True, name="node")(np.median)
+
+            node.compute()
+
+            self.assertEqual(node.result(), None)
+            self.assertIsNotNone(node.dag)
+            self.assertEqual(node.status, Status.FAILED)
+            self.assertEqual(
+                str(node.error),
+                "unsupported operand type(s) for *: 'function' and 'int'",
+            )
+
+    def test_dependency_fail_early(self):
+
+        with self.assertRaises(TypeError):
+            node = Delayed(lambda x: x * 2, local=True, name="node")(np.median)
+            node2 = Delayed(lambda x: x * 2, local=True, name="node2")(10)
+            node2.depends_on(node)
+
+            node2.compute()
+
+            self.assertEqual(node.result(), None)
+            self.assertEqual(node.status, Status.FAILED)
+            self.assertEqual(
+                str(node.error),
+                "unsupported operand type(s) for *: 'function' and 'int'",
+            )
+            self.assertEqual(node2.result(), None)
+            self.assertEqual(node2.status, Status.NOT_STARTED)
+            self.assertEqual(node2.dag.status, Status.FAILED)
+
+
+class DelayedCancelTest(unittest.TestCase):
+    def test_cancel(self):
+        with self.assertRaises(TimeoutError):
+            node = Delayed(time.sleep, local=True, name="multi_node_2")(100)
+            node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
+            node_2.depends_on(node)
+
+            # Set timeout to 1 second, the dependency on node will wait for 100 second, so we'll timeout and cancel
+            node_2.set_timeout(1)
+
+            node_2.compute()
+
+            # Cancel DAG
+            node_2.dag.cancel()
+
+            self.assertEqual(node.result(), None)
+            self.assertEqual(node.status, Status.CANCELLED)
+            self.assertEqual(node_2.dag.status, Status.CANCELLED)
+
+
+class DelayedCloudApplyTest(unittest.TestCase):
+    def test_array_apply(self):
+
+        uri = "tiledb://TileDB-inc/quickstart_sparse"
+        with tiledb.open(uri, ctx=tiledb.cloud.Ctx()) as A:
+            orig = A[:]
+
+        import numpy
+
+        node = DelayedArray(uri, lambda x: numpy.sum(x["a"]), name="node")(
+            [(1, 4), (1, 4)]
+        )
+
+        node.compute()
+
+        self.assertEqual(node.result(), numpy.sum(orig["a"]))
+
+    def test_udf_exec(self):
+        import numpy
+
+        node = Delayed(lambda x: numpy.sum(x), name="node")([1, 4, 10, 40])
+
+        node.compute()
+
+        self.assertEqual(node.result(), 55)
+
+    def test_sql_exec(self):
+
+        uri = "tiledb://TileDB-inc/quickstart_sparse"
+        with tiledb.open(uri, ctx=tiledb.cloud.Ctx()) as A:
+            orig = A[:]
+
+        import numpy
+
+        node = DelayedSQL("select SUM(`a`) as a from `{}`".format(uri), name="node")
+
+        node.compute()
+
+        self.assertEqual(node.result()["a"][0], numpy.sum(orig["a"]))
+
+    def test_apply_exec_multiple(self):
+
+        uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
+        uri_dense = "tiledb://TileDB-inc/quickstart_dense"
+        with tiledb.open(uri_sparse, ctx=tiledb.cloud.Ctx()) as A:
+            orig = A[:]
+
+        with tiledb.open(uri_dense, ctx=tiledb.cloud.Ctx()) as A:
+            orig_dense = A[:]
+
+        import numpy
+
+        node_array_apply = DelayedArray(
+            uri_sparse, lambda x: numpy.sum(x["a"]), name="node_array_apply"
+        )([(1, 4), (1, 4)])
+        node_sql = DelayedSQL(
+            "select SUM(`a`) as a from `{}`".format(uri_dense), name="node_sql",
+        )
+
+        def mean(args):
+            import numpy
+            import pandas
+
+            for i in range(len(args)):
+                item = args[i]
+                if isinstance(item, pandas.DataFrame):
+                    args[i] = item["a"][0]
+
+            return numpy.mean(args)
+
+        node_exec = Delayed(mean, name="node_exec")([node_array_apply, node_sql])
+
+        node_exec.compute()
+
+        self.assertEqual(node_array_apply.result(), numpy.sum(orig["a"]))
+        self.assertEqual(node_sql.result()["a"][0], numpy.sum(orig_dense["a"]))
+        self.assertEqual(
+            node_exec.result(),
+            numpy.mean([numpy.sum(orig["a"]), numpy.sum(orig_dense["a"])]),
+        )
+        self.assertEqual(node_exec.dag.status, Status.COMPLETED)
+
+    def test_apply_exec_multiple_2(self):
+
+        uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
+        uri_dense = "tiledb://TileDB-inc/quickstart_dense"
+        with tiledb.open(uri_sparse, ctx=tiledb.cloud.Ctx()) as A:
+            orig = A[:]
+
+        with tiledb.open(uri_dense, ctx=tiledb.cloud.Ctx()) as A:
+            orig_dense = A[:]
+
+        import numpy
+
+        node_local = Delayed(lambda x: x * 2, local=True)(100)
+
+        node_array_apply = DelayedArray(
+            uri_sparse, lambda x: numpy.sum(x["a"]), name="node_array_apply"
+        )([(1, 4), (1, 4)])
+        node_sql = DelayedSQL(
+            "select SUM(`a`) as a from `{}`".format(uri_dense), name="node_sql"
+        )
+
+        def mean(args):
+            import numpy
+            import pandas
+
+            for i in range(len(args)):
+                item = args[i]
+                if isinstance(item, pandas.DataFrame):
+                    args[i] = item["a"][0]
+
+            return numpy.mean(args)
+
+        node_exec = Delayed(func_exec=mean, name="node_exec")(
+            [node_local, node_array_apply, node_sql]
+        )
+
+        node_exec.compute()
+
+        self.assertEqual(node_local.result(), 200)
+        self.assertEqual(node_array_apply.result(), numpy.sum(orig["a"]))
+        self.assertEqual(node_sql.result()["a"][0], numpy.sum(orig_dense["a"]))
+        self.assertEqual(
+            node_exec.result(),
+            numpy.mean([200, numpy.sum(orig["a"]), numpy.sum(orig_dense["a"])]),
+        )
+        self.assertEqual(node_exec.status, Status.COMPLETED)

--- a/tiledb/cloud/__init__.py
+++ b/tiledb/cloud/__init__.py
@@ -29,3 +29,5 @@ from . import sql
 from . import udf
 
 from . import dag
+
+from . import compute

--- a/tiledb/cloud/compute/__init__.py
+++ b/tiledb/cloud/compute/__init__.py
@@ -1,0 +1,3 @@
+from .delayed import Delayed, DelayedSQL, DelayedArray
+
+from ..dag import Status

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -1,0 +1,140 @@
+from ..dag.dag import Node, DAG
+
+from ..array import apply as array_apply
+from ..sql import exec as sql_exec
+from ..udf import exec as udf_exec
+
+import numbers
+
+
+class DelayedBase(Node):
+    def __init__(self, func, *args, name=None, dag=None, **kwargs):
+        self.timeout = None
+        super().__init__(func, *args, name=name, dag=dag, **kwargs)
+
+    def set_timeout(self, timeout):
+        if timeout is not None and not isinstance(timeout, numbers.Number):
+            raise TypeError(
+                "timeout must be numeric value representing seconds to wait"
+            )
+        self.timeout = timeout
+
+    def compute(self):
+        """
+        Execute function for node
+        :return: results
+        """
+        if self.dag is None:
+            self.__set_all_parent_nodes_same_dag(DAG())
+
+        self.dag.compute()
+        super().wait(self.timeout)
+
+        if not super().done():
+            self.dag.cancel()
+
+        return super().result()
+
+    def __set_all_parent_nodes_same_dag(self, dag):
+        # If this node already has the day we have reached a base case
+        if self.dag == dag:
+            return
+
+        self.dag = dag
+        self.dag.add_node_obj(self)
+        for node in self.parents.values():
+            node.__set_all_parent_nodes_same_dag(dag)
+        for node in self.children.values():
+            node.__set_all_parent_nodes_same_dag(dag)
+
+    def visualize(self, notebook=True, auto_update=True):
+        """
+        Build and render a tree diagram of the DAG.
+        :param notebook: Is the visualization inside a jupyter notebook? If so we'll use a widget
+        :param auto_update: Should the diagram be auto updated with each status change
+        :return: returns plotly figure
+        """
+        if self.dag is None:
+            self.__set_all_parent_nodes_same_dag(DAG())
+
+        if self.dag is not None:
+            return self.dag.visualize(notebook=notebook, auto_update=auto_update)
+
+        return None
+
+
+class Delayed(DelayedBase):
+    def __init__(self, func_exec, *args, local=False, **kwargs):
+        self.func_exec = func_exec
+        self.local = local
+        if func_exec is not None and not callable(func_exec):
+            raise TypeError("func_exec argument to `Node` must be callable!")
+
+        if not local:
+            super().__init__(udf_exec, func_exec, *args, **kwargs)
+        else:
+            super().__init__(func_exec, *args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        if not self.local:
+            self.args = [self.func_exec, *args]
+        else:
+            self.args = args
+        self.kwargs = kwargs
+        # Loop through non-default parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.args is not None:
+            super()._build_dependencies_list(self.args)
+
+        # Loop through defaulted named parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.kwargs is not None:
+            super()._build_dependencies_list(self.kwargs)
+
+        return self
+
+
+class DelayedSQL(DelayedBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(sql_exec, *args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        # Loop through non-default parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.args is not None:
+            super()._build_dependencies_list(self.args)
+
+        # Loop through defaulted named parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.kwargs is not None:
+            super()._build_dependencies_list(self.kwargs)
+
+        return self
+
+
+class DelayedArray(DelayedBase):
+    def __init__(self, uri, func_exec, *args, **kwargs):
+        self.func_exec = func_exec
+        self.uri = uri
+
+        if func_exec is not None and not callable(func_exec):
+            raise TypeError("func_exec argument to `Node` must be callable!")
+
+        super().__init__(array_apply, self.uri, self.func_exec, *args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.args = [self.uri, self.func_exec, *args]
+        self.kwargs = kwargs
+        # Loop through non-default parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.args is not None:
+            super()._build_dependencies_list(self.args)
+
+        # Loop through defaulted named parameters and find any Node objects
+        # Node objects will be used to automatically add dependencies
+        if self.kwargs is not None:
+            super()._build_dependencies_list(self.kwargs)
+
+        return self


### PR DESCRIPTION
A new delayed api is added for Generic UDFs, local functions, Array UDFs and SQL queries.

Three new Delayed classes are presenting to the user, `Delayed`, `DelayedSQL` and `DelayedArray`.

Example usage:

```
# Run a delayed function local instead of serverless
local = Delayed(lambda x: x * 2, local=True)(100)

# Run a udf on array
array_apply = DelayedArray(uri_sparse, lambda x: numpy.sum(x["a"]), name="node_array_apply")([(1, 4), (1, 4)])

sql = DelayedSQL("select SUM(`a`) as a from `{}`".format(uri_dense), name="node_sql")

def mean(args):
    import numpy
    import pandas

    for i in range(len(args)):
        item = args[i]
        if isinstance(item, pandas.DataFrame):
            args[i] = item["a"][0]

    return numpy.mean(args)

# Run a Generic UDF serverlessly
final_results = Delayed(func_exec=mean, name="node_exec")([node_local, node_array_apply, node_sql])

# Calling compute causes the DAG to be executed
final_results.compute()

# Render graph to visualize the graph
final_results.visualize()
```

Depends on #73 #72 