### PR TITLE
Adds support for X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME header

### DIFF
--- a/tiledb/cloud/rest_api/api/array_api.py
+++ b/tiledb/cloud/rest_api/api/array_api.py
@@ -1421,6 +1421,8 @@ class ArrayApi(object):
             header_params["Content-Type"] = local_var_params[
                 "content_type"
             ]  # noqa: E501
+        if 'x_tiledb_cloud_access_credentials_name' in local_var_params:
+            header_params['X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME'] = local_var_params['x_tiledb_cloud_access_credentials_name']  # noqa: E501    
 
         form_params = []
         local_var_files = {}

--- a/tiledb/cloud/rest_api/docs/Organization.md
+++ b/tiledb/cloud/rest_api/docs/Organization.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **enabled_features** | **list[str]** | List of extra/optional/beta features to enable for namespace | [optional] [readonly] 
 **unpaid_subscription** | **bool** | A notice that the user has an unpaid subscription | [optional] [readonly] 
 **default_s3_path** | **str** | default s3 path to store newly created notebooks | [optional] 
+**default_s3_path_credentials_name** | **str** | default credentials to use for default s3 path for newly created notebooks | [optional]
 **stripe_connect** | **bool** | Denotes that the organization is able to apply pricing to arrays by means of Stripe Connect | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tiledb/cloud/rest_api/docs/User.md
+++ b/tiledb/cloud/rest_api/docs/User.md
@@ -20,6 +20,7 @@ Name | Type | Description | Notes
 **enabled_features** | **list[str]** | List of extra/optional/beta features to enable for namespace | [optional] [readonly] 
 **unpaid_subscription** | **bool** | A notice that the user has an unpaid subscription | [optional] [readonly] 
 **default_s3_path** | **str** | default s3 path to store newly created notebooks | [optional] 
+**default_s3_path_credentials_name** | **str** | default credentials to use for default s3 path for newly created notebooks | [optional]
 **default_namespace_charged** | **str** | Override the default namespace charged for actions when no namespace is specified | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tiledb/cloud/rest_api/models/organization.py
+++ b/tiledb/cloud/rest_api/models/organization.py
@@ -46,7 +46,7 @@ class Organization(object):
         "enabled_features": "list[str]",
         "unpaid_subscription": "bool",
         "default_s3_path": "str",
-        'default_s3_path_credentials_name': 'str',
+        "default_s3_path_credentials_name": "str",
         "stripe_connect": "bool",
     }
 
@@ -64,7 +64,7 @@ class Organization(object):
         "enabled_features": "enabled_features",
         "unpaid_subscription": "unpaid_subscription",
         "default_s3_path": "default_s3_path",
-        'default_s3_path_credentials_name': 'default_s3_path_credentials_name',
+        "default_s3_path_credentials_name": "default_s3_path_credentials_name",
         "stripe_connect": "stripe_connect",
     }
 

--- a/tiledb/cloud/rest_api/models/organization.py
+++ b/tiledb/cloud/rest_api/models/organization.py
@@ -46,6 +46,7 @@ class Organization(object):
         "enabled_features": "list[str]",
         "unpaid_subscription": "bool",
         "default_s3_path": "str",
+        'default_s3_path_credentials_name': 'str',
         "stripe_connect": "bool",
     }
 
@@ -63,6 +64,7 @@ class Organization(object):
         "enabled_features": "enabled_features",
         "unpaid_subscription": "unpaid_subscription",
         "default_s3_path": "default_s3_path",
+        'default_s3_path_credentials_name': 'default_s3_path_credentials_name',
         "stripe_connect": "stripe_connect",
     }
 
@@ -81,6 +83,7 @@ class Organization(object):
         enabled_features=None,
         unpaid_subscription=None,
         default_s3_path=None,
+        default_s3_path_credentials_name=None,
         stripe_connect=None,
         local_vars_configuration=None,
     ):  # noqa: E501
@@ -102,6 +105,7 @@ class Organization(object):
         self._enabled_features = None
         self._unpaid_subscription = None
         self._default_s3_path = None
+        self._default_s3_path_credentials_name = None
         self._stripe_connect = None
         self.discriminator = None
 
@@ -130,6 +134,8 @@ class Organization(object):
             self.unpaid_subscription = unpaid_subscription
         if default_s3_path is not None:
             self.default_s3_path = default_s3_path
+        if default_s3_path_credentials_name is not None:
+            self.default_s3_path_credentials_name = default_s3_path_credentials_name
         if stripe_connect is not None:
             self.stripe_connect = stripe_connect
 
