### PR TITLE
Retry support for Delayed tasks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ plotly = ">= 4.0.0"
 networkx = ">= 2.0.0"
 pydot = "*"
 tiledb-plot-widget = ">= 0.1.7"
+tenacity = "*"
 
 [dev-packages]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     "networkx>= 2.0.0",
     "pydot",
     "tiledb-plot-widget>=0.1.7",
+    "tenacity",
 ]
 
 # NOTE: we cannot use an __init__.py file in the tiledb/ directory, because it is supplied


### PR DESCRIPTION
Draft proposal for transparent retrying of Delayed tasks. The actual retrying logic (when to stop, how long to wait between retries, etc.) is provided by [tenacity](https://tenacity.readthedocs.io/en/latest/). Docs and tests to be added if there are no objections to the idea.

Usage:
```py
import logging
import random
import time
from tiledb.cloud.compute import Delayed

from tenacity import (
    Retrying,
    wait_fixed,
    stop_after_attempt,
    before_log,
    before_sleep_log,
)


logging.basicConfig(level=logging.INFO, format="%(asctime)s: %(message)s")


def f(x, p):
    v = random.random()
    if v < p:
        raise ValueError(f"Value less than {p}: {v}")
    time.sleep(v * 10)
    return v ** x


retrying = Retrying(
    stop=stop_after_attempt(3),
    wait=wait_fixed(2),
    before=before_log(logging, logging.INFO),
    before_sleep=before_sleep_log(logging, logging.INFO),
)

nodes = [Delayed(f, name=f"node_{i}", retrying=retrying)(i, 0.4) for i in range(3)]
print(Delayed(sum, local=True)(nodes).compute())
```
Sample output:
```
2021-02-04 14:07:42,161: Starting call to 'node_1', this is the 1st time calling it.
2021-02-04 14:07:42,171: Starting call to 'node_2', this is the 1st time calling it.
2021-02-04 14:07:42,266: Starting call to 'node_0', this is the 1st time calling it.
2021-02-04 14:07:47,219: Retrying node_0 in 2.0 seconds as it raised TileDBCloudError: Docker logs: Running UDF.
Error executing UDF:
------------------- UDF Backtrace -------------------
Traceback (most recent call last):
  File "/opt/python_generic_udf_entry.py", line 486, in main
    result = udf_function(*(udf_args_parsed[0]))
  File "retry_demo.py", line 21, in f
ValueError: Value less than 0.4: 0.23205460161491887

------------------- End Backtrace -------------------
Error(s): docker container exited with non-zero code: 1. - Code: 4010.
2021-02-04 14:07:49,221: Starting call to 'node_0', this is the 2nd time calling it.
2021-02-04 14:07:54,510: Retrying node_0 in 2.0 seconds as it raised TileDBCloudError: Docker logs: Running UDF.
Error executing UDF:
------------------- UDF Backtrace -------------------
Traceback (most recent call last):
  File "/opt/python_generic_udf_entry.py", line 486, in main
    result = udf_function(*(udf_args_parsed[0]))
  File "retry_demo.py", line 21, in f
ValueError: Value less than 0.4: 0.024038032335790716

------------------- End Backtrace -------------------
Error(s): docker container exited with non-zero code: 1. - Code: 4010.
2021-02-04 14:07:56,512: Starting call to 'node_0', this is the 3rd time calling it.
1.9224380470427413
```