### PR TITLE
Add function to set namespace for sql/udf

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -188,6 +188,22 @@ def organization(organization):
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
+def find_organization_or_user_for_default_charges(user):
+    """
+    Takes a user model and finds either the first non public organization or the user itself
+    :param user:
+    :return: namespace name to charge by default (organization or user if not part of any organization)
+    """
+
+    namespace_to_charge = user.username
+    for org in user.organizations:
+        if org.organization_name != "public":
+            namespace_to_charge = org.organization_name
+            break
+
+    return namespace_to_charge
+
+
 class Client:
     def update_clients(self):
         self.array_api = self.__get_array_api()

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -89,7 +89,7 @@ def exec_async(
         if config.user is None:
             config.user = client.user_profile()
 
-        namespace = config.user.username
+        namespace = client.find_organization_or_user_for_default_charges(config.user)
 
     api_instance = client.client.sql_api
 

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -48,7 +48,7 @@ def exec_async(
         if config.user is None:
             config.user = client.user_profile()
 
-        namespace = config.user.username
+        namespace = client.find_organization_or_user_for_default_charges(config.user)
 
     if func is not None and not callable(func):
         raise TypeError("func argument to `exec` must be callable!")


### PR DESCRIPTION
If the user does not pass in a namespace for a task to run in, we should default to any organization they are part of before falling back to charging the user.