### PR TITLE
Fix task failure handling

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -190,18 +190,21 @@ class DAGFailureTest(unittest.TestCase):
 class DAGCancelTest(unittest.TestCase):
     def test_dag_cancel(self):
         d = dag.DAG()
-
         node = d.add_node(time.sleep, 1)
         node_2 = d.add_node(np.mean, [1, 1])
+        node_2.depends_on(node)
 
         d.compute()
-
         # Cancel DAG
         d.cancel()
 
-        self.assertEqual(node.result(), None)
-        self.assertEqual(node.status, dag.Status.CANCELLED)
         self.assertEqual(d.status, dag.Status.CANCELLED)
+
+        self.assertEqual(node.status, dag.Status.CANCELLED)
+        self.assertEqual(node.result(), None)
+
+        self.assertEqual(node_2.status, dag.Status.CANCELLED)
+        self.assertEqual(node_2.result(), None)
 
 
 class DAGCloudApplyTest(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -198,13 +198,13 @@ class DAGCancelTest(unittest.TestCase):
         # Cancel DAG
         d.cancel()
 
-        self.assertEqual(d.status, dag.Status.CANCELLED)
-
         self.assertEqual(node.status, dag.Status.CANCELLED)
         self.assertEqual(node.result(), None)
 
         self.assertEqual(node_2.status, dag.Status.CANCELLED)
         self.assertEqual(node_2.result(), None)
+
+        self.assertEqual(d.status, dag.Status.CANCELLED)
 
 
 class DAGCloudApplyTest(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -182,7 +182,7 @@ class DAGFailureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             node.result()
 
-        self.assertEqual(node2.status, dag.Status.NOT_STARTED)
+        self.assertEqual(node2.status, dag.Status.CANCELLED)
         self.assertEqual(node2.result(), None)
         self.assertEqual(d.status, dag.Status.FAILED)
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -155,12 +155,12 @@ class DAGFailureTest(unittest.TestCase):
         d.wait(30)
 
         self.assertEqual(node.status, dag.Status.FAILED)
+        with self.assertRaises(TypeError) as ctx:
+            node.result()
         self.assertEqual(
-            str(node.error),
+            str(ctx.exception),
             "unsupported operand type(s) for *: 'function' and 'int'",
         )
-        with self.assertRaises(TypeError):
-            node.result()
 
     def test_dag_dependency_fail_early(self):
         d = dag.DAG()
@@ -175,12 +175,12 @@ class DAGFailureTest(unittest.TestCase):
         d.wait(30)
 
         self.assertEqual(node.status, dag.Status.FAILED)
+        with self.assertRaises(TypeError) as ctx:
+            node.result()
         self.assertEqual(
-            str(node.error),
+            str(ctx.exception),
             "unsupported operand type(s) for *: 'function' and 'int'",
         )
-        with self.assertRaises(TypeError):
-            node.result()
 
         self.assertEqual(node2.status, dag.Status.CANCELLED)
         self.assertEqual(node2.result(), None)

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -123,14 +123,14 @@ class DelayedCancelTest(unittest.TestCase):
 
         node_2.dag.cancel()
 
-        self.assertIs(node.dag, node_2.dag)
-        self.assertEqual(node.dag.status, Status.CANCELLED)
-
         self.assertEqual(node.status, Status.CANCELLED)
         self.assertEqual(node.result(), None)
 
         self.assertEqual(node_2.status, Status.CANCELLED)
         self.assertEqual(node_2.result(), None)
+
+        self.assertIs(node.dag, node_2.dag)
+        self.assertEqual(node.dag.status, Status.CANCELLED)
 
 
 class DelayedCloudApplyTest(unittest.TestCase):

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -104,7 +104,7 @@ class DelayedFailureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             node.result()
 
-        self.assertEqual(node2.status, Status.NOT_STARTED)
+        self.assertEqual(node2.status, Status.CANCELLED)
         self.assertEqual(node2.result(), None)
         self.assertEqual(node2.dag.status, Status.FAILED)
 

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -111,22 +111,26 @@ class DelayedFailureTest(unittest.TestCase):
 
 class DelayedCancelTest(unittest.TestCase):
     def test_cancel(self):
+        node = Delayed(time.sleep, local=True, name="multi_node_2")(3)
+        node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
+        node_2.depends_on(node)
+
         with self.assertRaises(TimeoutError):
-            node = Delayed(time.sleep, local=True, name="multi_node_2")(100)
-            node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
-            node_2.depends_on(node)
-
-            # Set timeout to 1 second, the dependency on node will wait for 100 second, so we'll timeout and cancel
+            # Set timeout to 1 second, the dependency on node will wait for 3 seconds,
+            # so we'll timeout and cancel
             node_2.set_timeout(1)
-
             node_2.compute()
 
-            # Cancel DAG
-            node_2.dag.cancel()
+        node_2.dag.cancel()
 
-            self.assertEqual(node.result(), None)
-            self.assertEqual(node.status, Status.CANCELLED)
-            self.assertEqual(node_2.dag.status, Status.CANCELLED)
+        self.assertIs(node.dag, node_2.dag)
+        self.assertEqual(node.dag.status, Status.CANCELLED)
+
+        self.assertEqual(node.status, Status.CANCELLED)
+        self.assertEqual(node.result(), None)
+
+        self.assertEqual(node_2.status, Status.CANCELLED)
+        self.assertEqual(node_2.result(), None)
 
 
 class DelayedCloudApplyTest(unittest.TestCase):

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -79,12 +79,12 @@ class DelayedFailureTest(unittest.TestCase):
 
         self.assertIsNotNone(node.dag)
         self.assertEqual(node.status, Status.FAILED)
+        with self.assertRaises(TypeError) as ctx:
+            node.result()
         self.assertEqual(
-            str(node.error),
+            str(ctx.exception),
             "unsupported operand type(s) for *: 'function' and 'int'",
         )
-        with self.assertRaises(TypeError):
-            node.result()
 
     def test_dependency_fail_early(self):
         node = Delayed(lambda x: x * 2, local=True, name="node")(np.median)
@@ -97,12 +97,12 @@ class DelayedFailureTest(unittest.TestCase):
             node2.compute()
 
         self.assertEqual(node.status, Status.FAILED)
+        with self.assertRaises(TypeError) as ctx:
+            node.result()
         self.assertEqual(
-            str(node.error),
+            str(ctx.exception),
             "unsupported operand type(s) for *: 'function' and 'int'",
         )
-        with self.assertRaises(TypeError):
-            node.result()
 
         self.assertEqual(node2.status, Status.CANCELLED)
         self.assertEqual(node2.result(), None)

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -64,12 +64,9 @@ class DelayedBase(Node):
         if self.dag is None:
             self.__set_all_parent_nodes_same_dag(DAG())
 
-        if self.dag is not None:
-            return self.dag.visualize(
-                notebook=notebook, auto_update=auto_update, force_plotly=force_plotly
-            )
-
-        return None
+        return self.dag.visualize(
+            notebook=notebook, auto_update=auto_update, force_plotly=force_plotly
+        )
 
     @staticmethod
     def all(futures, namespace=None):

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -1,4 +1,4 @@
-from ..dag.dag import Node, DAG
+from ..dag.dag import Node, DAG, Status
 
 from ..array import apply as array_apply
 from ..sql import exec as sql_exec
@@ -34,12 +34,13 @@ class DelayedBase(Node):
             self.dag.namespace = namespace
 
         self.dag.compute()
-        super().wait(self.timeout)
+        self.wait(self.timeout)
 
-        if not super().done():
-            self.dag.cancel()
+        if self.dag.status == Status.FAILED:
+            # reraise the first failed node exception
+            raise next(iter(self.dag.failed_nodes.values())).error
 
-        return super().result()
+        return self.result()
 
     def __set_all_parent_nodes_same_dag(self, dag):
         # If this node already has the day we have reached a base case

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -38,7 +38,7 @@ class DelayedBase(Node):
 
         if self.dag.status == Status.FAILED:
             # reraise the first failed node exception
-            raise next(iter(self.dag.failed_nodes.values())).error
+            raise next(iter(self.dag.failed_nodes.values())).future.exception()
 
         return self.result()
 

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -34,7 +34,7 @@ class DelayedBase(Node):
             self.dag.namespace = namespace
 
         self.dag.compute()
-        self.wait(self.timeout)
+        self.dag.wait(self.timeout)
 
         if self.dag.status == Status.FAILED:
             # reraise the first failed node exception

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -214,23 +214,13 @@ class Node:
     def __handle_completed_future(self, future):
         try:
             self.__results = future.result()
+            if self.status == Status.RUNNING:
+                self.status = Status.COMPLETED
         except CancelledError:
             self.status = Status.CANCELLED
-
-        # Set status if it has not already been set for cancelled or failed
-        if self.status == Status.RUNNING:
-            self.status = Status.COMPLETED
-
-        try:
-            self.error = future.exception()
-        except CancelledError:
-            pass
         except Exception as exc:
             self.error = exc
-
-        if self.error is not None:
             self.status = Status.FAILED
-
         self.dag.report_node_complete(self)
 
     def ready_to_compute(self):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -473,8 +473,7 @@ class DAG:
             self.cancelled_nodes[node.id] = node
         else:
             self.failed_nodes[node.id] = node
-            for node in self.not_started_nodes.values():
-                node.cancel()
+            self.cancel()
 
         self.execute_update_callbacks()
 
@@ -544,9 +543,10 @@ class DAG:
                 )
 
     def cancel(self):
-
         self.status = Status.CANCELLED
         for node in self.running_nodes.values():
+            node.cancel()
+        for node in self.not_started_nodes.values():
             node.cancel()
 
     def find_end_nodes(self):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -195,14 +195,8 @@ class Node:
 
         # Execute user function with the parameters that the user requested
         # The function is executed on the dag's worker pool
-        future = self.dag.executor.submit(self.func, *self.args, **self.kwargs)
-        # If the node is already finished by the time we get here, call complete function directly
-        # In python 3.7 if we add a call back to a future with an exception it throws an exception
-        if future.done():
-            self.__handle_completed_future(future)
-        else:
-            future.add_done_callback(self.__handle_completed_future)
-        self.future = future
+        self.future = self.dag.executor.submit(self.func, *self.args, **self.kwargs)
+        self.future.add_done_callback(self.__handle_completed_future)
 
     compute = exec
 

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -148,8 +148,7 @@ class Node:
         if self.error is not None:
             self.status = Status.FAILED
 
-        if self.dag is not None and isinstance(self.dag, DAG):
-            self.dag.report_node_complete(self)
+        self.dag.report_node_complete(self)
 
     def __handle_complete_results(self):
         """
@@ -253,6 +252,7 @@ class Node:
 
         # Execute user function with the parameters that the user requested
         # The function is executed on the dag's worker pool
+        assert self.dag is not None
         if self.dag is not None:
             if len(self.kwargs) > 0 and len(self.args) > 0:
                 res = self.dag.executor.submit(self.func, *self.args, **self.kwargs)

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -134,12 +134,7 @@ class Node:
         Is the node finished
         :return: True if the node's function is finished
         """
-        if self.status == Status.COMPLETED or self.status == Status.FAILED:
-            return True
-        elif self.status == Status.RUNNING:
-            if self.future is not None and self.future.done():
-                return True
-        return False
+        return self.status in (Status.COMPLETED, Status.FAILED, Status.CANCELLED)
 
     done = finished
 
@@ -488,14 +483,14 @@ class DAG:
 
         if node.status == Status.COMPLETED:
             self.completed_nodes[node.id] = node
-
             for child in node.children.values():
-                if child.ready_to_compute():
-                    self._exec_node(child)
+                self._exec_node(child)
         elif node.status == Status.CANCELLED:
             self.cancelled_nodes[node.id] = node
         else:
             self.failed_nodes[node.id] = node
+            for node in self.not_started_nodes.values():
+                node.cancel()
 
         self.execute_update_callbacks()
 


### PR DESCRIPTION
- Simplify internals by removing the unused `dag is None` code path (https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/bbb93d07aadcddc715add2a15dbb075e83b48037, https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/032369ce7d27ba73f6a7b15307848f83b5938e28, https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/ab5d5e0251e1d252a4bc62955454cf2469d83906)
- Fix tests for failed tasks: `.compute()` raises an exception so all subsequent code was being skipped ( https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/7f6da0816f130e9471e3e6c23baabd0e0f81c683)
- Fix the hanging `DelayedBase.compute()` when a task fails (https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/066e81648421b026ad8f343f1b5ca8f82484b414, https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/5d0c8659cbde105c741684d8472ab5b9eda2108b)
- Cancel all non-started tasks on `DAG.cancel()` to be on the safe side and fix/update the cancellation tests (https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/c379a64bd543f98278426a343b541534bc0da0ad)
- Minor DAG refactorings (https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/37eff22cb6138de09a98a708b692ef6682000ca9, https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/123/commits/b1184667d71094120cc8fa2b416029f8246b3766)
