### PR TITLE
Add code to support stored params in UDF server.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,15 +1,21 @@
+import base64
 import collections
 import collections.abc as cabc
 import os
 import pickle
 import time
 import unittest
+import uuid
 
+import cloudpickle
 import numpy as np
+import pandas as pd
 
 import tiledb.cloud
 from tiledb.cloud import dag
+from tiledb.cloud import results
 from tiledb.cloud.dag import dag as internal
+from tiledb.cloud.dag import stored_params as sp
 
 tiledb.cloud.login(
     token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
@@ -424,18 +430,8 @@ class DAGCallbackTest(unittest.TestCase):
         self.assertEqual(done_updates, 1)
 
 
-def _node(val):
-    """Creates a completed node with the given value."""
-    n = dag.Node(lambda: None)
-    n.status = dag.Status.COMPLETED
-    n._results = val
-    return n
-
-
 class CustomSeq(cabc.MutableSequence):
     """Custom sequence implementation to test value replacement."""
-
-    lst: list
 
     def __init__(self, items=()):
         self.lst = list(items)
@@ -459,7 +455,7 @@ class CustomSeq(cabc.MutableSequence):
         return type(self) == type(other) and self.lst == other.lst
 
 
-class TestDAGInternals(unittest.TestCase):
+class ReplaceNodesTest(unittest.TestCase):
     def test_basic(self):
         self.assertEqual(5, internal._replace_nodes_with_results(5))
         self.assertEqual("hi", internal._replace_nodes_with_results(_node("hi")))
@@ -486,7 +482,7 @@ class TestDAGInternals(unittest.TestCase):
         }
         lst = [dct, _node("nod")]
         dct["lst"] = lst
-        tup = (_node("lst"), lst, _node("dct"), dct)
+        tup = (_node("a lst:"), lst, _node("a dct:"), dct)
         lst.append(tup)
         got_lst = internal._replace_nodes_with_results(lst)
 
@@ -495,7 +491,7 @@ class TestDAGInternals(unittest.TestCase):
         }
         want_lst = [want_dct, "nod"]
         want_dct["lst"] = want_lst
-        want_tup = ("lst", want_lst, "dct", want_dct)
+        want_tup = ("a lst:", want_lst, "a dct:", want_dct)
         want_lst.append(want_tup)
 
         # assertEqual will blow up if you try to compare a recursive structure.
@@ -523,3 +519,102 @@ class TestDAGInternals(unittest.TestCase):
                 )
             ),
         )
