### PR TITLE
Add support for stored parameter replacement

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,14 +1,20 @@
+import base64
 import collections
 import collections.abc as cabc
 import os
 import pickle
 import time
 import unittest
+import uuid
+import cloudpickle
 
 import numpy as np
+import pandas as pd
 import tiledb.cloud
 from tiledb.cloud import dag
 from tiledb.cloud.dag import dag as internal
+from tiledb.cloud.dag import stored_params as sp
+from tiledb.cloud import results
 
 tiledb.cloud.login(
     token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
@@ -431,9 +437,12 @@ def _node(val):
     return n
 
 
+def _uid(num: int) -> uuid.UUID:
+    return uuid.UUID(int=num)
+
+
 class CustomSeq(cabc.MutableSequence):
     """Custom sequence implementation to test value replacement."""
-    lst: list
 
     def __init__(self, items=()):
         self.lst = list(items)
@@ -457,8 +466,7 @@ class CustomSeq(cabc.MutableSequence):
         return type(self) == type(other) and self.lst == other.lst
 
 
-class TestDAGInternals(unittest.TestCase):
-
+class ReplaceNodesTest(unittest.TestCase):
     def test_basic(self):
         self.assertEqual(5, internal._replace_nodes_with_results(5))
         self.assertEqual("hi", internal._replace_nodes_with_results(_node("hi")))
@@ -470,11 +478,13 @@ class TestDAGInternals(unittest.TestCase):
         )
         self.assertEqual(
             (1, 2, ["i", "ii"]),
-            internal._replace_nodes_with_results((1, 2, [_node("i"), "ii"]))
+            internal._replace_nodes_with_results((1, 2, [_node("i"), "ii"])),
         )
 
     def test_special_sequences(self):
-        self.assertEqual("some_string", internal._replace_nodes_with_results("some_string"))
+        self.assertEqual(
+            "some_string", internal._replace_nodes_with_results("some_string")
+        )
         self.assertEqual(b"bytes", internal._replace_nodes_with_results(b"bytes"))
 
     def test_self_recursion(self):
@@ -483,7 +493,7 @@ class TestDAGInternals(unittest.TestCase):
         }
         lst = [dct, _node("nod")]
         dct["lst"] = lst
-        tup = (_node("lst"), lst, _node("dct"), dct)
+        tup = (_node("a lst:"), lst, _node("a dct:"), dct)
         lst.append(tup)
         got_lst = internal._replace_nodes_with_results(lst)
 
@@ -492,7 +502,7 @@ class TestDAGInternals(unittest.TestCase):
         }
         want_lst = [want_dct, "nod"]
         want_dct["lst"] = want_lst
-        want_tup = ("lst", want_lst, "dct", want_dct)
+        want_tup = ("a lst:", want_lst, "a dct:", want_dct)
         want_lst.append(want_tup)
 
         # assertEqual will blow up if you try to compare a recursive structure.
