### PR TITLE
 Add support for default namespace charge for tasks

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -305,6 +305,13 @@ def find_organization_or_user_for_default_charges(user):
     """
 
     namespace_to_charge = user.username
+
+    if (
+        user.default_namespace_charged is not None
+        and user.default_namespace_charged != ""
+    ):
+        return user.default_namespace_charged
+
     for org in user.organizations:
         if org.organization_name != "public":
             namespace_to_charge = org.organization_name


### PR DESCRIPTION
This allows a user in the setting to set the default namespace for all task charges. If this is set then we'll use this instead of the
user/first organization as default.

Requires #93 for the auto-generated client update. Will rebase after #93 is merged.