### PR TITLE
 Add SQL parameters for severless SQL

### DIFF
--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -63,3 +63,20 @@ class BasicTests(unittest.TestCase):
 
         # Validate task name was set
         self.assertEqual(tiledb.cloud.last_sql_task().name, task_name)
+
+    def test_sql_parameters(self):
+        task_name = "test_sql_parameters"
+        self.assertEqual(
+            float(
+                tiledb.cloud.sql.exec_async(
+                    "select @A a, ? param1",
+                    task_name=task_name,
+                    init_commands=["SET @A=1"],
+                    parameters=["1.1"],
+                ).get()["param1"]
+            ),
+            1.1,
+        )
+
+        # Validate task name was set
+        self.assertEqual(tiledb.cloud.last_sql_task().name, task_name)

--- a/tiledb/cloud/rest_api/docs/ArrayTask.md
+++ b/tiledb/cloud/rest_api/docs/ArrayTask.md
@@ -27,6 +27,7 @@ Name | Type | Description | Notes
 **logs** | **str** | logs from array task | [optional] 
 **duration** | **float** | duration in nanoseconds of an array task | [optional] 
 **sql_init_commands** | **list[str]** | SQL queries or commands to run before main sql query | [optional] 
+**sql_parameters** | **list[object]** | SQL query parameters | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tiledb/cloud/rest_api/docs/SQLParameters.md
+++ b/tiledb/cloud/rest_api/docs/SQLParameters.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **output_uri** | **str** | Output array uri | [optional] 
 **store_results** | **bool** | store results for later retrieval | [optional] 
 **init_commands** | **list[str]** | Queries or commands to run before main query | [optional] 
+**parameters** | **list[object]** | SQL query parameters | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tiledb/cloud/rest_api/models/array_task.py
+++ b/tiledb/cloud/rest_api/models/array_task.py
@@ -56,6 +56,7 @@ class ArrayTask(object):
         "logs": "str",
         "duration": "float",
         "sql_init_commands": "list[str]",
+        "sql_parameters": "list[object]",
     }
 
     attribute_map = {
@@ -82,6 +83,7 @@ class ArrayTask(object):
         "logs": "logs",
         "duration": "duration",
         "sql_init_commands": "sql_init_commands",
+        "sql_parameters": "sql_parameters",
     }
 
     def __init__(
@@ -109,6 +111,7 @@ class ArrayTask(object):
         logs=None,
         duration=None,
         sql_init_commands=None,
+        sql_parameters=None,
         local_vars_configuration=None,
     ):  # noqa: E501
         """ArrayTask - a model defined in OpenAPI"""  # noqa: E501
@@ -139,6 +142,7 @@ class ArrayTask(object):
         self._logs = None
         self._duration = None
         self._sql_init_commands = None
+        self._sql_parameters = None
         self.discriminator = None
 
         if id is not None:
@@ -187,6 +191,8 @@ class ArrayTask(object):
             self.duration = duration
         if sql_init_commands is not None:
             self.sql_init_commands = sql_init_commands
+        if sql_parameters is not None:
+            self.sql_parameters = sql_parameters
 
     @property
     def id(self):
@@ -706,6 +712,29 @@ class ArrayTask(object):
         """
 
         self._sql_init_commands = sql_init_commands
+
+    @property
+    def sql_parameters(self):
+        """Gets the sql_parameters of this ArrayTask.  # noqa: E501
+
+        SQL query parameters  # noqa: E501
+
+        :return: The sql_parameters of this ArrayTask.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._sql_parameters
+
+    @sql_parameters.setter
+    def sql_parameters(self, sql_parameters):
+        """Sets the sql_parameters of this ArrayTask.
+
+        SQL query parameters  # noqa: E501
+
+        :param sql_parameters: The sql_parameters of this ArrayTask.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._sql_parameters = sql_parameters
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tiledb/cloud/rest_api/models/sql_parameters.py
+++ b/tiledb/cloud/rest_api/models/sql_parameters.py
@@ -38,6 +38,7 @@ class SQLParameters(object):
         "output_uri": "str",
         "store_results": "bool",
         "init_commands": "list[str]",
+        "parameters": "list[object]",
     }
 
     attribute_map = {
@@ -46,6 +47,7 @@ class SQLParameters(object):
         "output_uri": "output_uri",
         "store_results": "store_results",
         "init_commands": "init_commands",
+        "parameters": "parameters",
     }
 
     def __init__(
@@ -55,6 +57,7 @@ class SQLParameters(object):
         output_uri=None,
         store_results=None,
         init_commands=None,
+        parameters=None,
         local_vars_configuration=None,
     ):  # noqa: E501
         """SQLParameters - a model defined in OpenAPI"""  # noqa: E501
@@ -67,6 +70,7 @@ class SQLParameters(object):
         self._output_uri = None
         self._store_results = None
         self._init_commands = None
+        self._parameters = None
         self.discriminator = None
 
         if name is not None:
@@ -79,6 +83,8 @@ class SQLParameters(object):
             self.store_results = store_results
         if init_commands is not None:
             self.init_commands = init_commands
+        if parameters is not None:
+            self.parameters = parameters
 
     @property
     def name(self):
@@ -194,6 +200,29 @@ class SQLParameters(object):
         """
 
         self._init_commands = init_commands
