### PR TITLE
Add tiledb.cloud.version Module

### DIFF
--- a/tiledb/cloud/__init__.py
+++ b/tiledb/cloud/__init__.py
@@ -27,6 +27,8 @@ from .tiledb_cloud_error import TileDBCloudError
 from .tasks import task, tasks, last_sql_task, last_udf_task
 from .tasks import retry as retry_task
 
+from .version import version as __version__
+
 from . import sql
 
 from . import udf


### PR DESCRIPTION
* Similar to TileDB-Py's `tiledb.version`, `tiledb.cloud.version` is a
  module containing two attributes: the `version` string and `version_tuple`