### PR TITLE
 Add support for async_req to all functions 

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,13 +28,13 @@ class BasicTests(unittest.TestCase):
         self.assertIsNotNone(tasks())
 
     def test_list_arrays(self):
-        self.assertIsNone(client.list_arrays())
+        self.assertIsNone(client.list_arrays().arrays)
 
     def test_list_shared_arrays(self):
-        self.assertIsNone(client.list_shared_arrays())
+        self.assertIsNone(client.list_shared_arrays().arrays)
 
     def test_list_public_arrays(self):
-        self.assertTrue(len(client.list_public_arrays()) > 0)
+        self.assertTrue(len(client.list_public_arrays().arrays) > 0)
 
     def test_quickstart(self):
         with tiledb.open(

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -53,9 +53,11 @@ class UDFResult(multiprocessing.pool.ApplyResult):
         return res
 
 
-def info(uri):
+def info(uri, async_req=False):
     """
     Returns the cloud metadata
+
+    :param async_req: return future instead of results for async support
 
     :return: metadata object
     """
@@ -63,30 +65,33 @@ def info(uri):
     api_instance = client.client.array_api
 
     try:
-        return api_instance.get_array_metadata(namespace=namespace, array=array_name)
+        return api_instance.get_array_metadata(
+            namespace=namespace, array=array_name, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def list_shared_with(uri):
+def list_shared_with(uri, async_req=False):
     """Return array sharing policies"""
     (namespace, array_name) = split_uri(uri)
     api_instance = client.client.array_api
 
     try:
         return api_instance.get_array_sharing_policies(
-            namespace=namespace, array=array_name
+            namespace=namespace, array=array_name, async_req=async_req
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def share_array(uri, namespace, permissions):
+def share_array(uri, namespace, permissions, async_req=False):
     """
     Shares array with give namespace and permissions
 
     :param str namespace:
     :param list(str) permissions:
+    :param async_req: return future instead of results for async support
     :return:
     """
 
@@ -110,20 +115,22 @@ def share_array(uri, namespace, permissions):
             array_sharing=rest_api.models.ArraySharing(
                 namespace=namespace, actions=permissions
             ),
+            async_req=async_req,
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def unshare_array(uri, namespace):
+def unshare_array(uri, namespace, async_req=False):
     """
     Removes sharing of an array from given namespace
 
     :param str namespace: namespace to remove shared access to the array
+    :param async_req: return future instead of results for async support
     :return:
     :raises: :py:exc:
     """
-    return share_array(uri, namespace, list())
+    return share_array(uri, namespace, list(), async_req=async_req)
 
 
 def update_info(
@@ -132,6 +139,7 @@ def update_info(
     description=None,
     access_credentials_name=None,
     tags=None,
+    async_req=False,
 ):
     """
     Update an array's info
@@ -140,6 +148,7 @@ def update_info(
     :param str description: optional description
     :param str access_credentials_name: optional name of access credentials to use, if left blank default for namespace will be used
     :param list tags to update to
+    :param async_req: return future instead of results for async support
     """
     api_instance = client.client.array_api
     (namespace, current_array_name) = split_uri(uri)
@@ -155,13 +164,19 @@ def update_info(
                 access_credentials_name=access_credentials_name,
                 tags=tags,
             ),
+            async_req=async_req,
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
 def register_array(
-    uri, namespace=None, array_name=None, description=None, access_credentials_name=None
+    uri,
+    namespace=None,
+    array_name=None,
+    description=None,
+    access_credentials_name=None,
+    async_req=False,
 ):
     """
     Register this array with the tiledb cloud service
@@ -169,6 +184,7 @@ def register_array(
     :param str array_name: name of array
     :param str description: optional description
     :param str access_credentials_name: optional name of access credentials to use, if left blank default for namespace will be used
+    :param async_req: return future instead of results for async support
     """
     api_instance = client.client.array_api
 
@@ -193,25 +209,32 @@ def register_array(
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def deregister_array(uri):
+def deregister_array(uri, async_req=False):
     """
     Deregister the from the tiledb cloud service. This does not physically delete the array, it will remain
     in your bucket. All access to the array and cloud metadata will be removed.
+
+    :param async_req: return future instead of results for async support
+
+    :return success or error
     """
     (namespace, array_name) = split_uri(uri)
 
     api_instance = client.client.array_api
 
     try:
-        return api_instance.deregister_array(namespace=namespace, array=array_name)
+        return api_instance.deregister_array(
+            namespace=namespace, array=array_name, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def array_activity(uri):
+def array_activity(uri, async_req=False):
     """
     Fetch array activity
     :param uri:
+    :param async_req: return future instead of results for async support
     :return:
     """
     (namespace, array_name) = split_uri(uri)
@@ -219,7 +242,9 @@ def array_activity(uri):
     api_instance = client.client.array_api
 
     try:
-        return api_instance.array_activity_log(namespace=namespace, array=array_name)
+        return api_instance.array_activity_log(
+            namespace=namespace, array=array_name, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
@@ -229,6 +254,7 @@ def split_uri(uri):
     Split a URI into namespace and array name
 
     :param uri: uri to split into namespace and array name
+    :param async_req: return future instead of results for async support
     :return: tuple (namespace, array_name)
     """
     parsed = urllib.parse.urlparse(uri)

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -144,8 +144,6 @@ def list_public_arrays(
         res = api_instance.arrays_browser_public_get(**kwargs)
 
         # if the user didn't ask for pagination just return raw array list
-        if page is None:
-            return res.arrays
         return res
 
     except GenApiException as exc:
@@ -195,8 +193,6 @@ def list_shared_arrays(
         res = api_instance.arrays_browser_shared_get(**kwargs)
 
         # if the user didn't ask for pagination just return raw array list
-        if page is None:
-            return res.arrays
         return res
 
     except GenApiException as exc:
@@ -247,8 +243,6 @@ def list_arrays(
         res = api_instance.arrays_browser_owned_get(**kwargs)
 
         # if the user didn't ask for pagination just return raw array list
-        if page is None:
-            return res.arrays
         return res
 
     except GenApiException as exc:

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -102,7 +102,13 @@ def login(
 
 
 def list_public_arrays(
-    namespace=None, permissions=None, tag=None, search=None, page=None, per_page=None
+    namespace=None,
+    permissions=None,
+    tag=None,
+    search=None,
+    page=None,
+    per_page=None,
+    async_req=False,
 ):
     """
     List public arrays
@@ -113,6 +119,7 @@ def list_public_arrays(
     :param str search: search string
     :param int page: optional page for pagination
     :param int per_page: optional per_page for pagination
+    :param async_req: return future instead of results for async support
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
@@ -121,7 +128,7 @@ def list_public_arrays(
         permissions = [permissions]
 
     try:
-        kwargs = {}
+        kwargs = {"async_req": async_req}
         if namespace is not None:
             kwargs["namespace"] = namespace
         if search is not None:
@@ -146,7 +153,13 @@ def list_public_arrays(
 
 
 def list_shared_arrays(
-    namespace=None, permissions=None, tag=None, search=None, page=None, per_page=None
+    namespace=None,
+    permissions=None,
+    tag=None,
+    search=None,
+    page=None,
+    per_page=None,
+    async_req=False,
 ):
     """
     List shared arrays
@@ -157,6 +170,7 @@ def list_shared_arrays(
     :param str search: search string
     :param int page: optional page for pagination
     :param int per_page: optional per_page for pagination
+    :param async_req: return future instead of results for async support
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
@@ -165,7 +179,7 @@ def list_shared_arrays(
         permissions = [permissions]
 
     try:
-        kwargs = {}
+        kwargs = {"async_req": async_req}
         if namespace is not None:
             kwargs["namespace"] = namespace
         if search is not None:
@@ -190,7 +204,13 @@ def list_shared_arrays(
 
 
 def list_arrays(
-    namespace=None, permissions=None, tag=None, search=None, page=None, per_page=None
+    namespace=None,
+    permissions=None,
+    tag=None,
+    search=None,
+    page=None,
+    per_page=None,
+    async_req=False,
 ):
     """
     List arrays in a user account
@@ -201,6 +221,7 @@ def list_arrays(
     :param str search: search string
     :param int page: optional page for pagination
     :param int per_page: optional per_page for pagination
+    :param async_req: return future instead of results for async support
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
@@ -209,7 +230,7 @@ def list_arrays(
         permissions = [permissions]
 
     try:
-        kwargs = {}
+        kwargs = {"async_req": async_req}
         if namespace is not None:
             kwargs["namespace"] = namespace
         if search is not None:
@@ -234,8 +255,9 @@ def list_arrays(
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def user_profile():
+def user_profile(async_req=False):
     """
+    :param async_req: return future instead of results for async support
 
     :return: your user profile
     """
@@ -243,36 +265,40 @@ def user_profile():
     api_instance = client.user_api
 
     try:
-        return api_instance.get_user()
+        return api_instance.get_user(async_req=async_req)
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def organizations():
+def organizations(async_req=False):
     """
 
+    :param async_req: return future instead of results for async support
     :return: list of all organizations user is part of
     """
 
     api_instance = client.organization_api
 
     try:
-        return api_instance.get_all_organizations()
+        return api_instance.get_all_organizations(async_req=async_req)
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def organization(organization):
+def organization(organization, async_req=False):
     """
 
     :param str organization: organization to fetct
+    :param async_req: return future instead of results for async support
     :return: details about organization
     """
 
     api_instance = client.organization_api
 
     try:
-        return api_instance.get_organization(organization=organization)
+        return api_instance.get_organization(
+            organization=organization, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 

--- a/tiledb/cloud/notebook.py
+++ b/tiledb/cloud/notebook.py
@@ -10,12 +10,14 @@ def rename_notebook(
     uri,
     notebook_name=None,
     access_credentials_name=None,
+    async_req=False,
 ):
     """
     Update an array's info
     :param str namespace: optional username or organization array should be registered under. If unset will default to the user
     :param str array_name: name of notebook to rename to
     :param str access_credentials_name: optional name of access credentials to use, if left blank default for namespace will be used
+    :param async_req: return future instead of results for async support
     """
     api_instance = client.client.notebook_api
     (namespace, current_notebook_name) = array.split_uri(uri)
@@ -29,6 +31,7 @@ def rename_notebook(
                 uri=uri,
                 access_credentials_name=access_credentials_name,
             ),
+            async_req=async_req,
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None

--- a/tiledb/cloud/tasks.py
+++ b/tiledb/cloud/tasks.py
@@ -8,10 +8,11 @@ from .rest_api import ApiException as GenApiException
 import datetime
 
 
-def task(id):
+def task(id, async_req=False):
     """
     Fetch a single array task
     :param str id: id to lookup, if unset will use the id of the last array task run in the current python session
+    :param async_req: return future instead of results for async support
     :return task : object with task details
     """
 
@@ -21,7 +22,7 @@ def task(id):
     api_instance = client.client.tasks_api
 
     try:
-        return api_instance.task_id_get(id=id)
+        return api_instance.task_id_get(id=id, async_req=async_req)
 
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
@@ -35,6 +36,7 @@ def tasks(
     status=None,
     page=None,
     per_page=None,
+    async_req=False,
 ):
     """
     Fetch all tasks a user has access too
@@ -45,6 +47,7 @@ def tasks(
     :param str status: optional filter on status can be one of ['FAILED', 'RUNNING', 'COMPLETED']
     :param int page: optional page for pagenating results
     :param int per_page: optional records to return per page
+    :param async_req: return future instead of results for async support
     :return:
     """
     api_instance = client.client.tasks_api
@@ -71,7 +74,7 @@ def tasks(
         (namespace, array) = split_uri(array)
 
     try:
-        args = {}
+        args = {"async_req": async_req}
         if namespace is not None:
             args["namespace"] = namespace
         if array is not None:

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -201,7 +201,7 @@ def register_udf(
 
         source_lines = utils.getsourcelines(func) if include_source_lines else None
 
-        udf_model = rest_api.models.UDFRegistration(
+        udf_model = rest_api.models.UDFInfoUpdate(
             name=name,
             language=rest_api.models.UDFLanguage.PYTHON,
             version="{}.{}.{}".format(
@@ -218,7 +218,7 @@ def register_udf(
         if source_lines is not None:
             udf_model.exec_raw = source_lines
 
-        api_instance.register_udf(
+        api_instance.register_udf_info(
             namespace=namespace, name=name, udf=udf_model, async_req=async_req
         )
 
@@ -324,7 +324,7 @@ def update_udf(
 
         source_lines = utils.getsourcelines(func) if include_source_lines else None
 
-        udf_model = rest_api.models.UDFRegistration(
+        udf_model = rest_api.models.UDFInfoUpdate(
             name=name,
             language=rest_api.models.UDFLanguage.PYTHON,
             version="{}.{}.{}".format(
@@ -431,7 +431,9 @@ def info(name=None, async_req=False):
 
             namespace = config.user.username
 
-        return api_instance.get_udf(namespace=namespace, name=name, async_req=async_req)
+        return api_instance.get_udf_info(
+            namespace=namespace, name=name, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
@@ -447,7 +449,7 @@ def list_registered_udfs(namespace=None, search=None, async_req=False):
     try:
         api_instance = client.client.udf_api
 
-        return api_instance.get_ud_fs(
+        return api_instance.get_udf_info_list(
             namespace=namespace, search=search, async_req=async_req
         )
     except GenApiException as exc:
@@ -480,7 +482,7 @@ def share(name=None, namespace=None, async_req=False):
     try:
         api_instance = client.client.udf_api
 
-        return api_instance.share_udf(
+        return api_instance.share_udf_info(
             udf_namespace,
             udf_name,
             udf_sharing=rest_api.models.UDFSharing(
@@ -518,7 +520,7 @@ def unshare(name=None, namespace=None, async_req=False):
     try:
         api_instance = client.client.udf_api
 
-        return api_instance.share_udf(
+        return api_instance.share_udf_info(
             udf_namespace,
             udf_name,
             udf_sharing=rest_api.models.UDFSharing(namespace=namespace),

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -168,6 +168,7 @@ def register_udf(
     image_name=None,
     type=None,
     include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -177,6 +178,7 @@ def register_udf(
     :param image_name: optional image name
     :param type: type of udf, generic or single_array
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
 
@@ -216,14 +218,21 @@ def register_udf(
         if source_lines is not None:
             udf_model.exec_raw = source_lines
 
-        api_instance.register_udf(namespace=namespace, name=name, udf=udf_model)
+        api_instance.register_udf(
+            namespace=namespace, name=name, udf=udf_model, async_req=async_req
+        )
 
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
 def register_generic_udf(
-    func, name, namespace=None, image_name=None, include_source_lines=True
+    func,
+    name,
+    namespace=None,
+    image_name=None,
+    include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -232,6 +241,7 @@ def register_generic_udf(
     :param namespace: namespace to register in
     :param image_name: optional image name
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
     return register_udf(
@@ -241,11 +251,17 @@ def register_generic_udf(
         image_name=image_name,
         type=rest_api.models.UDFType.GENERIC,
         include_source_lines=include_source_lines,
+        async_req=async_req,
     )
 
 
 def register_single_array_udf(
-    func, name, namespace=None, image_name=None, include_source_lines=True
+    func,
+    name,
+    namespace=None,
+    image_name=None,
+    include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -254,6 +270,7 @@ def register_single_array_udf(
     :param namespace: namespace to register in
     :param image_name: optional image name
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
     return register_udf(
@@ -263,6 +280,7 @@ def register_single_array_udf(
         image_name=image_name,
         type=rest_api.models.UDFType.SINGLE_ARRAY,
         include_source_lines=include_source_lines,
+        async_req=async_req,
     )
 
 
@@ -273,6 +291,7 @@ def update_udf(
     image_name=None,
     type=None,
     include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -282,6 +301,7 @@ def update_udf(
     :param image_name: optional image name
     :param type: type of udf, generic or single_array
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
 
@@ -322,7 +342,7 @@ def update_udf(
             udf_model.exec_raw = source_lines
 
         api_instance.updated_registered_udf(
-            namespace=namespace, name=name, udf=udf_model
+            namespace=namespace, name=name, udf=udf_model, async_req=async_req
         )
 
     except GenApiException as exc:
@@ -330,7 +350,12 @@ def update_udf(
 
 
 def update_generic_udf(
-    func, name, namespace=None, image_name=None, include_source_lines=True
+    func,
+    name,
+    namespace=None,
+    image_name=None,
+    include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -339,6 +364,7 @@ def update_generic_udf(
     :param namespace: namespace to register in
     :param image_name: optional image name
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
     return update_udf(
@@ -348,11 +374,17 @@ def update_generic_udf(
         image_name=image_name,
         type=rest_api.models.UDFType.GENERIC,
         include_source_lines=include_source_lines,
+        async_req=async_req,
     )
 
 
 def update_single_array_udf(
-    func, name, namespace=None, image_name=None, include_source_lines=True
+    func,
+    name,
+    namespace=None,
+    image_name=None,
+    include_source_lines=True,
+    async_req=False,
 ):
     """
 
@@ -361,6 +393,7 @@ def update_single_array_udf(
     :param namespace: namespace to register in
     :param image_name: optional image name
     :param include_source_lines: disables sending sources lines of function along with udf
+    :param async_req: return future instead of results for async support
     :return:
     """
     return update_udf(
@@ -370,13 +403,15 @@ def update_single_array_udf(
         image_name=image_name,
         type=rest_api.models.UDFType.SINGLE_ARRAY,
         include_source_lines=include_source_lines,
+        async_req=async_req,
     )
 
 
-def info(name=None):
+def info(name=None, async_req=False):
     """
     Fetch info on a registered udf
     :param name: name of udf in "namespace/name" format
+    :param async_req: return future instead of results for async support
     :return: registered udf details
     """
     try:
@@ -396,31 +431,35 @@ def info(name=None):
 
             namespace = config.user.username
 
-        return api_instance.get_udf(namespace=namespace, name=name)
+        return api_instance.get_udf(namespace=namespace, name=name, async_req=async_req)
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def list_registered_udfs(namespace=None, search=None):
+def list_registered_udfs(namespace=None, search=None, async_req=False):
     """
     Fetch all registered udf user has access to
     :param namespace: namespace to filter to
     :param search: string search for udfs
+    :param async_req: return future instead of results for async support
     :return: registered udf details
     """
     try:
         api_instance = client.client.udf_api
 
-        return api_instance.get_ud_fs(namespace=namespace, search=search)
+        return api_instance.get_ud_fs(
+            namespace=namespace, search=search, async_req=async_req
+        )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def share(name=None, namespace=None):
+def share(name=None, namespace=None, async_req=False):
     """
     Share a registered udf
     :param name: name of udf in "namespace/name" format
     :param namespace: namespace to share array with
+    :param async_req: return future instead of results for async support
     :return: registered udf details
     """
     (udf_namespace, udf_name) = name.split("/")
@@ -447,16 +486,18 @@ def share(name=None, namespace=None):
             udf_sharing=rest_api.models.UDFSharing(
                 namespace=namespace, actions=[rest_api.models.UDFActions.FETCH_UDF]
             ),
+            async_req=async_req,
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def unshare(name=None, namespace=None):
+def unshare(name=None, namespace=None, async_req=False):
     """
     Share a registered udf
     :param name: name of udf in "namespace/name" format
     :param namespace: namespace to share array with
+    :param async_req: return future instead of results for async support
     :return: registered udf details
     """
     (udf_namespace, udf_name) = name.split("/")
@@ -481,6 +522,7 @@ def unshare(name=None, namespace=None):
             udf_namespace,
             udf_name,
             udf_sharing=rest_api.models.UDFSharing(namespace=namespace),
+            async_req=async_req,
         )
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None


### PR DESCRIPTION
Now any function can be run as an async request by passing the `async_req` parameter. This allows clients to perform listing and other api requests async if they wish. Default is still for synchronous requests.