### PR TITLE
Copy signature of async array and UDF functions onto sync versions.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+import importlib
+import os
+import os.path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from tiledb.cloud import utils
+
+
+class SourceLinesTest(unittest.TestCase):
+    def test_this_function(self):
+        me = utils.getsourcelines(self.test_this_function)
+        self.assertIsInstance(me, str)
+
+    def test_missing_function(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            testfile = os.path.join(tmpdir, "bogus_module.py")
+            with open(testfile, "w") as out:
+                out.write(
+                    textwrap.dedent(
+                        """\
+                        def unimportant_function(a):
+                            pass
+                        """
+                    )
+                )
+            sys.path.insert(0, tmpdir)
+            try:
+                bogus = importlib.import_module("bogus_module")
+            finally:
+                sys.path.pop(0)
+                sys.modules.pop("bogus_module", None)
+
+            os.remove(testfile)
+            self.assertIsNone(utils.getsourcelines(bogus.unimportant_function))

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -560,39 +560,15 @@ def apply_async(
         raise tiledb_cloud_error.check_udf_exc(exc) from None
 
 
-def apply(
-    uri,
-    func=None,
-    ranges=None,
-    name=None,
-    attrs=None,
-    layout=None,
-    image_name=None,
-    http_compressor="deflate",
-    task_name=None,
-    v2=True,
-    result_format=rest_api.models.UDFResultType.NATIVE,
-    result_format_version=None,
-    **kwargs
-):
+@utils.signature_of(apply_async)
+def apply(*args, **kwargs):
     """
-    Apply a user defined function to an array synchronous
+    Apply a user defined function to an array, synchronously.
 
-    :param uri: array to apply on
-    :param func: user function to run
-    :param ranges: ranges to issue query on
-    :param attrs: list of attributes or dimensions to fetch in query
-    :param layout: tiledb query layout
-    :param image_name: udf image name to use, useful for testing beta features
-    :param http_compressor: set http compressor for results
-    :param str task_name: optional name to assign the task for logging and audit purposes
-    :param bool v2: use v2 array udfs
-    :param UDFResultType result_format: result serialization format
-    :param str result_format_version: set a format version for cloudpickle or arrow IPC
-    :param kwargs: named arguments to pass to function
-    :return: UDFResult object which is a future containing the results of the UDF
+    All arguments are exactly as in :func:`apply_async`.
 
-    **Example**
+    **Example:**
+
     >>> import tiledb, tiledb.cloud, numpy
     >>> def median(df):
     ...   return numpy.median(df["a"])
@@ -600,21 +576,7 @@ def apply(
     >>> tiledb.cloud.array.apply("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"])
     2.0
     """
-    return apply_async(
-        uri=uri,
-        func=func,
-        ranges=ranges,
-        name=name,
-        attrs=attrs,
-        layout=layout,
-        image_name=image_name,
-        http_compressor=http_compressor,
-        task_name=task_name,
-        v2=v2,
-        result_format=result_format,
-        result_format_version=result_format_version,
-        **kwargs,
-    ).get()
+    return apply_async(*args, **kwargs).get()
 
 
 def exec_multi_array_udf_async(
@@ -658,6 +620,7 @@ def exec_multi_array_udf_async(
     >>> res = array.exec_multi_array_udf(median, array_list, namespace)
     >>> print("Median Multi UDF:\n{}\n".format(res))
     """
+    del layout  # unused
 
     api_instance = client.client.udf_api
 
@@ -744,31 +707,10 @@ def exec_multi_array_udf_async(
         raise tiledb_cloud_error.check_udf_exc(exc) from None
 
 
-def exec_multi_array_udf(
-    func=None,
-    array_list=None,
-    namespace=None,
-    name=None,
-    layout=None,
-    image_name=None,
-    http_compressor="deflate",
-    include_source_lines=True,
-    task_name=None,
-    result_format=rest_api.models.UDFResultType.NATIVE,
-    result_format_version=None,
-    **kwargs
-):
-    return exec_multi_array_udf_async(
-        func=func,
-        array_list=array_list,
-        namespace=namespace,
-        name=name,
-        layout=layout,
-        image_name=image_name,
-        http_compressor=http_compressor,
-        include_source_lines=include_source_lines,
-        task_name=task_name,
-        result_format=result_format,
-        result_format_version=result_format_version,
-        **kwargs,
-    ).get()
+@utils.signature_of(exec_multi_array_udf_async)
+def exec_multi_array_udf(*args, **kwargs):
+    """Apply a user-defined function to multiple arrays, synchronously.
+
+    All arguments are exactly as in :func:`exec_multi_array_udf_async`.
+    """
+    return exec_multi_array_udf_async(*args, **kwargs).get()

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -126,48 +126,14 @@ def exec_async(
         raise tiledb_cloud_error.check_sql_exc(exc) from None
 
 
-def exec(
-    *args,
-    func=None,
-    name=None,
-    namespace=None,
-    image_name=None,
-    http_compressor="deflate",
-    include_source_lines=True,
-    task_name=None,
-    result_format=rest_api.models.UDFResultType.NATIVE,
-    result_format_version=None,
-    **kwargs
-):
-    """
-     Run a user defined function
+@utils.signature_of(exec_async)
+def exec(*args, **kwargs):
+    """Run a user defined function, synchronously.
 
-
-    :param args: arguments to pass to function
-    :param func: user function to run
-    :param namespace: namespace to run udf under
-    :param image_name: udf image name to use, useful for testing beta features
-    :param http_compressor: set http compressor for results
-    :param include_source_lines: disables sending sources lines of function along with udf
-    :param str task_name: optional name to assign the task for logging and audit purposes
-    :param UDFResultType result_format: result serialization format
-    :param str result_format_version: set a format version for cloudpickle or arrow IPC
-    :param kwargs: named arguments to pass to function
-    :return: UDFResult object which is a future containing the results of the UDF
+    Arguments are exactly as in :func:`exec_async`. Returns an immediate value
+    rather than a future.
     """
-    return exec_async(
-        *args,
-        func=func,
-        name=name,
-        namespace=namespace,
-        image_name=image_name,
-        http_compressor=http_compressor,
-        include_source_lines=include_source_lines,
-        task_name=task_name,
-        result_format=result_format,
-        result_format_version=result_format_version,
-        **kwargs,
-    ).get()
+    return exec_async(*args, **kwargs).get()
 
 
 def register_udf(

--- a/tiledb/cloud/utils.py
+++ b/tiledb/cloud/utils.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Callable, Optional
+from typing import Callable, Optional, TypeVar
 
 logger = logging.getLogger("tiledb.cloud")
 
@@ -18,3 +18,30 @@ def getsourcelines(func: Callable) -> Optional[str]:
             exc,
         )
     return None
+
+
+_T = TypeVar("_T")
+
+
+def signature_of(src: Callable) -> Callable[[_T], _T]:
+    """Decorator that applies the signature of ``func`` to the wrapped function.
+
+    This allows autocomplete tools, like in Jupyter notebooks or IPython,
+    to use function signature information from the source function when
+    providing help for users about the destination function.
+
+    In this example, users will be able to see prompts for ``b`` or ``c``
+    when they press ``Tab`` while writing a call to  ``iter_a``:
+
+    >>> def a(b, c):
+    ...   return f'Hello, {b}! I am {c}.'
+    >>> @signature_of(a)
+    ... def iter_a(*args, **kwargs):
+    ...   yield a(*args, **kwargs)
+    """
+
+    def copy_to(dst):
+        dst.__signature__ = inspect.signature(src)
+        return dst
+
+    return copy_to


### PR DESCRIPTION
This change introduces `signature_of`, which copies the function
signature from a source to the decorated function, and applies it to
the synchronous functions in array.py and udf.py.

This avoids potential issues with parameter order or defaults falling
out of sync between the synchronous and the async versions, while still
allowing interactive users to access tab-completion. The docstrings
of the synchronous versions link directly to the async versions.

I have manually tested this both in IPython and Jupyter and tab
completion and other contextual help continues to work there.

Also adds tests for `tiledb.cloud.utils`.