### PR TITLE
Fix task failure handling

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -190,18 +190,21 @@ class DAGFailureTest(unittest.TestCase):
 class DAGCancelTest(unittest.TestCase):
     def test_dag_cancel(self):
         d = dag.DAG()
-
         node = d.add_node(time.sleep, 1)
         node_2 = d.add_node(np.mean, [1, 1])
+        node_2.depends_on(node)
 
         d.compute()
-
         # Cancel DAG
         d.cancel()
 
-        self.assertEqual(node.result(), None)
-        self.assertEqual(node.status, dag.Status.CANCELLED)
         self.assertEqual(d.status, dag.Status.CANCELLED)
+
+        self.assertEqual(node.status, dag.Status.CANCELLED)
+        self.assertEqual(node.result(), None)
+
+        self.assertEqual(node_2.status, dag.Status.CANCELLED)
+        self.assertEqual(node_2.result(), None)
 
 
 class DAGCloudApplyTest(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -182,7 +182,7 @@ class DAGFailureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             node.result()
 
-        self.assertEqual(node2.status, dag.Status.NOT_STARTED)
+        self.assertEqual(node2.status, dag.Status.CANCELLED)
         self.assertEqual(node2.result(), None)
         self.assertEqual(d.status, dag.Status.FAILED)
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -151,8 +151,10 @@ class DAGFailureTest(unittest.TestCase):
         node.name = "node"
 
         d.compute()
-        # Wait for dag to complete
-        d.wait(30)
+        with self.assertRaises(TypeError):
+            # Wait for dag to complete
+            d.wait(30)
+        self.assertEqual(d.status, dag.Status.FAILED)
 
         self.assertEqual(node.status, dag.Status.FAILED)
         self.assertEqual(
@@ -171,8 +173,10 @@ class DAGFailureTest(unittest.TestCase):
         node2.depends_on(node)
 
         d.compute()
-        # Wait for dag to complete
-        d.wait(30)
+        with self.assertRaises(TypeError):
+            # Wait for dag to complete
+            d.wait(30)
+        self.assertEqual(d.status, dag.Status.FAILED)
 
         self.assertEqual(node.status, dag.Status.FAILED)
         self.assertEqual(
@@ -184,7 +188,6 @@ class DAGFailureTest(unittest.TestCase):
 
         self.assertEqual(node2.status, dag.Status.CANCELLED)
         self.assertEqual(node2.result(), None)
-        self.assertEqual(d.status, dag.Status.FAILED)
 
 
 class DAGCancelTest(unittest.TestCase):

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -104,7 +104,7 @@ class DelayedFailureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             node.result()
 
-        self.assertEqual(node2.status, Status.NOT_STARTED)
+        self.assertEqual(node2.status, Status.CANCELLED)
         self.assertEqual(node2.result(), None)
         self.assertEqual(node2.dag.status, Status.FAILED)
 

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -111,22 +111,26 @@ class DelayedFailureTest(unittest.TestCase):
 
 class DelayedCancelTest(unittest.TestCase):
     def test_cancel(self):
+        node = Delayed(time.sleep, local=True, name="multi_node_2")(3)
+        node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
+        node_2.depends_on(node)
+
         with self.assertRaises(TimeoutError):
-            node = Delayed(time.sleep, local=True, name="multi_node_2")(100)
-            node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
-            node_2.depends_on(node)
-
-            # Set timeout to 1 second, the dependency on node will wait for 100 second, so we'll timeout and cancel
+            # Set timeout to 1 second, the dependency on node will wait for 3 seconds,
+            # so we'll timeout and cancel
             node_2.set_timeout(1)
-
             node_2.compute()
 
-            # Cancel DAG
-            node_2.dag.cancel()
+        node_2.dag.cancel()
 
-            self.assertEqual(node.result(), None)
-            self.assertEqual(node.status, Status.CANCELLED)
-            self.assertEqual(node_2.dag.status, Status.CANCELLED)
+        self.assertIs(node.dag, node_2.dag)
+        self.assertEqual(node.dag.status, Status.CANCELLED)
+
+        self.assertEqual(node.status, Status.CANCELLED)
+        self.assertEqual(node.result(), None)
+
+        self.assertEqual(node_2.status, Status.CANCELLED)
+        self.assertEqual(node_2.result(), None)
 
 
 class DelayedCloudApplyTest(unittest.TestCase):

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -64,12 +64,9 @@ class DelayedBase(Node):
         if self.dag is None:
             self.__set_all_parent_nodes_same_dag(DAG())
 
-        if self.dag is not None:
-            return self.dag.visualize(
-                notebook=notebook, auto_update=auto_update, force_plotly=force_plotly
-            )
-
-        return None
+        return self.dag.visualize(
+            notebook=notebook, auto_update=auto_update, force_plotly=force_plotly
+        )
 
     @staticmethod
     def all(futures, namespace=None):

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -36,10 +36,6 @@ class DelayedBase(Node):
         self.dag.compute()
         self.dag.wait(self.timeout)
 
-        if self.dag.status == Status.FAILED:
-            # reraise the first failed node exception
-            raise next(iter(self.dag.failed_nodes.values())).error
-
         return self.result()
 
     def __set_all_parent_nodes_same_dag(self, dag):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -483,8 +483,7 @@ class DAG:
             self.cancelled_nodes[node.id] = node
         else:
             self.failed_nodes[node.id] = node
-            for node in self.not_started_nodes.values():
-                node.cancel()
+            self.cancel()
 
         self.execute_update_callbacks()
 
@@ -559,9 +558,10 @@ class DAG:
                 )
 
     def cancel(self):
-
         self.status = Status.CANCELLED
         for node in self.running_nodes.values():
+            node.cancel()
+        for node in self.not_started_nodes.values():
             node.cancel()
 
     def find_end_nodes(self):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -557,6 +557,10 @@ class DAG:
                     "timeout of {} reached and dag is not complete".format(timeout)
                 )
 
+        # in case of failure reraise the first failed node exception
+        if self.status == Status.FAILED:
+            raise next(iter(self.failed_nodes.values())).error
+
     def cancel(self):
         self.status = Status.CANCELLED
         for node in self.running_nodes.values():


### PR DESCRIPTION
- Fix tests for failed tasks: `.compute()` raises an exception so all subsequent code was being skipped
- Fix the hanging `DelayedBase.compute()` when a task fails
- Cancel all non-started tasks on `DAG.cancel()` and fix the cancellation tests