### PR TITLE
Add helper functions for return end nodes of DAG

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -101,6 +101,48 @@ class DAGClassTest(unittest.TestCase):
         self.assertEqual(node_5.result(), 8)
         self.assertEqual(node_6.result(), 24)
 
+    def test_end_nodes_dag(self):
+        d = dag.DAG()
+
+        node_1 = d.add_node(np.median, [1, 2, 3])
+        node_1.name = "multi_node_1"
+        l = lambda x: x * 2
+        node_2 = d.add_node(l, node_1)
+        node_2.name = "multi_node_2"
+        node_3 = d.add_node(l, node_2)
+        node_3.name = "multi_node_3"
+        node_4 = d.add_node(l, node_2)
+        node_4.name = "multi_node_4"
+        node_5 = d.add_node(l, node_2)
+        node_5.name = "multi_node_5"
+
+        node_6 = d.add_node(lambda *x: np.sum(x), node_3, node_4, node_5)
+        node_6.name = "multi_node_6"
+
+        d.compute()
+
+        # Wait for dag to complete
+        d.wait(30)
+
+        self.assertEqual(node_1.result(), 2)
+        self.assertEqual(node_2.result(), 4)
+        self.assertEqual(node_3.result(), 8)
+        self.assertEqual(node_4.result(), 8)
+        self.assertEqual(node_5.result(), 8)
+        self.assertEqual(node_6.result(), 24)
+
+        end_nodes = d.end_nodes()
+        self.assertEqual(1, len(end_nodes))
+        self.assertEqual(node_6.id, end_nodes[0].id)
+
+        end_results = d.end_results()
+        self.assertEqual(1, len(end_results))
+        self.assertEqual(node_6.result(), end_results[node_6.id])
+
+        end_results = d.end_results_by_name()
+        self.assertEqual(1, len(end_results))
+        self.assertEqual(node_6.result(), end_results[node_6.name])
+
 
 class DAGFailureTest(unittest.TestCase):
     def test_dag_failure(self):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -837,3 +837,57 @@ class DAG:
             self.add_update_callback(self.__update_dag_plotly_graph)
 
         return fig
+
+    def end_nodes(self):
+        """
+        Find all ends nodes
+
+        dag = DAG()
+        dag.add_node(Node())
+
+        end_nodes = dag.end_nodes()
+
+        :return: list of root nodes
+        """
+        ends = []
+        for node in self.nodes.values():
+            if node.children is None or len(node.children) == 0:
+                ends.append(node)
+
+        return ends
+
+    def end_results(self):
+        """
+        Get all end results, will block if all results are not ready
+
+        dag = DAG()
+        dag.add_node(Node())
+
+        end_results = dag.end_results()
+
+        :return: map of results by node ID
+        """
+
+        results = {}
+        for node in self.end_nodes():
+            results[node.id] = node.result()
+
+        return results
+
+    def end_results_by_name(self):
+        """
+        Get all end results, will block if all results are not ready
+
+        dag = DAG()
+        dag.add_node(Node())
+
+        end_results = dag.end_results_by_name()
+
+        :return: map of results by node name
+        """
+
+        results = {}
+        for node in self.end_nodes():
+            results[node.name] = node.result()
+
+        return results


### PR DESCRIPTION
Three new functions are added to help return the end nodes or end results of a DAG. End is defined as nodes which have no children.