### PR TITLE
Fully support Apache Arrow as a Serverless SQL response format

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ plotly = ">= 4.0.0"
 networkx = ">= 2.0.0"
 pydot = "*"
 tiledb-plot-widget = ">= 0.1.7"
+pyarrow = "3.0.0"
 
 [dev-packages]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     "networkx>= 2.0.0",
     "pydot",
     "tiledb-plot-widget>=0.1.7",
+    "pyarrow==3.0.0",
 ]
 
 # NOTE: we cannot use an __init__.py file in the tiledb/ directory, because it is supplied

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -80,3 +80,53 @@ class BasicTests(unittest.TestCase):
 
         # Validate task name was set
         self.assertEqual(tiledb.cloud.last_sql_task().name, task_name)
+
+    def test_quickstart_sql_arrow(self):
+        with tiledb.open(
+            "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
+        ) as A:
+            print("quickstart_sparse:")
+            print(A[:])
+
+            with self.assertRaises(TypeError):
+                A.apply(None, [(0, 1)]).get()
+
+            import numpy
+
+            orig = A[:]
+            task_name = "test_quickstart_sql_arrow"
+            self.assertEqual(
+                int(
+                    tiledb.cloud.sql.exec_async(
+                        "select sum(a) as sum from `tiledb://TileDB-Inc/quickstart_sparse`",
+                        task_name=task_name,
+                        result_format=tiledb.cloud.ResultFormat.ARROW,
+                    ).get()["sum"]
+                ),
+                numpy.sum(orig["a"]),
+            )
+
+    def test_quickstart_sql_json(self):
+        with tiledb.open(
+            "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
+        ) as A:
+            print("quickstart_sparse:")
+            print(A[:])
+
+            with self.assertRaises(TypeError):
+                A.apply(None, [(0, 1)]).get()
+
+            import numpy
+
+            orig = A[:]
+            task_name = "test_quickstart_sql_arrow"
+            self.assertEqual(
+                int(
+                    tiledb.cloud.sql.exec_async(
+                        "select sum(a) as sum from `tiledb://TileDB-Inc/quickstart_sparse`",
+                        task_name=task_name,
+                        result_format=tiledb.cloud.ResultFormat.JSON,
+                    ).get()["sum"]
+                ),
+                numpy.sum(orig["a"]),
+            )

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -20,7 +20,7 @@ from .rest_api import rest
 last_udf_task_id = None
 
 
-class UDFResult(multiprocessing.pool.ApplyResult):
+class TaskResult(multiprocessing.pool.ApplyResult):
     def __init__(self, response, result_format, result_format_version=None):
         self.response = response
         self.task_id = None
@@ -30,8 +30,6 @@ class UDFResult(multiprocessing.pool.ApplyResult):
     def get(self, timeout=None):
         try:
             response = rest.RESTResponse(self.response.get(timeout=timeout))
-            global last_udf_task_id
-            self.task_id = last_udf_task_id = response.getheader(client.TASK_ID_HEADER)
             res = response.data
         except GenApiException as exc:
             if exc.headers:
@@ -39,6 +37,8 @@ class UDFResult(multiprocessing.pool.ApplyResult):
             raise tiledb_cloud_error.check_udf_exc(exc) from None
         except multiprocessing.TimeoutError as exc:
             raise tiledb_cloud_error.check_udf_exc(exc) from None
+
+        self.task_id = response.getheader(client.TASK_ID_HEADER)
 
         if res[:2].hex() in ["7801", "785e", "789c", "78da"]:
             try:
@@ -65,6 +65,20 @@ class UDFResult(multiprocessing.pool.ApplyResult):
                 res = reader.read_all()
         except:
             raise tiledb_cloud_error.TileDBCloudError("Failed to load result object")
+
+        return res
+
+
+class UDFResult(TaskResult):
+    def __init__(self, response, result_format, result_format_version=None):
+        super().__init__(response, result_format, result_format_version)
+
+    def get(self, timeout=None):
+        res = super().get(timeout=timeout)
+
+        # Set last udf task id
+        global last_udf_task_id
+        last_udf_task_id = self.task_id
 
         return res
 

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -1,16 +1,16 @@
-from . import rest_api
-from . import config
-from . import client
-from . import array
-from . import tiledb_cloud_error
-from .rest_api import ApiException as GenApiException
-from .rest_api import rest
-
-import tiledb
+import inspect
 import time
+
 import pandas
