### PR TITLE
Support caching of multi-region redirects

### DIFF
--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -129,6 +129,8 @@ def setup_configuration(
         raise_on_status=False,
         # Don't remove any headers on redirect
         remove_headers_on_redirect=[],
+        redirect=0,
+        raise_on_redirect=False,
     )
     # Set logged in at this point
     global logged_in


### PR DESCRIPTION
Wraps request and overrides redirects:

  - Not exactly the most less-intrusive change
  - Disables request handling in `PoolManager` (using `config` but adding a `self.retries`)
  - Disables exceptions due to multiple redirects (using `config`)
  - Wraps request, checking for `302`
  - Uses `Location` field from headers dictionary to manually redirect
  - Current behavior should be equivalent to existing functionality
  - A dictionary of `array->location` is pending to be added in `RESTClientObject` if changes here are acceptable