### PR TITLE
Fix tiledb.cloud.udf.update_generic_udf

### DIFF
--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -341,7 +341,7 @@ def update_udf(
         if source_lines is not None:
             udf_model.exec_raw = source_lines
 
-        api_instance.updated_registered_udf(
+        api_instance.update_udf_info(
             namespace=namespace, name=name, udf=udf_model, async_req=async_req
         )
 


### PR DESCRIPTION
Fixes `AttributeError: 'UdfApi' object has no attribute 'update_registered_udf'`