### PR TITLE
Add support for arbitrary parameters in Array UDFs

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -83,6 +83,21 @@ class BasicTests(unittest.TestCase):
                 numpy.sum(orig["a"]),
             )
 
+    def test_quickstart_arbitrary_parameters(self):
+        with tiledb.open(
+            "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
+        ) as A:
+            print("quickstart_sparse:")
+            print(A[:])
+
+            def hello(data_ignored, param):
+                return "hello " + param
+
+            self.assertEqual(
+                A.apply(hello, [[1, slice(2, 4)], [(1, 2), 4]], v2=True, param="world"),
+                "hello world",
+            )
+
     def test_quickstart_async(self):
         with tiledb.open(
             "tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.Ctx()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,7 +90,7 @@ class BasicTests(unittest.TestCase):
             print("quickstart_sparse:")
             print(A[:])
 
-            def hello(data_ignored, param):
+            def hello(data_ignored, param=""):
                 return "hello " + param
 
             self.assertEqual(

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -346,10 +346,12 @@ def apply_async(
     include_source_lines=True,
     task_name=None,
     v2=True,
+    **kwargs
 ):
     """
     Apply a user defined function to an array asynchronous
 
+    :param uri: array to apply on
     :param func: user function to run
     :param ranges: ranges to issue query on
     :param attrs: list of attributes or dimensions to fetch in query
@@ -359,6 +361,7 @@ def apply_async(
     :param include_source_lines: disables sending sources lines of function along with udf
     :param str task_name: optional name to assign the task for logging and audit purposes
     :param bool v2: use v2 array udfs
+    :param kwargs: named arguments to pass to function
     :return: UDFResult object which is a future containing the results of the UDF
 
     **Example**
@@ -400,6 +403,15 @@ def apply_async(
 
     ranges = rest_api.models.UDFRanges(layout=converted_layout, ranges=ranges)
 
+    arguments = None
+    if kwargs is not None and len(kwargs) > 0:
+        arguments = []
+        if len(kwargs) > 0:
+            arguments.append(kwargs)
+        arguments = tuple(arguments)
+        arguments = cloudpickle.dumps(arguments, protocol=udf.tiledb_cloud_protocol)
+        arguments = base64.b64encode(arguments).decode("ascii")
+
     if image_name is None:
         image_name = "default"
     try:
@@ -422,6 +434,7 @@ def apply_async(
             ),
             image_name=image_name,
             task_name=task_name,
+            argument=arguments,
         )
 
         if pickledUDF is not None:
@@ -454,10 +467,12 @@ def apply(
     http_compressor="deflate",
     task_name=None,
     v2=True,
+    **kwargs
 ):
     """
     Apply a user defined function to an array synchronous
 
+    :param uri: array to apply on
     :param func: user function to run
     :param ranges: ranges to issue query on
     :param attrs: list of attributes or dimensions to fetch in query
@@ -466,6 +481,7 @@ def apply(
     :param http_compressor: set http compressor for results
     :param str task_name: optional name to assign the task for logging and audit purposes
     :param bool v2: use v2 array udfs
+    :param kwargs: named arguments to pass to function
     :return: UDFResult object which is a future containing the results of the UDF
 
     **Example**
@@ -487,4 +503,5 @@ def apply(
         http_compressor=http_compressor,
         task_name=task_name,
         v2=v2,
+        **kwargs,
     ).get()

--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -15,6 +15,7 @@ class CloudArray(object):
         http_compressor="deflate",
         task_name=None,
         v2=False,
+        **kwargs
     ):
         """
         Apply a user defined function to an array asynchronous
@@ -27,6 +28,7 @@ class CloudArray(object):
         :param http_compressor: set http compressor for results
         :param str task_name: optional name to assign the task for logging and audit purposes
         :param bool v2: use v2 array udfs
+        :param kwargs: named arguments to pass to function
         :return: UDFResult object which is a future containing the results of the UDF
 
         **Example**
@@ -50,6 +52,7 @@ class CloudArray(object):
             http_compressor=http_compressor,
             task_name=task_name,
             v2=v2,
+            **kwargs,
         )
 
     def apply(
@@ -63,6 +66,7 @@ class CloudArray(object):
         http_compressor="deflate",
         task_name=None,
         v2=False,
+        **kwargs
     ):
         """
         Apply a user defined function to an array
@@ -74,6 +78,7 @@ class CloudArray(object):
         :param http_compressor: set http compressor for results
         :param str task_name: optional name to assign the task for logging and audit purposes
         :param bool v2: use v2 array udfs
+        :param kwargs: named arguments to pass to function
         :return: results of the UDF
         """
         return self.apply_async(
@@ -86,4 +91,5 @@ class CloudArray(object):
             http_compressor=http_compressor,
             task_name=task_name,
             v2=v2,
+            **kwargs,
         ).get()


### PR DESCRIPTION
 Only arbitrary keyword arguments are added in order to support compatibility with all existing examples which don't pass named
parameters. Fundamentally the server side supports lists and named parameters.