+
+    def test_dont_enter_special_types(self):
+        df = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 3}])
+        self.assertIs(df, internal._replace_nodes_with_results(df))
+        arr = np.array([["a", 1], ["b", 2]])
+        self.assertIs(arr, internal._replace_nodes_with_results(arr))
+
+    def test_ref_equality(self):
+        lst = ["a", _node("B"), "c"]
+        got_val = internal._replace_nodes_with_results([lst, lst])
+        self.assertIs(got_val[0], got_val[1])
+        self.assertIsNot(lst, got_val[0])
+
+    def test_replace_stored_params(self):
+        # Since the corner cases of tree traversal are tested in the other
+        # ReplaceNodesTests, this just tests the basics of stored params.
+        got = internal.replace_stored_params(
+            [
+                sp.StoredParam(_uid(0x1), decoder=results.Decoder("json")),
+                {
+                    "sub-dict": sp.StoredParam(
+                        _uid(0x2), decoder=results.Decoder("native")
+                    )
+                },
+                (sp.StoredParam(_uid(0x1), decoder=results.Decoder("json")),),
+            ],
+            sp.ParamLoader(
+                {
+                    "00000000-0000-0000-0000-000000000001": "W3RydWUsICJ0d28iLCAzXQ==",
+                    "00000000-0000-0000-0000-000000000002": _b64(cloudpickle.dumps(())),
+                }
+            ),
+        )
+
+        want = [
+            [True, "two", 3],
+            {"sub-dict": ()},
+            ([True, "two", 3],),
+        ]
+        self.assertEqual(want, got)
+        self.assertIs(got[0], got[2][0], "restored values must be same object")
+
+    def test_replace_stored_params_pandas(self):
+        arrow_pd, json_pd, json_raw = internal.replace_stored_params(
+            [
+                sp.StoredParam(_uid(0x3), decoder=results.PandasDecoder("arrow")),
+                # Ensure that we can restore the same source object
+                # using multiple encodings.
+                sp.StoredParam(_uid(0x4), decoder=results.PandasDecoder("json")),
+                sp.StoredParam(_uid(0x4), decoder=results.Decoder("json")),
+            ],
+            sp.ParamLoader(
+                {
+                    "00000000-0000-0000-0000-000000000003": _ARROW_DATA,
+                    "00000000-0000-0000-0000-000000000004": _b64(
+                        b'[{"a": 1, "b": "x"}, {"a": 2, "b": "Y"}]'
+                    ),
+                }
+            ),
+        )
+
+        want_arrow_pd = pd.DataFrame([[1, 1.1]], columns=("a", "param1"))
+        self.assertTrue(want_arrow_pd.equals(arrow_pd))
+        want_json_pd = pd.DataFrame([[1, "x"], [2, "Y"]], columns=("a", "b"))
+        self.assertTrue(want_json_pd.equals(json_pd))
+        self.assertEqual(
+            [{"a": 1, "b": "x"}, {"a": 2, "b": "Y"}],
+            json_raw,
+        )
+
+
+def _node(val):
+    """Creates a completed node with the given value."""
+    n = dag.Node(lambda: None)
+    n.status = dag.Status.COMPLETED
+    n._results = val
+    return n
+
+
+def _uid(num: int) -> uuid.UUID:
+    return uuid.UUID(int=num)
+
+
+def _b64(x: bytes) -> str:
+    return str(base64.b64encode(x), encoding="ascii")
+
+
+# set @a = 1;
+# select @a a, ? param1;  -- params: [1.1]
+_ARROW_DATA = """
+/////8AAAAAQAAAAAAAKAAwACgAJAAQACgAAABAAAAAAAQQACAAIAAAABAAIAAAABAAAAAIAAABcAAAA
+FAAAABAAFAAQAAAADwAIAAAABAAQAAAAEAAAABgAAAAAAAADGAAAAAAAAAAAAAYACAAGAAYAAAAAAAIA
+BgAAAHBhcmFtMQAAEAAUABAADwAOAAgAAAAEABAAAAAQAAAAGAAAAAAAAgEcAAAAAAAAAAgADAAIAAcA
+CAAAAAAAAAFAAAAAAQAAAGEAAAD/////yAAAABQAAAAAAAAADAAYABYAFQAQAAQADAAAAEAAAAAAAAAA
+AAAAABQAAAAAAwQADAAcABAADAAIAAQADAAAABwAAAAcAAAAYAAAAAEAAAAAAAAAAAAAAAQABAAEAAAA
+BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB8AAAAAAAAAIAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA
+HwAAAAAAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEIk0Y
+YECCCAAAgAEAAAAAAAAAAAAAAAAIAAAAAAAAAAQiTRhgQIIIAACAmpmZmZmZ8T8AAAAAAP////8AAAAA
+"""

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -835,6 +835,9 @@ class _ResultReplacer:
 
         # Descend into sequences and mappings.
         if isinstance(arg, cabc.MutableSequence):
+            # Mutable types may contain self references, so we create one and
+            # store it as the canonical substitution for this instance in case
+            # we see this original again.
             replaced = type(arg)()
             self.seen[original_id] = replaced
             replaced.extend(map(self._replace_internal, arg))
@@ -844,6 +847,7 @@ class _ResultReplacer:
             self.seen[original_id] = replaced
             return replaced
         if isinstance(arg, cabc.MutableMapping):
+            # Create the mapping in advance to allow self references.
             replaced = type(arg)()
             self.seen[original_id] = replaced
             replaced.update((k, self._replace_internal(v)) for k, v in arg.items())

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -4,7 +4,7 @@ import numbers
 import time
 import uuid
 from concurrent import futures
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import networkx as nx
 