-import json
-import multiprocessing
+import tiledb
+
+from . import array
+from . import client
+from . import config
+from . import rest_api
+from . import tiledb_cloud_error
+from . import utils
+from .rest_api import models
 
 last_sql_task_id = None
 
@@ -31,9 +31,9 @@ class SQLResult(array.TaskResult):
         last_sql_task_id = self.task_id
 
         if self.result_type == "pandas":
-            if self.result_format == rest_api.models.ResultFormat.JSON:
+            if self.result_format == models.ResultFormat.JSON:
                 return pandas.DataFrame(res)
-            elif self.result_format == rest_api.models.ResultFormat.ARROW:
+            elif self.result_format == models.ResultFormat.ARROW:
                 return res.to_pandas()
 
         # Fall back to just returning base results
@@ -51,7 +51,7 @@ def exec_async(
     http_compressor="deflate",
     init_commands=None,
     parameters=None,
-    result_format=rest_api.models.ResultFormat.ARROW,
+    result_format=models.ResultFormat.ARROW,
     result_format_version=None,
 ):
     """
@@ -145,60 +145,30 @@ def exec_async(
             None if raw_results else "pandas",
         )
 
-    except GenApiException as exc:
+    except rest_api.ApiException as exc:
+        if exc.headers:
+            task_id = exc.headers.get(client.TASK_ID_HEADER)
+            if task_id:
+                global last_sql_task_id
+                last_sql_task_id = task_id
         raise tiledb_cloud_error.check_sql_exc(exc) from None
 
 
-def exec_and_fetch(
-    query,
-    output_uri,
-    output_schema=None,
-    namespace=None,
-    task_name=None,
-    output_array_name=None,
-    init_commands=None,
-    parameters=None,
-    result_format=rest_api.models.ResultFormat.ARROW,
-    result_format_version=None,
-):
+@utils.signature_of(exec_async)
+def exec_and_fetch(*args, **kwargs):
     """
     Run a sql query, results are not stored
-    :param str query: query to run
-    :param str output_uri: array to store results to, must be either a tiledb:// for an already registered array or a s3:// if passing a new schema to create new output array
-    :param tiledb.ArraySchema output_schema: array schema to create output array with
-    :param str namespace: optional namespace to charge the query to
-    :param str task_name: optional name to assign the task for logging and audit purposes
-    :param str output_array_name: optional name for registering new output array if output_schema schema is passed
-    :param list init_commands: optional list of sql queries or commands to run before main query
-    :param list parameters: optional list of sql parameters for use in query
-    :param UDFResultType result_format: result serialization format
-    :param str result_format_version: set a format version for cloudpickle or arrow IPC
+
+    All arguments are exactly as in :func:`exec_async`.
 
     :return: TileDB Array with results
     """
-
-    # If the namespace is not set, we will default to the user's namespace
-    if namespace is None:
-        # Fetch the client profile for username if it is not already cached
-        if config.user is None:
-            config.user = client.user_profile()
-
-        namespace = config.user.username
+    my_sig: inspect.Signature = exec_and_fetch.__signature__
+    output_uri = my_sig.bind(*args, **kwargs).arguments["output_uri"]
 
     # Execute the sql query
     try:
-        exec(
-            query=query,
-            output_uri=output_uri,
-            output_schema=output_schema,
-            namespace=namespace,
-            task_name=task_name,
-            output_array_name=output_array_name,
-            init_commands=init_commands,
-            parameters=parameters,
-            result_format=result_format,
-            result_format_version=result_format_version,
-        )
+        exec(*args, **kwargs)
 
         # Fetch output schema to check if its sparse or dense
         schema = tiledb.ArraySchema.load(output_uri, ctx=client.Ctx())
@@ -208,52 +178,15 @@ def exec_and_fetch(
 
         return tiledb.DenseArray(output_uri, ctx=client.Ctx())
 
-    except GenApiException as exc:
+    except rest_api.ApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-def exec(
-    query,
-    output_uri=None,
-    output_schema=None,
-    namespace=None,
-    task_name=None,
-    output_array_name=None,
-    raw_results=False,
-    http_compressor="deflate",
-    init_commands=None,
-    parameters=None,
-    result_format=rest_api.models.ResultFormat.ARROW,
-    result_format_version=None,
-):
+@utils.signature_of(exec_async)
+def exec(*args, **kwargs):
     """