@@ -457,6 +463,29 @@ class Organization(object):
         """
 
         self._default_s3_path = default_s3_path
+
+    @property
+    def default_s3_path_credentials_name(self):
+        """Gets the default_s3_path_credentials_name of this Organization.  # noqa: E501
+
+        Default s3 path credentials name is the credentials name to use along with default_s3_path  # noqa: E501
+
+        :return: The default_s3_path_credentials_name of this Organization.  # noqa: E501
+        :rtype: str
+        """
+        return self._default_s3_path_credentials_name
+
+    @default_s3_path_credentials_name.setter
+    def default_s3_path_credentials_name(self, default_s3_path_credentials_name):
+        """Sets the default_s3_path_credentials_name of this Organization.
+
+        Default s3 path credentials name is the credentials name to use along with default_s3_path  # noqa: E501
+
+        :param default_s3_path_credentials_name: The default_s3_path_credentials_name of this Organization.  # noqa: E501
+        :type: str
+        """
+
+        self._default_s3_path_credentials_name = default_s3_path_credentials_name
 
     @property
     def stripe_connect(self):

--- a/tiledb/cloud/rest_api/models/user.py
+++ b/tiledb/cloud/rest_api/models/user.py
@@ -49,6 +49,7 @@ class User(object):
         "enabled_features": "list[str]",
         "unpaid_subscription": "bool",
         "default_s3_path": "str",
+        'default_s3_path_credentials_name': 'str',
         "default_namespace_charged": "str",
     }
 
@@ -69,6 +70,7 @@ class User(object):
         "enabled_features": "enabled_features",
         "unpaid_subscription": "unpaid_subscription",
         "default_s3_path": "default_s3_path",
+        'default_s3_path_credentials_name': 'default_s3_path_credentials_name',
         "default_namespace_charged": "default_namespace_charged",
     }
 
@@ -90,6 +92,7 @@ class User(object):
         enabled_features=None,
         unpaid_subscription=None,
         default_s3_path=None,
+        default_s3_path_credentials_name=None,
         default_namespace_charged=None,
         local_vars_configuration=None,
     ):  # noqa: E501
@@ -114,6 +117,7 @@ class User(object):
         self._enabled_features = None
         self._unpaid_subscription = None
         self._default_s3_path = None
+        self._default_s3_path_credentials_name = None
         self._default_namespace_charged = None
         self.discriminator = None
 
@@ -148,6 +152,8 @@ class User(object):
             self.unpaid_subscription = unpaid_subscription
         if default_s3_path is not None:
             self.default_s3_path = default_s3_path
+        if default_s3_path_credentials_name is not None:
+            self.default_s3_path_credentials_name = default_s3_path_credentials_name
         if default_namespace_charged is not None:
             self.default_namespace_charged = default_namespace_charged
 
@@ -562,6 +568,29 @@ class User(object):
         """
 
         self._default_s3_path = default_s3_path
+
+    @property
+    def default_s3_path_credentials_name(self):
+        """Gets the default_s3_path_credentials_name of this User.  # noqa: E501
+
+        Default s3 path credentials name is the credentials name to use along with default_s3_path  # noqa: E501
+
+        :return: The default_s3_path_credentials_name of this User.  # noqa: E501
+        :rtype: str
+        """
+        return self._default_s3_path_credentials_name
+
+    @default_s3_path_credentials_name.setter
+    def default_s3_path_credentials_name(self, default_s3_path_credentials_name):
+        """Sets the default_s3_path_credentials_name of this User.
+
+        Default s3 path credentials name is the credentials name to use along with default_s3_path  # noqa: E501
+
+        :param default_s3_path_credentials_name: The default_s3_path_credentials_name of this User.  # noqa: E501
+        :type: str
+        """
+
+        self._default_s3_path_credentials_name = default_s3_path_credentials_name
 
     @property
     def default_namespace_charged(self):

--- a/tiledb/cloud/rest_api/models/user.py
+++ b/tiledb/cloud/rest_api/models/user.py
@@ -49,7 +49,7 @@ class User(object):
         "enabled_features": "list[str]",
         "unpaid_subscription": "bool",
         "default_s3_path": "str",
-        'default_s3_path_credentials_name': 'str',
+        "default_s3_path_credentials_name": "str",
         "default_namespace_charged": "str",
     }
 
@@ -70,7 +70,7 @@ class User(object):
         "enabled_features": "enabled_features",
         "unpaid_subscription": "unpaid_subscription",
         "default_s3_path": "default_s3_path",
-        'default_s3_path_credentials_name': 'default_s3_path_credentials_name',
+        "default_s3_path_credentials_name": "default_s3_path_credentials_name",
         "default_namespace_charged": "default_namespace_charged",
     }
 

--- a/tiledb/cloud/rest_api/test/test_organization.py
+++ b/tiledb/cloud/rest_api/test/test_organization.py
@@ -63,6 +63,7 @@ class TestOrganization(unittest.TestCase):
                 enabled_features=["0"],
                 unpaid_subscription=True,
                 default_s3_path="0",
+                default_s3_path_credentials_name="0",
                 stripe_connect=False,
             )
         else:

--- a/tiledb/cloud/rest_api/test/test_user.py
+++ b/tiledb/cloud/rest_api/test/test_user.py
@@ -64,6 +64,7 @@ class TestUser(unittest.TestCase):
                 enabled_features=["0"],
                 unpaid_subscription=True,
                 default_s3_path="0",
+                default_s3_path_credentials_name="0",
                 default_namespace_charged="0",
             )
         else:


### PR DESCRIPTION
In array creation

Ref: https://github.com/TileDB-Inc/TileDB-Cloud-REST/pull/1172
https://github.com/TileDB-Inc/TileDB/pull/2025