@@ -512,8 +522,98 @@ class TestDAGInternals(unittest.TestCase):
 
         self.assertEqual(
             collections.OrderedDict(zero=0, one=1, two=2),
-            internal._replace_nodes_with_results(collections.OrderedDict(
-                zero=_node(0),
-                one=_node(1),
-                two=2,
-            )))
+            internal._replace_nodes_with_results(
+                collections.OrderedDict(
+                    zero=_node(0),
+                    one=_node(1),
+                    two=2,
+                )
+            ),
+        )
+
+    def test_dont_enter_special_types(self):
+        df = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 3}])
+        self.assertIs(df, internal._replace_nodes_with_results(df))
+        arr = np.array([["a", 1], ["b", 2]])
+        self.assertIs(arr, internal._replace_nodes_with_results(arr))
+
+    def test_ref_equality(self):
+        lst = ["a", _node("B"), "c"]
+        got_val = internal._replace_nodes_with_results([lst, lst])
+        self.assertIs(got_val[0], got_val[1])
+        self.assertIsNot(lst, got_val[0])
+
+    def test_replace_stored_params(self):
+        # Since the corner cases of tree traversal are tested in the other
+        # ReplaceNodesTests, this just tests the basics of stored params.
+        got = internal.replace_stored_params(
+            [
+                sp.StoredParam(_uid(0x1), decoder=results.Decoder("json")),
+                {
+                    "sub-dict": sp.StoredParam(
+                        _uid(0x2), decoder=results.Decoder("native")
+                    )
+                },
+                (sp.StoredParam(_uid(0x1), decoder=results.Decoder("json")),),
+            ],
+            sp.ParamLoader(
+                {
+                    "00000000-0000-0000-0000-000000000001": "W3RydWUsICJ0d28iLCAzXQ==",
+                    "00000000-0000-0000-0000-000000000002": _b64(cloudpickle.dumps(())),
+                }
+            ),
+        )
+
+        want = [
+            [True, "two", 3],
+            {"sub-dict": ()},
+            ([True, "two", 3],),
+        ]
+        self.assertEqual(want, got)
+        self.assertIs(got[0], got[2][0], "restored values must be same object")
+
+    def test_replace_stored_params_pandas(self):
+        arrow_pd, json_pd, json_raw = internal.replace_stored_params(
+            [
+                sp.StoredParam(_uid(0x3), decoder=results.PandasDecoder("arrow")),
+                # Ensure that we can restore the same source object
+                # using multiple encodings.
+                sp.StoredParam(_uid(0x4), decoder=results.PandasDecoder("json")),
+                sp.StoredParam(_uid(0x4), decoder=results.Decoder("json")),
+            ],
+            sp.ParamLoader(
+                {
+                    "00000000-0000-0000-0000-000000000003": _ARROW_DATA,
+                    "00000000-0000-0000-0000-000000000004": _b64(
+                        b'[{"a": 1, "b": "x"}, {"a": 2, "b": "Y"}]'
+                    ),
+                }
+            ),
+        )
+
+        want_arrow_pd = pd.DataFrame([[1, 1.1]], columns=("a", "param1"))
+        self.assertTrue(want_arrow_pd.equals(arrow_pd))
+        want_json_pd = pd.DataFrame([[1, "x"], [2, "Y"]], columns=("a", "b"))
+        self.assertTrue(want_json_pd.equals(json_pd))
+        self.assertEqual(
+            [{"a": 1, "b": "x"}, {"a": 2, "b": "Y"}],
+            json_raw,
+        )
+
+
+def _b64(x: bytes) -> str:
+    return str(base64.b64encode(x), encoding="ascii")
+
+
+# set @a = 1;
+# select @a a, ? param1;  -- params: [1.1]
+_ARROW_DATA = """
+/////8AAAAAQAAAAAAAKAAwACgAJAAQACgAAABAAAAAAAQQACAAIAAAABAAIAAAABAAAAAIAAABcAAAA
+FAAAABAAFAAQAAAADwAIAAAABAAQAAAAEAAAABgAAAAAAAADGAAAAAAAAAAAAAYACAAGAAYAAAAAAAIA
+BgAAAHBhcmFtMQAAEAAUABAADwAOAAgAAAAEABAAAAAQAAAAGAAAAAAAAgEcAAAAAAAAAAgADAAIAAcA
+CAAAAAAAAAFAAAAAAQAAAGEAAAD/////yAAAABQAAAAAAAAADAAYABYAFQAQAAQADAAAAEAAAAAAAAAA
+AAAAABQAAAAAAwQADAAcABAADAAIAAQADAAAABwAAAAcAAAAYAAAAAEAAAAAAAAAAAAAAAQABAAEAAAA
+BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB8AAAAAAAAAIAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA
+HwAAAAAAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEIk0Y
+YECCCAAAgAEAAAAAAAAAAAAAAAAIAAAAAAAAAAQiTRhgQIIIAACAmpmZmZmZ8T8AAAAAAP////8AAAAA
+"""

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,10 +1,14 @@
+import collections
+import collections.abc as cabc
+import os
+import pickle
 import time
 import unittest
-import os
 
 import numpy as np
-from tiledb.cloud import dag
 import tiledb.cloud
