### PR TITLE
Update `cloudarray.Array` to use `*args`/`**kwargs` and `signature_of`.

### DIFF
--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -1,33 +1,37 @@
 from . import array
+from . import utils
 
 
 class CloudArray(object):
+    @utils.signature_of(array.apply_async)
     def apply_async(
         self,
-        func=None,
-        ranges=None,
-        name=None,
-        attrs=None,
-        layout=None,
-        image_name=None,
-        http_compressor="deflate",
-        task_name=None,
-        v2=False,
-        **kwargs
+        *args,
+        **kwargs,
     ):
         """
-        Apply a user defined function to an array asynchronous
+        Apply a user-defined function to this array, asynchronously.
 
-        :param func: user function to run
-        :param ranges: ranges to issue query on
-        :param attrs: list of attributes or dimensions to fetch in query
-        :param layout: tiledb query layout
-        :param image_name: udf image name to use, useful for testing beta features
-        :param http_compressor: set http compressor for results
-        :param str task_name: optional name to assign the task for logging and audit purposes
-        :param bool v2: use v2 array udfs
-        :param kwargs: named arguments to pass to function
-        :return: UDFResult object which is a future containing the results of the UDF
+        Params are the same as :func:`array.apply_async`, but this instance
+        provides the URI.
+        """
+        return array.apply_async(
+            self.uri,  # pylint: disable=E1101
+            *args,
+            **kwargs,
+        )
+
+    @utils.signature_of(apply_async)
+    def apply(
+        self,
+        *args,
+        **kwargs,
+    ):
+        """
+        Apply a user-defined function to this array, asynchronously.
+
+        Params are the same as :func:`array.apply_async`, but this instance
+        provides the URI.
 
         **Example**
         >>> import tiledb, tiledb.cloud, numpy
@@ -37,57 +41,8 @@ class CloudArray(object):
         >>> with tiledb.SparseArray("tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.ctx()) as A:
         ...   A.apply(median, [(0,5), (0,5)], attrs=["a", "b", "c"])
         2.0
-
-        """
-        return array.apply_async(
-            uri=self.uri,  # pylint: disable=E1101
-            func=func,
-            ranges=ranges,
-            name=name,
-            attrs=attrs,
-            layout=layout,
-            image_name=image_name,
-            http_compressor=http_compressor,
-            task_name=task_name,
-            v2=v2,
-            **kwargs,
-        )
-
-    def apply(
-        self,
-        func=None,
-        ranges=None,
-        name=None,
-        attrs=None,
-        layout=None,
-        image_name=None,
-        http_compressor="deflate",
-        task_name=None,
-        v2=False,
-        **kwargs
-    ):
-        """
-        Apply a user defined function to an array
-        :param func: user function to run
-        :param ranges: ranges to issue query on
-        :param attrs: list of attributes or dimensions to fetch in query
-        :param layout: tiledb query layout
-        :param image_name: udf image name to use, useful for testing beta features
-        :param http_compressor: set http compressor for results
-        :param str task_name: optional name to assign the task for logging and audit purposes
-        :param bool v2: use v2 array udfs
-        :param kwargs: named arguments to pass to function
-        :return: results of the UDF
         """
         return self.apply_async(
-            func=func,
-            ranges=ranges,
-            name=name,
-            attrs=attrs,
-            layout=layout,
-            image_name=image_name,
-            http_compressor=http_compressor,
-            task_name=task_name,
-            v2=v2,
+            *args,
             **kwargs,
         ).get()


### PR DESCRIPTION
Currently, `cloudarray.Array` has a bunch of `None`s as the default
in the definition of its `apply_async` and `apply` functions. However,
these currently conflict with the way that `array.apply[_async]` work,
where all the parameters have type-appropriate immutable defaults
(e.g. `()` for an empty sequence). This means that `None` is passed in,
when the receiving function expects an actual value (which may be
the default).

This change makes both `cloudarray.Array` functions work similarly to
`array.apply`. The documentation now links to the canonical version
at `array.apply_async`, replacing the currently out-of-date docstring
(which, like the signature, is missing some params that are present in
`array.apply_async`).  The new docstring is less detailed (since it is
only a reference to the canonical one) but, like `array.apply`, cannot
fall out of date.

Users who open an array in a with-block won’t notice anything, because
IPython doesn’t have enough information to give useful hints:

```python
with tiledb.open('tiledb://path/to/array', ctx=tiledb.cloud.Ctx()) as arr:
  arr.apply(...)  # pressing TAB here gives nothing useful
```

It will affect users who save an array for later:

```python
arr = tiledb.open('tiledb://path/to/array', ctx=tiledb.cloud.Ctx())

arr.apply(...)
```

In the old version, running `arr.apply?` gives this output:

```
Signature:
arr.apply(
    func=None,
    ranges=None,
    name=None,
    attrs=None,
    layout=None,
    image_name=None,
    http_compressor='deflate',
    task_name=None,
    v2=False,
    **kwargs,
)
Docstring:
Apply a user defined function to an array
:param func: user function to run
:param ranges: ranges to issue query on
:param attrs: list of attributes or dimensions to fetch in query
:param layout: tiledb query layout
:param image_name: udf image name to use, useful for testing beta features
:param http_compressor: set http compressor for results
:param str task_name: optional name to assign the task for logging and audit purposes
:param bool v2: use v2 array udfs
:param kwargs: named arguments to pass to function
:return: results of the UDF
File:      /opt/conda/lib/python3.7/site-packages/tiledb/cloud/cloudarray.py
Type:      method
```

The new version gives a more complete signature, but does not include
the parameter descriptions:

```
Signature:
gene_arr.apply(
    func: Union[str, Callable, NoneType] = None,
    ranges: Sequence = (),
    name: Union[str, NoneType] = None,
    attrs: Sequence = (),
    layout: Union[str, NoneType] = None,
    image_name: str = 'default',
    http_compressor: str = 'deflate',
    include_source_lines: bool = True,
    task_name: Union[str, NoneType] = None,
    v2: bool = True,
    result_format: str = 'native',
    result_format_version=None,
    **kwargs: Any,
) -> tiledb.cloud.array.UDFResult
Docstring:
Apply a user-defined function to this array, asynchronously.

Params are the same as :func:`array.apply_async`, but this instance
provides the URI.

**Example**
>>> import tiledb, tiledb.cloud, numpy
>>> def median(df):
...   return numpy.median(df["a"])
>>> # Open the array then run the UDF
>>> with tiledb.SparseArray("tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.ctx()) as A:
...   A.apply(median, [(0,5), (0,5)], attrs=["a", "b", "c"])
2.0
File:      ~/core/venv/lib/python3.7/site-packages/tiledb/cloud/cloudarray.py
Type:      method
```