### PR TITLE
Rename DelayedArray to DelayedArrayUDF

### DIFF
--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -3,7 +3,7 @@ import unittest
 import os
 
 import numpy as np
-from tiledb.cloud.compute import Delayed, DelayedSQL, DelayedArray, Status
+from tiledb.cloud.compute import Delayed, DelayedSQL, DelayedArrayUDF, Status
 import tiledb.cloud
 
 tiledb.cloud.login(
@@ -126,7 +126,7 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
         import numpy
 
-        node = DelayedArray(uri, lambda x: numpy.sum(x["a"]), name="node")(
+        node = DelayedArrayUDF(uri, lambda x: numpy.sum(x["a"]), name="node")(
             [(1, 4), (1, 4)]
         )
 
@@ -169,7 +169,7 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
         import numpy
 
-        node_array_apply = DelayedArray(
+        node_array_apply = DelayedArrayUDF(
             uri_sparse, lambda x: numpy.sum(x["a"]), name="node_array_apply"
         )([(1, 4), (1, 4)])
         node_sql = DelayedSQL(
@@ -213,7 +213,7 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
         node_local = Delayed(lambda x: x * 2, local=True)(100)
 
-        node_array_apply = DelayedArray(
+        node_array_apply = DelayedArrayUDF(
             uri_sparse, lambda x: numpy.sum(x["a"]), name="node_array_apply"
         )([(1, 4), (1, 4)])
         node_sql = DelayedSQL(

--- a/tiledb/cloud/compute/__init__.py
+++ b/tiledb/cloud/compute/__init__.py
@@ -1,3 +1,3 @@
-from .delayed import Delayed, DelayedSQL, DelayedArray
+from .delayed import Delayed, DelayedSQL, DelayedArrayUDF
 
 from ..dag import Status

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -117,7 +117,7 @@ class DelayedSQL(DelayedBase):
         return self
 
 
-class DelayedArray(DelayedBase):
+class DelayedArrayUDF(DelayedBase):
     def __init__(self, uri, func_exec, *args, **kwargs):
         self.func_exec = func_exec
         self.uri = uri


### PR DESCRIPTION
Rename `DelayedArray` to `DelayedArrayUDF `as `DelayedArray` term already commonly used to mean something else. To avoid confusion we rename the class.