### PR TITLE
Add ResultFormat alias back to __init__.py and sort imports.

### DIFF
--- a/tiledb/cloud/__init__.py
+++ b/tiledb/cloud/__init__.py
@@ -1,42 +1,63 @@
 # This file imports specifically to re-export.
-# flake8: noqa: F401
-
-from .client import (
-    Config,
-    Ctx,
-    list_arrays,
-    list_public_arrays,
-    list_shared_arrays,
-    login,
-    organizations,
-    organization,
-    user_profile,
-)
-
-from .array import (
-    info,
-    register_array,
-    deregister_array,
-    list_shared_with,
-    share_array,
-    unshare_array,
-    array_activity,
-)
-
-from .notebook import rename_notebook
-
-from .tiledb_cloud_error import TileDBCloudError
-
-from .tasks import task, tasks, last_sql_task, last_udf_task
-
-from .version import version as __version__
-
-from . import sql
-
-from . import udf
-
-from . import dag
 
 from . import compute
+from . import dag
+from . import sql
+from . import udf
+from .array import array_activity
+from .array import deregister_array
+from .array import info
+from .array import list_shared_with
+from .array import register_array
+from .array import share_array
+from .array import unshare_array
+from .client import Config
+from .client import Ctx
+from .client import list_arrays
+from .client import list_public_arrays
+from .client import list_shared_arrays
+from .client import login
+from .client import organization
+from .client import organizations
+from .client import user_profile
+from .notebook import rename_notebook
+from .rest_api import models
+from .tasks import last_sql_task
+from .tasks import last_udf_task
+from .tasks import task
+from .tasks import tasks
+from .tiledb_cloud_error import TileDBCloudError
+from .version import version as __version__
 
-from .rest_api.models import ResultFormat
+ResultFormat = models.ResultFormat
+UDFResultType = ResultFormat
+
+__all__ = (
+    "compute",
+    "dag",
+    "sql",
+    "udf",
+    "array_activity",
+    "deregister_array",
+    "info",
+    "list_shared_with",
+    "register_array",
+    "share_array",
+    "unshare_array",
+    "Config",
+    "Ctx",
+    "list_arrays",
+    "list_public_arrays",
+    "list_shared_arrays",
+    "login",
+    "organization",
+    "organizations",
+    "user_profile",
+    "rename_notebook",
+    "last_sql_task",
+    "last_udf_task",
+    "task",
+    "tasks",
+    "TileDBCloudError",
+    "__version__",
+)

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -16,7 +16,7 @@ from ..array import apply as array_apply
 from ..sql import exec as sql_exec
 from ..udf import exec as udf_exec
 
-from tiledb.cloud import TileDBCloudError
+from ..tiledb_cloud_error import TileDBCloudError
 
 
 class Status(Enum):


### PR DESCRIPTION
- Adds ResultFormat alias to (hopefully) restore backwards compat
  with some existing code.
- Creates __all__ to avoid to lint-disable.
- Organizes imports.