### PR TITLE
Remove "fresh" dependency strategy from the matrix.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.7", "3.6"]
         dependencies:
           - pinned
-          - fresh
+          # - fresh
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip


### PR DESCRIPTION
This is a shot in the dark attempt at reducing the number of 502s when
running tests by reducing concurrency.  It really seems like it should
not be a problem, yet here we are.