### PR TITLE
Move decoding of results into classes in `results.py`.

### DIFF
--- a/tiledb/cloud/dag/stored_params.py
+++ b/tiledb/cloud/dag/stored_params.py
@@ -1,0 +1,58 @@
+"""Handles stored parameters for clients and the UDF environment."""
+
+import base64
+import dataclasses
+import uuid
+from typing import Any, Dict
+
+from tiledb.cloud import results
+
+
+@dataclasses.dataclass(frozen=True)
+class StoredParam:
+    """The information needed to identify and decode a stored parameter.
+
+    This type is used as a sentinel for stored params in Python UDF parameters.
+    When the UDF execution environment unpacks its parameters, if it runs into
+    a StoredParam value, it will unpack it from the server-side stored parameter
+    dictionary, replacing the StoredParam instance with the actual value that
+    should be replaced.
+    """
+
+    # The server-generated UUID included in the X-TileDB-Cloud-Task-ID header.
+    task_id: uuid.UUID
+
+    # The Decoder that will be used to turn the bytes into a useful value.
+    decoder: results.AbstractDecoder
+
+    def decode(self, binary_data: bytes) -> Any:
+        return self.decoder.decode(binary_data)
+
+
+class ParamLoader:
+    """A class to load server-side params while reusing loaded instances."""
+
+    def __init__(self, raw_params: Dict[str, str]):
+        """Sets up a new ParamLoader.
+
+        :param raw_params: A dictionary of UUID-as-hex-string (no ``{}``s)
+          to base64-encoded binary data.
+        """
+        self._raw_params = raw_params
+        self._loaded: Dict[StoredParam, Any] = {}
+
+    def load(self, param: StoredParam) -> Any:
+        """Loads the given parameter from the input, reusing instances.
+
+        This is not guaranteed to be thread-safe since we expect to restore
+        server-side parameters on one thread.
+        """
+        try:
+            return self._loaded[param]
+        except KeyError:
+            pass  # not cached yet.
+        b64_data = self._raw_params[str(param.task_id)].encode("ascii")
+        binary_data = base64.standard_b64decode(b64_data)
+        real_data = param.decode(binary_data)
+        self._loaded[param] = real_data
+        return real_data

--- a/tiledb/cloud/results.py
+++ b/tiledb/cloud/results.py
@@ -1,0 +1,54 @@
+"""Handles the tracking and decoding of task results."""
+
+import abc
+import dataclasses
+import json
+from typing import Any
+
+import cloudpickle
+import pandas
+import pyarrow
+from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud.rest_api import models
+
+
+class AbstractDecoder(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def decode(data: bytes) -> Any:
+        raise NotImplementedError()
+
+
+def _load_arrow(data: bytes):
+    reader = pyarrow.RecordBatchStreamReader(data)
+    return reader.read_all()
+
+
+@dataclasses.dataclass(frozen=True)
+class Decoder(AbstractDecoder):
+
+    format: str
+
+    _DECODE_FNS = {
+        models.ResultFormat.NATIVE: cloudpickle.loads,
+        models.ResultFormat.JSON: json.loads,
+        models.ResultFormat.ARROW: _load_arrow,
+    }
+
+    def decode(self, data: bytes) -> Any:
+        try:
+            decoder = self._DECODE_FNS[self.format]
+        except KeyError:
+            raise tce.TileDBCloudError(f"{self.format!r} is not a valid result format.")
+        return decoder(data)
+
+
+@dataclasses.dataclass(frozen=True)
+class PandasDecoder(AbstractDecoder):
+
+    format: str
+
+    def decode(self, data: bytes) -> pandas.DataFrame:
+        if self.format == models.ResultFormat.ARROW:
+            reader = pyarrow.RecordBatchStreamReader(data)
+            return reader.read_pandas()
+        return pandas.DataFrame(Decoder(self.format).decode(data))


### PR DESCRIPTION
This moves most decoding logic into Decoder classes, which are designed
to be easily pickleable for future use in stored parameters. It also
introduces an early version of stored-parameter decoding in
`dag/stored_params.py`, which will eventually be used (along with a
reworking of async operations and DAG `Node`s) to avoid sending
parameters back to the server.

There are also some changes to make errors more explicit:

- Rather than silently ignoring unknown result types, they are raised
  as errors.
- Results returned as Pandas are now guaranteed to be returned as a
  DataFrame, rather than “a DataFrame, or potentially some other type”.

---

It is possible that this API will change slightly, but for now it's internal-only, and I wanted to get something working reasonably well to build on for stored param substitution in the UDF execution environment.