+
+    @property
+    def parameters(self):
+        """Gets the parameters of this SQLParameters.  # noqa: E501
+
+        SQL query parameters  # noqa: E501
+
+        :return: The parameters of this SQLParameters.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """Sets the parameters of this SQLParameters.
+
+        SQL query parameters  # noqa: E501
+
+        :param parameters: The parameters of this SQLParameters.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._parameters = parameters
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tiledb/cloud/rest_api/test/test_array_task.py
+++ b/tiledb/cloud/rest_api/test/test_array_task.py
@@ -134,6 +134,7 @@ class TestArrayTask(unittest.TestCase):
                 logs="0",
                 duration=3.41e11,
                 sql_init_commands=["0"],
+                sql_parameters=[None],
             )
         else:
             return ArrayTask()

--- a/tiledb/cloud/rest_api/test/test_array_task_data.py
+++ b/tiledb/cloud/rest_api/test/test_array_task_data.py
@@ -136,6 +136,7 @@ class TestArrayTaskData(unittest.TestCase):
                         logs="0",
                         duration=3.41e11,
                         sql_init_commands=["0"],
+                        sql_parameters=[None],
                     )
                 ],
                 pagination_metadata=tiledb.cloud.rest_api.models.pagination_metadata.PaginationMetadata(

--- a/tiledb/cloud/rest_api/test/test_sql_parameters.py
+++ b/tiledb/cloud/rest_api/test/test_sql_parameters.py
@@ -42,6 +42,7 @@ class TestSQLParameters(unittest.TestCase):
                 output_uri="s3://my_bucket/my_output_array",
                 store_results=True,
                 init_commands=["0"],
+                parameters=[None],
             )
         else:
             return SQLParameters()

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -58,6 +58,7 @@ def exec_async(
     raw_results=False,
     http_compressor="deflate",
     init_commands=None,
+    parameters=None,
 ):
     """
     Run a sql query asynchronous
@@ -70,6 +71,7 @@ def exec_async(
     :param bool raw_results: optional flag to return raw json bytes of results instead of converting to pandas dataframe
     :param string http_compressor: optional http compression method to use
     :param list init_commands: optional list of sql queries or commands to run before main query
+    :param list parameters: optional list of sql parameters for use in query
 
     :return: A SQLResult object which is a future for a pandas dataframe if no output array is given and query returns results
     """
@@ -133,6 +135,7 @@ def exec_async(
                 query=query,
                 output_uri=output_uri,
                 init_commands=init_commands,
+                parameters=parameters,
             ),
             **kwargs
         )
@@ -151,6 +154,7 @@ def exec_and_fetch(
     task_name=None,
     output_array_name=None,
     init_commands=None,
+    parameters=None,
 ):
     """
     Run a sql query, results are not stored
@@ -161,6 +165,7 @@ def exec_and_fetch(
     :param str task_name: optional name to assign the task for logging and audit purposes
     :param str output_array_name: optional name for registering new output array if output_schema schema is passed
     :param list init_commands: optional list of sql queries or commands to run before main query
+    :param list parameters: optional list of sql parameters for use in query
 
     :return: TileDB Array with results
     """
@@ -183,6 +188,7 @@ def exec_and_fetch(
             task_name=task_name,
             output_array_name=output_array_name,
             init_commands=init_commands,
+            parameters=parameters,
         )
 
         # Fetch output schema to check if its sparse or dense
@@ -207,6 +213,7 @@ def exec(
     raw_results=False,
     http_compressor="deflate",
     init_commands=None,
+    parameters=None,
 ):
     """
     Run a sql query
@@ -219,6 +226,7 @@ def exec(
     :param bool raw_results: optional flag to return raw json bytes of results instead of converting to pandas dataframe
     :param string http_compressor: optional http compression method to use
     :param list init_commands: optional list of sql queries or commands to run before main query
+    :param list parameters: optional list of sql parameters for use in query
 
     :return: pandas dataframe if no output array is given and query returns results
     """
@@ -232,4 +240,5 @@ def exec(
         raw_results=raw_results,
         http_compressor=http_compressor,
         init_commands=init_commands,
+        parameters=parameters,
     ).get()


### PR DESCRIPTION
This adds support for the user to use `?` syntax in their sql queries and they can include the list of parameters to pass in in their request.

```
import tiledb.cloud
tiledb.cloud.sql.exec(
	query="select ? as param1, ? as param2",
	parameters=["1", 2.2])
```

Depends on #133 to avoid conflicts

cc: @normanb / @aaronwolen  for awareness of the new feature