### PR TITLE
Default Serverless SQL Queries to Arrow Return Type

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ plotly = ">= 4.0.0"
 networkx = ">= 2.0.0"
 pydot = "*"
 tiledb-plot-widget = ">= 0.1.7"
-arrow = "3.0.0"
+pyarrow = "3.0.0"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ plotly = ">= 4.0.0"
 networkx = ">= 2.0.0"
 pydot = "*"
 tiledb-plot-widget = ">= 0.1.7"
+arrow = "3.0.0"
 
 [dev-packages]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     "networkx>= 2.0.0",
     "pydot",
     "tiledb-plot-widget>=0.1.7",
+    "arrow==3.0.0",
 ]
 
 # NOTE: we cannot use an __init__.py file in the tiledb/ directory, because it is supplied

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "networkx>= 2.0.0",
     "pydot",
     "tiledb-plot-widget>=0.1.7",
-    "arrow==3.0.0",
+    "pyarrow==3.0.0",
 ]
 
 # NOTE: we cannot use an __init__.py file in the tiledb/ directory, because it is supplied

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -80,3 +80,53 @@ class BasicTests(unittest.TestCase):
 
         # Validate task name was set
         self.assertEqual(tiledb.cloud.last_sql_task().name, task_name)
+
+    def test_quickstart_sql_arrow(self):
+        with tiledb.open(
+            "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
+        ) as A:
+            print("quickstart_sparse:")
+            print(A[:])
+
+            with self.assertRaises(TypeError):
+                A.apply(None, [(0, 1)]).get()
+
+            import numpy
+
+            orig = A[:]
+            task_name = "test_quickstart_sql_arrow"
+            self.assertEqual(
+                int(
+                    tiledb.cloud.sql.exec_async(
+                        "select sum(a) as sum from `tiledb://TileDB-Inc/quickstart_sparse`",
+                        task_name=task_name,
+                        result_format=tiledb.cloud.ResultFormat.ARROW,
+                    ).get()["sum"]
+                ),
+                numpy.sum(orig["a"]),
+            )
+
+    def test_quickstart_sql_json(self):
+        with tiledb.open(
+            "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
+        ) as A:
+            print("quickstart_sparse:")
+            print(A[:])
+
+            with self.assertRaises(TypeError):
+                A.apply(None, [(0, 1)]).get()
+
+            import numpy
+
+            orig = A[:]
+            task_name = "test_quickstart_sql_arrow"
+            self.assertEqual(
+                int(
+                    tiledb.cloud.sql.exec_async(
+                        "select sum(a) as sum from `tiledb://TileDB-Inc/quickstart_sparse`",
+                        task_name=task_name,
+                        result_format=tiledb.cloud.ResultFormat.JSON,
+                    ).get()["sum"]
+                ),
+                numpy.sum(orig["a"]),
+            )


### PR DESCRIPTION
This PR switches the default return type of serverless SQL queries to apache arrow instead of JSON. The user is given the option to toggle the format they wish.

This PR also adjusts `UDFResult`/`SQLResults` classes to have a common base `TaskResult`. This allows for all the functionality around serialization and results to be handled in a common base class. As an effect now SQLResult gets support for apache arrow result type in the same way UDFs do.