### PR TITLE
Support setting namespace for all tasks in DAG

### DIFF
--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -88,7 +88,8 @@ class Delayed(DelayedBase):
             self.args = [self.func_exec, *args]
         else:
             self.args = args
-        self.kwargs = kwargs
+        self.kwargs.update(kwargs)
+
         # Loop through non-default parameters and find any Node objects
         # Node objects will be used to automatically add dependencies
         if self.args is not None:
@@ -117,7 +118,7 @@ class DelayedSQL(DelayedBase):
 
     def __call__(self, *args, **kwargs):
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs.update(kwargs)
         # Loop through non-default parameters and find any Node objects
         # Node objects will be used to automatically add dependencies
         if self.args is not None:
@@ -151,7 +152,7 @@ class DelayedArrayUDF(DelayedBase):
 
     def __call__(self, *args, **kwargs):
         self.args = [self.uri, self.func_exec, *args]
-        self.kwargs = kwargs
+        self.kwargs.update(kwargs)
         # Loop through non-default parameters and find any Node objects
         # Node objects will be used to automatically add dependencies
         if self.args is not None:


### PR DESCRIPTION
A DAG can now override the namespace a node/task is run in. The override can happen in a Delayed object or in the DAG directly. This allows easier setting of the namespace all tasks should run in.

This also fixes a minor issue with overriding namespaces in the `Delayed` API itself.

Example usage:

```
from tiledb.cloud.compute import Delayed
import numpy

# Wrap numpy median in a delayed object
x = Delayed(numpy.median, name="x")

# It can be called like a normal function to set the parameters
# Note at this point the function does not get executed since it
# is delayed type
x([1,2,3,4,5])

y = Delayed(numpy.median, name="y")
y([1, 2, x])

# To force execution and get the result call `compute()`
y.compute(namespace="seth")
```

Also basic namespace in a `Delayed` object:
```
from tiledb.cloud.compute import Delayed
import numpy

# Wrap numpy median in a delayed object
x = Delayed(numpy.median, name="x", namespace="seth")

# It can be called like a normal function to set the parameters
# Note at this point the function does not get executed since it
# is delayed type
x([1,2,3,4,5])

# To force execution and get the result call `compute()`
x.compute()
```