### PR TITLE
Adjust basic listing test for arrays in account

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,7 +29,7 @@ class BasicTests(unittest.TestCase):
         self.assertIsNotNone(tasks())
 
     def test_list_arrays(self):
-        self.assertIsNone(client.list_arrays().arrays)
+        self.assertIsNotNone(client.list_arrays().arrays)
 
     def test_list_shared_arrays(self):
         self.assertIsNone(client.list_shared_arrays().arrays)


### PR DESCRIPTION
Adjust basic listing test for arrays in account, so the listing is now non-empty.