### PR TITLE
 Add ability to run list of Delayed objects

### DIFF
--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -71,6 +71,31 @@ class DelayedBase(Node):
 
         return None
 
+    @staticmethod
+    def all(futures, namespace=None):
+        """
+        Run a list of Delayed object all in parallel
+        :param futures: list of Delayed objects to run
+        :param namespace: optional namespace to run all tasks in
+        :return: list of results in order of futures
+        """
+        if futures is None:
+            raise ValueError("list of delayed object must not be null")
+
+        dag = DAG()
+
+        for delayed in futures:
+            dag.add_node_obj(delayed)
+
+        dag.namespace = namespace
+        dag.compute()
+
+        ret = []
+        for delayed in futures:
+            ret.append(delayed.result())
+
+        return ret
+
 
 class Delayed(DelayedBase):
     def __init__(self, func_exec, *args, local=False, **kwargs):


### PR DESCRIPTION
Add new `DelayedBase.all` function to run a list of Delayed objects in a single dag. This also supports namespace overrides.

Depends on #89 

Example usage:

```
from tiledb.cloud.compute import Delayed
import numpy

# Wrap numpy median in a delayed object
x = Delayed(numpy.median, name="x")

# It can be called like a normal function to set the parameters
# Note at this point the function does not get executed since it
# is delayed type
x([1,2,3,4,5])

y = Delayed(numpy.median, name="y")
y([10, 20, 30])

# To force execution and get the result call `compute()`
Delayed.all([x, y], namespace="seth")
```