### PR TITLE
Remove "fresh" dependency strategy from the matrix.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -24,18 +24,12 @@ jobs:
           - ubuntu-20.04
           - macos-10.15
         python-version: ["3.7", "3.6"]
-        dependencies:
-          - pinned
-          - fresh
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip
           - os: macos-10.15
             path: ~/Library/Caches/pip
-        exclude:
-          # Only test against pinned dependencies on Mac OS.
-          - os: macos-10.15
-            dependencies: fresh
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +40,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pinned dependencies
-        if: ${{ matrix.dependencies == 'pinned' }}
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
@@ -54,30 +47,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-py${{ matrix.python-version }}-pip-
 
-      - name: Cache fresh install dependencies
-        if: ${{ matrix.dependencies == 'fresh' }}
-        uses: actions/cache@v2
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-fresh
-          restore-keys: |
-            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
-
-      - name: Install prerequisites
-        run: |
-          pip install --upgrade pip wheel pytest pytest-cov setuptools setuptools-scm
-
-      - name: Install pinned dependencies
-        if: ${{ matrix.dependencies == 'pinned' }}
-        run: |
-          pip install -r requirements-py${{ matrix.python-version }}.txt
-
       - name: Install TileDB-Cloud-Py
         run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements-py${{ matrix.python-version }}.txt
           pip install .
 
       - name: Run tests
         run: |
+          pip install pytest pytest-cov
           pytest -s -v --junitxml=junit/test-results.xml --cov=tiledb/cloud/ --cov-report=xml --cov-report=html
         env:
           TILEDB_CLOUD_HELPER_VAR: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}


### PR DESCRIPTION
This reverts to essentially the version of the pipeline YAML file from
before we added the "fresh checkout" version. It seems like running too
many tests concurrently is causing us trouble where the server gives us
502s, so this is an attempt to reduce it. Limiting the number of runners
means that we would have to wait for two (or more) tests to complete
one after the other. In the context of a test pipeline, pinned
dependencies are more useful than a fresh install.