-    Run a sql query
-    :param str query: query to run
-    :param str output_uri: optional array to store results to, must be a tiledb:// registered array
-    :param tiledb.ArraySchema output_schema: optional schema for creating output array if it does not exist
-    :param str namespace: optional namespace to charge the query to
-    :param str task_name: optional name to assign the task for logging and audit purposes
-    :param str output_array_name: optional array name to set if creating new output array
-    :param bool raw_results: optional flag to return raw json bytes of results instead of converting to pandas dataframe
-    :param string http_compressor: optional http compression method to use
-    :param list init_commands: optional list of sql queries or commands to run before main query
-    :param list parameters: optional list of sql parameters for use in query
-    :param UDFResultType result_format: result serialization format
-    :param str result_format_version: set a format version for cloudpickle or arrow IPC
+    Run a SQL query, synchronously.
 
-    :return: pandas dataframe if no output array is given and query returns results
+    All arguments are exactly as in :func:`exec_async`.
     """
-    return exec_async(
-        query=query,
-        output_uri=output_uri,
-        output_schema=output_schema,
-        namespace=namespace,
-        task_name=task_name,
-        output_array_name=output_array_name,
-        raw_results=raw_results,
-        http_compressor=http_compressor,
-        init_commands=init_commands,
-        parameters=parameters,
-        result_format=result_format,
-        result_format_version=result_format_version,
-    ).get()
+    return exec_async(*args, **kwargs).get()

--- a/tiledb/cloud/tiledb_cloud_error.py
+++ b/tiledb/cloud/tiledb_cloud_error.py
@@ -1,7 +1,4 @@
 import json
-from . import sql
-from . import client
-from . import array
 from tiledb import TileDBError
 
 
@@ -24,50 +21,6 @@ def check_exc(exc):
         body = json.loads(exc.body)
         new_exc = TileDBCloudError(
             "{} - Code: {}".format(body["message"], body["code"])
-        )
-    except:
-        raise Exception(internal_err_msg) from exc
-
-    return new_exc
-
-
-def check_sql_exc(exc):
-    internal_err_msg = (
-        "[InternalError: failed to parse or message missing from ApiException]"
-    )
-
-    if not isinstance(exc, BaseException):
-        raise Exception(internal_err_msg)
-
-    try:
-        if client.TASK_ID_HEADER in exc.headers:
-            sql.last_sql_task_id = exc.headers[client.TASK_ID_HEADER]
-        body = json.loads(exc.body)
-        new_exc = TileDBCloudError(
-            "{} - Code: {}".format(body["message"], body["code"])
-        )
-    except:
-        raise Exception(internal_err_msg) from exc
-
-    return new_exc
-
-
-def check_udf_exc(exc):
-    internal_err_msg = (
-        "[InternalError: failed to parse or message missing from ApiException]"
-    )
-
-    if not isinstance(exc, BaseException):
-        raise Exception(internal_err_msg)
-
-    try:
-        if client.TASK_ID_HEADER in exc.headers:
-            array.last_udf_task_id = exc.headers[client.TASK_ID_HEADER]
-        body = json.loads(exc.body)
-        new_exc = TileDBCloudError(
-            "{} - Code: {} - Request ID: {}".format(
-                body["message"], body["code"], body["request_id"]
-            )
         )
     except:
         raise Exception(internal_err_msg) from exc

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -123,7 +123,8 @@ def exec_async(
         return array.UDFResult(response, result_format=result_format)
 
     except GenApiException as exc:
-        raise tiledb_cloud_error.check_sql_exc(exc) from None
+        array._maybe_set_last_udf_id(exc)
+        raise tiledb_cloud_error.check_exc(exc) from None
 
 
 @utils.signature_of(exec_async)


### PR DESCRIPTION
This is a continuation of #143, but it felt weird to push a bunch of changes onto somebody else’s code review so here we are. Much of what was blocking that change was actually server-side issues but fixes for those are forthcoming.

Each of the original two changes has been slightly patched so that the project should be fully working at each commit. My changes to each are as follows:

- 3c180ee56d8dde92320e54c037d786f615f43876 (was df68652c6e5931cd38432aceaa512aa1a10758e6): Use the right arrow package (also reordered to be first in the sequence)
- fce6add3edc296c18d5a4cfd2d031964f7893e12 (was 04c693c6f63bf9b10d02febdb857b60d60a92382): Update TaskResult to correctly set `task_id`.

I also applied a final cleanup. Once the server-side changes for those are deployed, automated testing should pass and this should be good to go.