### PR TITLE
UDFResult.get: Set task_id on ApiException

### DIFF
--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -1,7 +1,5 @@
 from . import array
 
-last_udf_task_id = None
-
 
 class CloudArray(object):
     def apply_async(

--- a/tiledb/cloud/tasks.py
+++ b/tiledb/cloud/tasks.py
@@ -1,7 +1,6 @@
 from . import client
 from . import tiledb_cloud_error
 from .array import split_uri
-from . import cloudarray
 from . import sql
 from . import array
 from .rest_api import ApiException as GenApiException
@@ -153,7 +152,7 @@ def last_udf_task():
     :return task : object with task details
     """
 
-    if cloudarray.last_udf_task_id is None:
+    if array.last_udf_task_id is None:
         raise Exception("There is no last run udf task in current python session")
 
-    return task(id=cloudarray.last_udf_task_id)
+    return task(id=array.last_udf_task_id)

--- a/tiledb/cloud/tiledb_cloud_error.py
+++ b/tiledb/cloud/tiledb_cloud_error.py
@@ -1,7 +1,7 @@
 import json
 from . import sql
 from . import client
-from . import cloudarray
+from . import array
 from tiledb import TileDBError
 
 
@@ -62,7 +62,7 @@ def check_udf_exc(exc):
 
     try:
         if client.TASK_ID_HEADER in exc.headers:
-            cloudarray.last_sql_task_id = exc.headers[client.TASK_ID_HEADER]
+            array.last_udf_task_id = exc.headers[client.TASK_ID_HEADER]
         body = json.loads(exc.body)
         new_exc = TileDBCloudError(
             "{} - Code: {}".format(body["message"], body["code"])

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -13,8 +13,6 @@ tiledb_cloud_protocol = 4
 import base64
 import sys
 
-last_udf_task_id = None
-
 
 def exec_async(
     *args,


### PR DESCRIPTION
While trying to use the new `tiledb.cloud.retry_task` I found that when a task fails its `task_id` is not available in the returned `UDFResult` instance, although it is available in the response headers. This PR sets the `task_id` in case of `ApiException`.