@@ -13,6 +13,7 @@ from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error as tce
 from tiledb.cloud import udf
 from tiledb.cloud.dag import status as st
+from tiledb.cloud.dag import stored_params
 from tiledb.cloud.dag import visualization as viz
 
 Status = st.Status  # Re-export for compabitility.
@@ -764,34 +765,75 @@ class DAG:
         return results
 
 
-def _replace_nodes_with_results(arg):
-    """Descends into data structures and replaces nodes with their values.
+class _ReplaceWith(Exception):
+    """Indicates that the object should be replaced rather than descending."""
 
-    This is guaranteed to produce new data structures and not mutate the inputs.
+    def __init__(self, value: Any):
+        self.value = value
+
+
+def replace_stored_params(tree, loader: stored_params.ParamLoader) -> Any:
+    """Descends into data structures and replaces Stored Params with results.
+
+    This is only useful in the UDF execution environment.
+
+    Guaranteed to produce new output structures and not mutate the input.
     Supports cyclic data structures.
     """
-    return _ResultReplacer()._replace_internal(arg)
+
+    def visit(arg):
+        if isinstance(arg, stored_params.StoredParam):
+            raise _ReplaceWith(loader.load(arg))
+
+    return _ResultReplacer(visit)._replace_internal(tree)
+
+
+def _replace_nodes_with_results(tree):
+    """Descends into data structures and replaces Node IDs with their values.
+
+    Offers the same guarantees as :func:`replace_stored_params`.
+    """
+
+    def visit(arg):
+        if isinstance(arg, Node):
+            raise _ReplaceWith(arg.result())
+
+    return _ResultReplacer(visit)._replace_internal(tree)
 
 
 class _ResultReplacer:
-    """Class to keep track of visited items when materializing nodes."""
+    """Class to visit nodes and replace specific visited nodes.
 
-    seen: Dict[int, Any]
+    This class takes as a parameter a "visit" function.  When the visit function
+    is called, if it raises a :class:`_ReplaceWith`, instead of descending
+    further into the argument, the :class:`_ResultReplacer` will replace the
+    given argument with the value the :class:`_ReplaceWith` contains.
+    """
 
-    def __init__(self):
-        self.seen = {}
+    def __init__(self, visit: Callable[[Any], Any]):
+        self.seen: Dict[int, Any] = {}
+        self.visit = visit
 
     def _replace_internal(self, arg):
-        if isinstance(arg, Node):
-            return arg.result()
         if isinstance(arg, (str, bytes)):
             # Special-case these since they're weird sequences.
             return arg
+
         original_id = id(arg)
         try:
             return self.seen[original_id]
         except KeyError:
-            pass
+            pass  # We haven't seen this object yet; continue.
+
+        # First, handle if this is something to replace directly.
+        try:
+            result = self.visit(arg)
+        except _ReplaceWith as rw:
+            result = rw.value
+            self.seen[original_id] = result
+            return result
+
+        # Descend into sequences and mappings.
         if isinstance(arg, cabc.MutableSequence):
             replaced = type(arg)()
             self.seen[original_id] = replaced
@@ -810,5 +852,7 @@ class _ResultReplacer:
             replaced = type(arg)((k, self._replace_internal(v)) for k, v in arg.items())
             self.seen[original_id] = replaced
             return replaced
+
+        # Otherwise, we just return the original thing.
         self.seen[original_id] = arg
         return arg

--- a/tiledb/cloud/results.py
+++ b/tiledb/cloud/results.py
@@ -15,7 +15,7 @@ from tiledb.cloud.rest_api import models
 
 class AbstractDecoder(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def decode(data: bytes) -> Any:
+    def decode(self, data: bytes) -> Any:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
This pair of changes prepares for the addition of support for stored parameters in the UDF environment:

1. Pulls `_replace_nodes_with_results` to the root level and makes it more flexible.
2. Adds support for replacing the stored parameter sentinels (added in 8f73b340d0b1a296903c402b5f7bb2fec9b2ebdf) with their actual values (eventually to be provided by the UDF environment).

---

This is currently based on #165 since the cleanups there are used here.