### PR TITLE
Re-enable the full testing matrix and add PyPI step.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -1,11 +1,15 @@
-name: TileDB-Cloud-Py autobuild
+name: autobuild
 
 on:
-  push:
-    tags: [ "v*" ]
-    branches: [ master ]
   pull_request:
     branches: [ "*" ]
+  push:
+    branches: [ master ]
+  release:
+    types: [ published ]
+  schedule:
+    # 01:30 UTC = 20:30/21:30 America/New_York = 03:30/04:30 Europe/Athens
+    - cron: '30 1 * * *'
 
 
 jobs:
@@ -24,6 +28,9 @@ jobs:
           - ubuntu-20.04
           - macos-10.15
         python-version: ["3.7", "3.6"]
+        dependencies:
+          - pinned
+          - fresh
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip
@@ -40,6 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pinned dependencies
+        if: ${{ matrix.dependencies == 'pinned' }}
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
@@ -47,15 +55,75 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-py${{ matrix.python-version }}-pip-
 
+      # This step ensures that every month we have a new Pip cache, so that
+      # we don't have one cache sitting for months growing ever-staler.
+      - name: Get month for cache key
+        id: month
+        if: ${{ matrix.dependencies == 'fresh' }}
+        run: |
+          echo "::set-output name=month::$(date +'%Y-%m')"
+
+      - name: Cache fresh install dependencies
+        if: ${{ matrix.dependencies == 'fresh' }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-fresh-${{ steps.month.outputs.month }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-fresh-
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
+      - name: Install prerequisites
+        run: |
+          pip install --upgrade pip wheel pytest pytest-cov setuptools setuptools-scm
+
+      - name: Install pinned dependencies
+        if: ${{ matrix.dependencies == 'pinned' }}
+        run: |
+          pip install -r requirements-py${{ matrix.python-version }}.txt
+
       - name: Install TileDB-Cloud-Py
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r requirements-py${{ matrix.python-version }}.txt
           pip install .
 
       - name: Run tests
         run: |
-          pip install pytest pytest-cov
           pytest -s -v --junitxml=junit/test-results.xml --cov=tiledb/cloud/ --cov-report=xml --cov-report=html
         env:
           TILEDB_CLOUD_HELPER_VAR: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
+
+  upload-to-pypi:
+    # Upload a wheel only if the entire matrix succeeds and we're making a tag.
+    needs: run-tests
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+
+      - name: Cache pinned dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: upload-ubuntu-20.04-py3.7-pip-${{ hashFiles('requirements-py3.7.txt') }}
+          restore-keys: |
+            upload-ubuntu-20.04-py3.7-pip-
+
+      - name: Build wheel
+        run: |
+          pip install --upgrade pip wheel setuptools setuptools-scm
+          pip install -r requirements-py3.7.txt
+          python setup.py bdist_wheel -d dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -87,6 +87,8 @@ jobs:
           pip install .
 
       - name: Run tests
+        # Test pinned dependencies on commit / tag and fresh installs on nightlies
+        if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule')
         run: |
           pytest -s -v --junitxml=junit/test-results.xml --cov=tiledb/cloud/ --cov-report=xml --cov-report=html
         env:


### PR DESCRIPTION
- Re-enables the full testing matrix to run, concurrently.
- Adds nightly build to check for dependency regressions.
- Adds workflow to upload to PyPI when a release is created.