+from tiledb.cloud import dag
+from tiledb.cloud.dag import dag as internal
 
 tiledb.cloud.login(
     token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
@@ -417,3 +421,99 @@ class DAGCallbackTest(unittest.TestCase):
         global done_updates
         self.assertEqual(status_updates, 5)
         self.assertEqual(done_updates, 1)
+
+
+def _node(val):
+    """Creates a completed node with the given value."""
+    n = dag.Node(lambda: None)
+    n.status = dag.Status.COMPLETED
+    n._results = val
+    return n
+
+
+class CustomSeq(cabc.MutableSequence):
+    """Custom sequence implementation to test value replacement."""
+    lst: list
+
+    def __init__(self, items=()):
+        self.lst = list(items)
+
+    def __len__(self):
+        return len(self.lst)
+
+    def __getitem__(self, idx):
+        return self.lst[idx]
+
+    def __setitem__(self, idx, val):
+        self.lst[idx] = val
+
+    def __delitem__(self, idx):
+        del self.lst[idx]
+
+    def insert(self, idx, val):
+        self.lst.insert(idx, val)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.lst == other.lst
+
+
+class TestDAGInternals(unittest.TestCase):
+
+    def test_basic(self):
+        self.assertEqual(5, internal._replace_nodes_with_results(5))
+        self.assertEqual("hi", internal._replace_nodes_with_results(_node("hi")))
+
+    def test_sequences(self):
+        self.assertEqual(
+            ["a", "b", "c"],
+            internal._replace_nodes_with_results([_node("a"), "b", _node("c")]),
+        )
+        self.assertEqual(
+            (1, 2, ["i", "ii"]),
+            internal._replace_nodes_with_results((1, 2, [_node("i"), "ii"]))
+        )
+
+    def test_special_sequences(self):
+        self.assertEqual("some_string", internal._replace_nodes_with_results("some_string"))
+        self.assertEqual(b"bytes", internal._replace_nodes_with_results(b"bytes"))
+
+    def test_self_recursion(self):
+        dct = {
+            "nod": _node(("a", "b", "c")),
+        }
+        lst = [dct, _node("nod")]
+        dct["lst"] = lst
+        tup = (_node("lst"), lst, _node("dct"), dct)
+        lst.append(tup)
+        got_lst = internal._replace_nodes_with_results(lst)
+
+        want_dct = {
+            "nod": ("a", "b", "c"),
+        }
+        want_lst = [want_dct, "nod"]
+        want_dct["lst"] = want_lst
+        want_tup = ("lst", want_lst, "dct", want_dct)
+        want_lst.append(want_tup)
+
+        # assertEqual will blow up if you try to compare a recursive structure.
+        # However, pickle handles recursion, so we just see if the results
+        # have the same pickling.
+        self.assertEqual(pickle.dumps(want_lst), pickle.dumps(got_lst))
+
+    def test_custom_types(self):
+        my_seq = CustomSeq("abcde")
+        my_seq.append(CustomSeq(("F", _node("G"))))
+        my_seq.append(_node("h"))
+
+        self.assertEqual(
+            CustomSeq(("a", "b", "c", "d", "e", CustomSeq("FG"), "h")),
+            internal._replace_nodes_with_results(my_seq),
+        )
+
+        self.assertEqual(
+            collections.OrderedDict(zero=0, one=1, two=2),
+            internal._replace_nodes_with_results(collections.OrderedDict(
+                zero=_node(0),
+                one=_node(1),
+                two=2,
+            )))

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -1,8 +1,10 @@
+import collections.abc as cabc
 import json
 import numbers
 import time
 import uuid
 from concurrent import futures
+from typing import Any, Dict
 
 import networkx as nx
 from tiledb.cloud.dag import status as st
@@ -112,38 +114,6 @@ class Node:
 
     done = finished
 
-    def _replace_nodes_with_results(self, arg):
-        """
-        Recursively find arguments of Node instance and replace with the node results
-        :param arg:
-        :return: converted argument
-        """
-        tuple_conversion = False
-        if isinstance(arg, tuple):
-            arg = list(arg)
-            tuple_conversion = True
-
-        if isinstance(arg, tuple) or isinstance(arg, list):
-            for index in range(len(arg)):
-                a = arg[index]
-                if isinstance(a, Node):
-                    arg[index] = a.result()
-                elif isinstance(a, tuple) or isinstance(a, list) or isinstance(a, dict):
-                    arg[index] = self._replace_nodes_with_results(a)
-        elif isinstance(arg, dict):
-            for k, a in arg.items():
-                if isinstance(a, Node):
-                    arg[k] = a.result()
-                elif isinstance(a, tuple) or isinstance(a, list) or isinstance(a, dict):
-                    arg[k] = self._replace_nodes_with_results(a)
-        elif isinstance(arg, Node):
-            arg = arg.result()
-
-        if tuple_conversion:
-            arg = tuple(arg)
-
-        return arg
-
     def exec(self, namespace=None):
         """
         Execute function for node
@@ -159,13 +129,13 @@ class Node:
         # If there is a node as an argument, the user really just wants the results, so let's fetch them
         # and swap out the parameter
         if self.args is not None:
-            self.args = self._replace_nodes_with_results(self.args)
+            self.args = _replace_nodes_with_results(self.args)
 
         # First loop though any default named parameter arguments to find any nodes
         # If there is a node as an argument, the user really just wants the results, so let's fetch them
         # and swap out the parameter
         if self.kwargs is not None:
-            self.kwargs = self._replace_nodes_with_results(self.kwargs)
+            self.kwargs = _replace_nodes_with_results(self.kwargs)
 
         # Execute user function with the parameters that the user requested
         # The function is executed on the dag's worker pool
@@ -620,7 +590,6 @@ class DAG:
 
         try:
             return self._visualize_tiledb(auto_update=auto_update)
-
         except ImportError:
             return self._visualize_plotly(notebook=notebook, auto_update=auto_update)
 
@@ -787,3 +756,53 @@ class DAG:
             results[node.name] = node.result()
 
         return results
+
+
+def _replace_nodes_with_results(arg):
+    """Descends into data structures and replaces nodes with their values.
+
+    This is guaranteed to produce new data structures and not mutate the inputs.
+    Supports cyclic data structures.
+    """
+    return _ResultReplacer()._replace_internal(arg)
+
+
+class _ResultReplacer:
+    """Class to keep track of visited items when materializing nodes."""
+
+    seen: Dict[int, Any]
+
+    def __init__(self):
+        self.seen = {}
+
+    def _replace_internal(self, arg):
+        if isinstance(arg, Node):
+            return arg.result()
+        if isinstance(arg, (str, bytes)):
+            # Special-case these since they're weird sequences.
+            return arg
+        original_id = id(arg)
+        try:
+            return self.seen[original_id]
+        except KeyError:
+            pass
+        if isinstance(arg, cabc.MutableSequence):
+            replaced = type(arg)()
+            self.seen[original_id] = replaced
+            replaced.extend(map(self._replace_internal, arg))
+            return replaced
+        if isinstance(arg, cabc.Sequence):
+            replaced = type(arg)(map(self._replace_internal, arg))
+            self.seen[original_id] = replaced
+            return replaced
+        if isinstance(arg, cabc.MutableMapping):
+            replaced = type(arg)()
+            self.seen[original_id] = replaced
+            replaced.update((k, self._replace_internal(v)) for k, v in arg.items())
+            return replaced
+        if isinstance(arg, cabc.Mapping):
+            replaced = type(arg)((k, self._replace_internal(v)) for k, v in arg.items())
+            self.seen[original_id] = replaced
+            return replaced
+        self.seen[original_id] = arg
+        return arg

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -1,45 +1,19 @@
+import json
 import numbers
 import time
 import uuid
+from concurrent import futures
+
 import networkx as nx
+from tiledb.cloud.dag import status as st
+from tiledb.cloud.dag import visualization as viz
+from tiledb.cloud import array
+from tiledb.cloud import sql
+from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud import udf
 
-from concurrent.futures import CancelledError, ProcessPoolExecutor, ThreadPoolExecutor
-from enum import Enum
-
-from .visualization import (
-    build_graph_node_details,
-    update_plotly_graph,
-    update_tiledb_graph,
-    build_visualization_positions,
-)
-from ..array import apply as array_apply
-from ..sql import exec as sql_exec
-from ..udf import exec as udf_exec
-
-from ..tiledb_cloud_error import TileDBCloudError
-
-
-class Status(Enum):
-    NOT_STARTED = 1
-    RUNNING = 2
-    COMPLETED = 3
-    FAILED = 4
-    CANCELLED = 5
-
-    def __str__(self):
-        if self == self.NOT_STARTED:
-            return "Not Started"
-        elif self == self.RUNNING:
-            return "Running"
-        elif self == self.COMPLETED:
-            return "Completed"
-        elif self == self.FAILED:
-            return "Failed"
-        elif self == self.CANCELLED:
-            return "Cancelled"
-
-        return "Unknown Status"
-
+# Compatibility re-export.
+Status = st.Status
 
 class Node:
     def __init__(self, func, *args, name=None, dag=None, local_mode=False, **kwargs):
@@ -54,7 +28,7 @@ class Node:
         self.id = uuid.uuid4()
         self.error = None
         self.future = None
-        self.status = Status.NOT_STARTED
+        self.status = st.Status.NOT_STARTED
         self.dag = dag
         self.local_mode = local_mode
 
@@ -64,7 +38,7 @@ class Node:
 
         self.args = args
         self.kwargs = kwargs
-        self.__results = None
+        self._results = None
         self.parents = {}
         self.children = {}
         if name is None:
@@ -125,7 +99,7 @@ class Node:
             self.dag = node.dag
 
     def cancel(self):
-        self.status = Status.CANCELLED
+        self.status = st.Status.CANCELLED
         if self.future is not None:
             self.future.cancel()
 
@@ -134,11 +108,11 @@ class Node:
         Is the node finished
         :return: True if the node's function is finished
         """
-        return self.status in (Status.COMPLETED, Status.FAILED, Status.CANCELLED)
+        return self.status in (st.Status.COMPLETED, st.Status.FAILED, st.Status.CANCELLED)
 
     done = finished
 
-    def __replace_nodes_with_results(self, arg):
+    def _replace_nodes_with_results(self, arg):
         """
         Recursively find arguments of Node instance and replace with the node results
         :param arg:
@@ -155,13 +129,13 @@ class Node:
                 if isinstance(a, Node):
                     arg[index] = a.result()
                 elif isinstance(a, tuple) or isinstance(a, list) or isinstance(a, dict):
-                    arg[index] = self.__replace_nodes_with_results(a)
+                    arg[index] = self._replace_nodes_with_results(a)
         elif isinstance(arg, dict):
             for k, a in arg.items():
                 if isinstance(a, Node):
                     arg[k] = a.result()
                 elif isinstance(a, tuple) or isinstance(a, list) or isinstance(a, dict):
-                    arg[k] = self.__replace_nodes_with_results(a)
+                    arg[k] = self._replace_nodes_with_results(a)
         elif isinstance(arg, Node):
             arg = arg.result()
 
@@ -175,7 +149,7 @@ class Node:
         Execute function for node
         :return: None
         """
-        self.status = Status.RUNNING
+        self.status = st.Status.RUNNING
 
         # Override namespace if passed
         if namespace is not None and not self.local_mode:
@@ -185,31 +159,31 @@ class Node:
         # If there is a node as an argument, the user really just wants the results, so let's fetch them
         # and swap out the parameter
         if self.args is not None:
-            self.args = self.__replace_nodes_with_results(self.args)
+            self.args = self._replace_nodes_with_results(self.args)
 
         # First loop though any default named parameter arguments to find any nodes
         # If there is a node as an argument, the user really just wants the results, so let's fetch them
         # and swap out the parameter
         if self.kwargs is not None:
-            self.kwargs = self.__replace_nodes_with_results(self.kwargs)
+            self.kwargs = self._replace_nodes_with_results(self.kwargs)
 
         # Execute user function with the parameters that the user requested
         # The function is executed on the dag's worker pool
         self.future = self.dag.executor.submit(self.func, *self.args, **self.kwargs)
-        self.future.add_done_callback(self.__handle_completed_future)
+        self.future.add_done_callback(self._handle_completed_future)
 
     compute = exec
 
-    def __handle_completed_future(self, future):
+    def _handle_completed_future(self, future):
         try:
-            self.__results = future.result()
-            if self.status == Status.RUNNING:
-                self.status = Status.COMPLETED
-        except CancelledError:
-            self.status = Status.CANCELLED
+            self._results = future.result()
+            if self.status == st.Status.RUNNING:
+                self.status = st.Status.COMPLETED
+        except futures.CancelledError:
+            self.status = st.Status.CANCELLED
         except Exception as exc:
             self.error = exc
-            self.status = Status.FAILED
+            self.status = st.Status.FAILED
         self.dag.report_node_complete(self)
 
     def ready_to_compute(self):
@@ -217,11 +191,11 @@ class Node:
         Is the node ready to execute? Are all dependencies completed?
         :return: True if node is able to be run
         """
-        if self.status != Status.NOT_STARTED:
+        if self.status != st.Status.NOT_STARTED:
             return False
 
         for node in self.parents.values():
-            if not node.finished() or node.status != Status.COMPLETED:
+            if not node.finished() or node.status != st.Status.COMPLETED:
                 return False
         return True
 
@@ -233,12 +207,12 @@ class Node:
         if self.future is not None:
             # If future, catch exception to store error on node, then raise
             try:
-                self.__results = self.future.result()
+                self._results = self.future.result()
             except Exception as exc:
                 self.error = exc
                 raise exc
 
-        return self.__results
+        return self._results
 
     def result_or_future(self):
         """
@@ -248,7 +222,7 @@ class Node:
         if not self.finished() and self.future is not None:
             return self.future
 
-        return self.__results
+        return self._results
 
     def wait(self, timeout=None):
         """
@@ -304,11 +278,11 @@ class DAG:
         self.visualization = None
 
         if use_processes:
-            self.executor = ProcessPoolExecutor(max_workers=max_workers)
+            self.executor = futures.ProcessPoolExecutor(max_workers=max_workers)
         else:
-            self.executor = ThreadPoolExecutor(max_workers=max_workers)
+            self.executor = futures.ThreadPoolExecutor(max_workers=max_workers)
 
-        self.status = Status.NOT_STARTED
+        self.status = st.Status.NOT_STARTED
 
         self.done_callbacks = []
         self.called_done_callbacks = False
@@ -374,8 +348,8 @@ class DAG:
         Checks if DAG is complete
         :return: True if complete, False otherwise
         """
-        if self.status == Status.NOT_STARTED:
-            raise TileDBCloudError(
+        if self.status == st.Status.NOT_STARTED:
+            raise tce.TileDBCloudError(
                 "Can't call done for DAG before starting DAG with `exec()`"
             )
 
@@ -384,13 +358,13 @@ class DAG:
 
         # If there is no running nodes we can assume it is complete and check if we should mark as failed or successful
         if len(self.failed_nodes) > 0:
-            self.status = Status.FAILED
+            self.status = st.Status.FAILED
         elif len(self.cancelled_nodes) > 0:
-            self.status = Status.CANCELLED
+            self.status = st.Status.CANCELLED
         elif len(self.not_started_nodes) > 0:
             return False
         else:
-            self.status = Status.COMPLETED
+            self.status = st.Status.COMPLETED
 
         return True
 
@@ -424,7 +398,7 @@ class DAG:
         :param name: name
         :return: Node that is created
         """
-        return self.add_node(array_apply, *args, **kwargs)
+        return self.add_node(array.apply, *args, **kwargs)
 
     def submit_udf(self, *args, **kwargs):
         """
@@ -434,7 +408,7 @@ class DAG:
         :param name: name
         :return: Node that is created
         """
-        return self.add_node(udf_exec, *args, **kwargs)
+        return self.add_node(udf.exec, *args, **kwargs)
 
     def submit(self, *args, **kwargs):
         """
@@ -445,7 +419,7 @@ class DAG:
         :param name: name
         :return: Node that is created
         """
-        return self.add_node(udf_exec, *args, **kwargs)
+        return self.add_node(udf.exec, *args, **kwargs)
 
     def submit_sql(self, *args, **kwargs):
         """
@@ -455,7 +429,7 @@ class DAG:
         :param name: name
         :return: Node that is created
         """
-        return self.add_node(sql_exec, *args, **kwargs)
+        return self.add_node(sql.exec, *args, **kwargs)
 
     def submit_local(self, *args, **kwargs):
         """
@@ -475,11 +449,11 @@ class DAG:
         """
         del self.running_nodes[node.id]
 
-        if node.status == Status.COMPLETED:
+        if node.status == st.Status.COMPLETED:
             self.completed_nodes[node.id] = node
             for child in node.children.values():
                 self._exec_node(child)
-        elif node.status == Status.CANCELLED:
+        elif node.status == st.Status.CANCELLED:
             self.cancelled_nodes[node.id] = node
         else:
             self.failed_nodes[node.id] = node
@@ -491,7 +465,7 @@ class DAG:
         if self.done():
             self.execute_done_callbacks()
 
-    def __find_root_nodes(self):
+    def _find_root_nodes(self):
         """
         Find all root nodes
         :return: list of root nodes
@@ -509,11 +483,11 @@ class DAG:
         :return:
         """
         self.called_done_callbacks = False
-        roots = self.__find_root_nodes()
+        roots = self._find_root_nodes()
         if len(roots) == 0:
-            raise TileDBCloudError("DAG is circular, there are no root nodes")
+            raise tce.TileDBCloudError("DAG is circular, there are no root nodes")
 
-        self.status = Status.RUNNING
+        self.status = st.Status.RUNNING
         for node in roots:
             self._exec_node(node)
             # Make sure to execute any callbacks to signal this node has started
@@ -558,11 +532,11 @@ class DAG:
                 )
 
         # in case of failure reraise the first failed node exception
-        if self.status == Status.FAILED:
+        if self.status == st.Status.FAILED:
             raise next(iter(self.failed_nodes.values())).error
 
     def cancel(self):
-        self.status = Status.CANCELLED
+        self.status = st.Status.CANCELLED
         for node in self.running_nodes.values():
             node.cancel()
         for node in self.not_started_nodes.values():
@@ -594,15 +568,15 @@ class DAG:
 
     def networkx_graph(self):
         # Build networkx graph
-        G = nx.DiGraph()
+        graph = nx.DiGraph()
 
         for n in self.nodes.values():
-            G.add_node(n.name)
+            graph.add_node(n.name)
             for child in n.children.values():
-                G.add_node(child.name)
-                G.add_edge(n.name, child.name)
+                graph.add_node(child.name)
+                graph.add_edge(n.name, child.name)
 
-        return G
+        return graph
 
     def get_tiledb_plot_node_details(self):
         """
@@ -617,9 +591,9 @@ class DAG:
         return node_details
 
     @staticmethod
-    def __update_dag_tiledb_graph(graph):
+    def _update_dag_tiledb_graph(graph):
         graph.visualization["node_details"] = graph.get_tiledb_plot_node_details()
-        update_tiledb_graph(
+        viz.update_tiledb_graph(
             graph.visualization["nodes"],
             graph.visualization["edges"],
             graph.visualization["node_details"],
@@ -628,8 +602,10 @@ class DAG:
         )
 
     @staticmethod
-    def __update_dag_plotly_graph(graph):
-        update_plotly_graph(graph.visualization["nodes"], graph.visualization["fig"])
+    def _update_dag_plotly_graph(graph):
+        viz.update_plotly_graph(
+            graph.visualization["nodes"], graph.visualization["fig"]
+        )
 
     def visualize(self, notebook=True, auto_update=True, force_plotly=False):
         """
@@ -643,29 +619,24 @@ class DAG:
             return self._visualize_plotly(notebook=notebook, auto_update=auto_update)
 
         try:
-            import tiledb.plot.widget
-
-            return self.__visualize_tiledb(auto_update=auto_update)
+            return self._visualize_tiledb(auto_update=auto_update)
 
         except ImportError:
-            import plotly.graph_objects as go
-
             return self._visualize_plotly(notebook=notebook, auto_update=auto_update)
 
-    def __visualize_tiledb(self, auto_update=True):
+    def _visualize_tiledb(self, auto_update=True):
         """
         Create graph visualization with tiledb.plot.widget
         :param auto_update: Should the diagram be auto updated with each status change
         :return: figure
         """
-        import tiledb.plot.widget
-        import json
+        from tiledb.plot import widget
 
-        G = self.networkx_graph()
-        nodes = list(G.nodes())
-        edges = list(G.edges())
+        graph = self.networkx_graph()
+        nodes = list(graph.nodes())
+        edges = list(graph.edges())
         node_details = self.get_tiledb_plot_node_details()
-        positions = build_visualization_positions(G)
+        positions = viz.build_visualization_positions(graph)
 
         self.visualization = {
             "nodes": nodes,
@@ -673,11 +644,11 @@ class DAG:
             "node_details": node_details,
             "positions": positions,
         }
-        fig = tiledb.plot.widget.Visualize(data=json.dumps(self.visualization))
+        fig = widget.Visualize(data=json.dumps(self.visualization))
         self.visualization["fig"] = fig
 
         if auto_update:
-            self.add_update_callback(self.__update_dag_tiledb_graph)
+            self.add_update_callback(self._update_dag_tiledb_graph)
 
         return fig
 
@@ -690,13 +661,13 @@ class DAG:
         """
         import plotly.graph_objects as go
 
-        G = self.networkx_graph()
-        pos = build_visualization_positions(G)
+        graph = self.networkx_graph()
+        pos = viz.build_visualization_positions(graph)
 
         # Convert to plotly scatter plot
         edge_x = []
         edge_y = []
-        for edge in G.edges():
+        for edge in graph.edges():
             x0, y0 = pos[edge[0]]
             x1, y1 = pos[edge[1]]
             edge_x.append(x0)
@@ -719,7 +690,7 @@ class DAG:
         node_x = []
         node_y = []
         nodes = []
-        for node in G.nodes():
+        for node in graph.nodes():
             x, y = pos[node]
             node_x.append(x)
             node_y.append(y)
@@ -734,7 +705,7 @@ class DAG:
             marker=dict(size=15, line_width=2),
         )
 
-        (node_trace.marker.color, node_trace.text) = build_graph_node_details(nodes)
+        (node_trace.marker.color, node_trace.text) = viz.build_graph_node_details(nodes)
 
         fig_obj = go.Figure
         if notebook:
@@ -743,7 +714,7 @@ class DAG:
         fig = fig_obj(
             data=[edge_trace, node_trace],
             layout=go.Layout(
-                # title="Status",
+                # title="st.Status",
                 # titlefont_size=16,
                 showlegend=False,
                 hovermode="closest",
@@ -756,10 +727,10 @@ class DAG:
             ),
         )
 
-        self.visualization = dict(fig=fig, network=G, nodes=nodes)
+        self.visualization = dict(fig=fig, network=graph, nodes=nodes)
 
         if auto_update:
-            self.add_update_callback(self.__update_dag_plotly_graph)
+            self.add_update_callback(self._update_dag_plotly_graph)
 
         return fig
 

--- a/tiledb/cloud/dag/status.py
+++ b/tiledb/cloud/dag/status.py
@@ -1,0 +1,12 @@
+import enum
+
+
+class Status(enum.Enum):
+    NOT_STARTED = 1
+    RUNNING = 2
+    COMPLETED = 3
+    FAILED = 4
+    CANCELLED = 5
+
+    def __str__(self):
+        return self.name.replace("_", " ").title()

--- a/tiledb/cloud/dag/visualization.py
+++ b/tiledb/cloud/dag/visualization.py
@@ -2,7 +2,7 @@ import networkx as nx
 import random
 import json
 
-from . import dag
+from . import status as st
 
 
 def build_graph_node_details(nodes):
@@ -16,19 +16,19 @@ def build_graph_node_details(nodes):
     node_text = []
     for node in nodes:
         status = node.status
-        if status == dag.Status.NOT_STARTED:
+        if status == st.Status.NOT_STARTED:
             node_text.append("{} - Not Started".format(node.name))
             node_colors.append("black")
-        elif status == dag.Status.RUNNING:
+        elif status == st.Status.RUNNING:
             node_text.append("{} - Running".format(node.name))
             node_colors.append("blue")
-        elif status == dag.Status.COMPLETED:
+        elif status == st.Status.COMPLETED:
             node_text.append("{} - Completed".format(node.name))
             node_colors.append("green")
-        elif status == dag.Status.FAILED:
+        elif status == st.Status.FAILED:
             node_text.append("{} - Failed".format(node.name))
             node_colors.append("red")
-        elif status == dag.Status.CANCELLED:
+        elif status == st.Status.CANCELLED:
             node_text.append("{} - Cancelled".format(node.name))
             node_colors.append("yellow")
 


### PR DESCRIPTION
This change pulls out `_replace_nodes_with_results` to the root level, then makes it more generic to support stored parameters.

Since the tree-walking process for replacing stored parameters is fundamentally the same as that for replacing Nodes, this extracts out `_ResultReplacer`, which implements the tree-walking algorithm, and implements replacing results and stored parameters in terms of that function. In a future change, it will also be used to implement replacing Nodes with `StoredParam`s (though this will require some work on the graph side to better keep track of node results).

---

As usual, this should be less scary than it looks, since much of it is (newly-added) test code.