### PR TITLE
Remove spurious `ApplyResult` inheritance from `TaskResult`.

### DIFF
--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -21,7 +21,7 @@ from .rest_api import rest
 last_udf_task_id = None
 
 
-class TaskResult(multiprocessing.pool.ApplyResult):
+class TaskResult:
     def __init__(self, response, result_format, result_format_version=None):
         self.response = response
         self.task_id = None


### PR DESCRIPTION
`TaskResult` is not substitutable for a general
`multiprocessing.pool.ApplyResult` (and does not use any of the base
class functionality) so it should not be a subclass.