### PR TITLE
Handle empty arrow results

### DIFF
--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -55,6 +55,11 @@ class UDFResult(multiprocessing.pool.ApplyResult):
             elif self.result_format == rest_api.models.UDFResultType.ARROW:
                 import pyarrow
 
+                # Arrow optimized empty results by not serializing anything
+                # We need to account for this and return None to the user instead of trying to read it (which will produce an error)
+                if len(res) == 0:
+                    return None
+
                 reader = pyarrow.RecordBatchStreamReader(res)
                 res = reader.read_all()
         except:


### PR DESCRIPTION
It seems arrow can potentially send us zero results when we attempt to serialize an empty table server side. This handles this case and returns None to the user in this case.