### PR TITLE
Signal update callbacks on DAG compute()

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -413,5 +413,5 @@ class DAGCallbackTest(unittest.TestCase):
         self.assertEqual(node_3.result(), 8)
         global status_updates
         global done_updates
-        self.assertEqual(status_updates, 3)
+        self.assertEqual(status_updates, 5)
         self.assertEqual(done_updates, 1)

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -601,6 +601,11 @@ class DAG:
         self.status = Status.RUNNING
         for node in roots:
             self._exec_node(node)
+            # Make sure to execute any callbacks to signal this node has started
+            self.execute_update_callbacks()
+
+        # Make sure to execute any callbacks to signal things have started
+        self.execute_update_callbacks()
 
     def _exec_node(self, node):
         """


### PR DESCRIPTION
This allows callbacks to be notified that the tasks have started. For instance this lets the graph updated right away.