### PR TITLE
Make the primary implementations of UDFs synchronous.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,4 @@
 import os
-import platform
-import sys
 import unittest
 
 import numpy

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -1,12 +1,10 @@
-import multiprocessing
 import sys
 import urllib
+import uuid
 import warnings
-import zlib
 from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy
-import urllib3
 
 from tiledb.cloud import client
 from tiledb.cloud import config
@@ -16,51 +14,7 @@ from tiledb.cloud import utils
 from tiledb.cloud.rest_api import ApiException as GenApiException
 from tiledb.cloud.rest_api import models
 
-last_udf_task_id = None
-
-
-class TaskResult:
-    def __init__(self, response, result_format):
-        self.response = response
-        self.task_id = None
-        self.decoder = results.Decoder(result_format)
-
-    def get(self, timeout=None):
-        try:
-            response: urllib3.HTTPResponse = self.response.get(timeout=timeout)
-            res = response.data
-        except (GenApiException, multiprocessing.TimeoutError) as exc:
-            _maybe_set_last_udf_id(exc)
-            raise tiledb_cloud_error.check_exc(exc) from None
-
-        self.task_id = response.getheader(client.TASK_ID_HEADER)
-
-        if res[:2].hex() in ["7801", "785e", "789c", "78da"]:
-            try:
-                res = zlib.decompress(res)
-            except zlib.error:
-                raise tiledb_cloud_error.TileDBCloudError(
-                    "Failed to decompress (zlib) result object"
-                )
-
-        try:
-            return self.decoder.decode(res)
-        except Exception as e:
-            inner_msg = f": {e.args[0]}" if e.args else ""
-            raise tiledb_cloud_error.TileDBCloudError(
-                f"Failed to load result object{inner_msg}"
-            ) from e
-
-
-class UDFResult(TaskResult):
-    def get(self, timeout=None):
-        res = super().get(timeout=timeout)
-
-        # Set last udf task id
-        global last_udf_task_id
-        last_udf_task_id = self.task_id
-
-        return res
+last_udf_task_id: Optional[str] = None
 
 
 class ArrayList:
@@ -425,7 +379,7 @@ def parse_ranges(ranges):
     return result
 
 
-def apply_async(
+def apply_base(
     uri: str,
     func: Union[str, Callable, None] = None,
     ranges: Sequence = (),
@@ -439,10 +393,10 @@ def apply_async(
     v2: bool = True,
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
+    store_results: bool = False,
     **kwargs: Any,
-) -> UDFResult:
-    """
-    Apply a user defined function to an array, asynchronously.
+) -> results.Response:
+    """Apply a user-defined function to an array, and return data and metadata.
 
     :param uri: The ``tiledb://...`` URI of the array to apply the function to.
     :param func: The function to run. This can be either a callable function,
@@ -463,15 +417,16 @@ def apply_async(
     :param bool v2: use v2 array udfs
     :param ResultFormat result_format: result serialization format
     :param result_format_version: Deprecated and ignored.
+    :param store_results: True to temporarily store results on the server side
+        for later retrieval (in addition to downloading them).
     :param kwargs: named arguments to pass to function
-    :return: UDFResult, a future containing the results of the UDF
 
     **Example**
     >>> import tiledb, tiledb.cloud, numpy
     >>> def median(df):
     ...   return numpy.median(df["a"])
     >>> # Open the array then run the UDF
-    >>> tiledb.cloud.array.apply_async("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"]).get()
+    >>> tiledb.cloud.array.apply_base("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"]).result
     2.0
     """
 
@@ -519,6 +474,7 @@ def apply_async(
         image_name=image_name,
         task_name=task_name,
         result_format=result_format,
+        store_results=store_results,
     )
 
     if callable(user_func):
@@ -531,34 +487,32 @@ def apply_async(
     if kwargs:
         udf_model.argument = utils.b64_pickle((kwargs,))
 
-    submit_kwargs = {}
+    submit_kwargs = dict(
+        namespace=namespace,
+        array=array_name,
+        udf=udf_model,
+        v2=v2,
+    )
+
     if http_compressor:
         submit_kwargs["accept_encoding"] = http_compressor
 
-    try:
-        response = api_instance.submit_udf(
-            namespace=namespace,
-            array=array_name,
-            udf=udf_model,
-            async_req=True,
-            v2=v2,
-            _preload_content=False,  # needed to avoid decoding binary data
-            **submit_kwargs,
-        )
-
-        return UDFResult(response, result_format=result_format)
-
-    except GenApiException as exc:
-        _maybe_set_last_udf_id(exc)
-        raise tiledb_cloud_error.check_exc(exc) from None
+    return client.send_udf_call(
+        api_instance.submit_udf,
+        submit_kwargs,
+        results.Decoder(result_format),
+        id_callback=_maybe_set_last_udf_id,
+        store_results=store_results,
+    )
 
 
-@utils.signature_of(apply_async)
+@utils.signature_of(apply_base)
 def apply(*args, **kwargs) -> Any:
     """
     Apply a user defined function to an array, synchronously.
 
-    All arguments are exactly as in :func:`apply_async`.
+    All arguments are exactly as in :func:`apply_base`, but this returns
+    the data only.
 
     **Example:**
 
@@ -569,10 +523,19 @@ def apply(*args, **kwargs) -> Any:
     >>> tiledb.cloud.array.apply("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"])
     2.0
     """
-    return apply_async(*args, **kwargs).get()
+    return apply_base(*args, **kwargs).result
 
 
-def exec_multi_array_udf_async(
+def apply_async(*args, **kwargs) -> results.AsyncResponse:
+    """Apply a user-defined function to an array, asynchronously.
+
+    All arguments are exactly as in :func:`apply_base`, but this returns
+    the data as a future-like AsyncResponse.
+    """
+    return client.client.wrap_async_base_call(apply_base, *args, **kwargs)
+
+
+def exec_multi_array_udf_base(
     func: Union[str, Callable, None] = None,
     array_list: ArrayList = None,
     namespace: Optional[str] = None,
@@ -584,10 +547,11 @@ def exec_multi_array_udf_async(
     task_name: Optional[str] = None,
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
+    store_results: bool = False,
     **kwargs,
-) -> UDFResult:
+) -> results.Response:
     """
-    Apply a user defined function to multiple arrays, asynchronously.
+    Apply a user defined function to multiple arrays.
 
     :param func: The function to run. This can be either a callable function,
         or the name of a registered user-defined function
@@ -601,6 +565,8 @@ def exec_multi_array_udf_async(
         for logging and audit purposes
     :param ResultFormat result_format: result serialization format
     :param str result_format_version: Deprecated and ignored.
+    :param store_results: True to temporarily store results on the server side
+        for later retrieval (in addition to downloading them).
     :param kwargs: named arguments to pass to function
     :return: A future containing the results of the UDF.
     >>> import numpy as np
@@ -655,6 +621,7 @@ def exec_multi_array_udf_async(
         image_name=image_name,
         task_name=task_name,
         result_format=result_format,
+        store_results=store_results,
     )
 
     if callable(user_func):
@@ -667,33 +634,40 @@ def exec_multi_array_udf_async(
     if kwargs:
         udf_model.argument = utils.b64_pickle((kwargs,))
 
-    submit_kwargs = {}
+    submit_kwargs = dict(
+        namespace=namespace,
+        udf=udf_model,
+    )
     if http_compressor:
         submit_kwargs["accept_encoding"] = http_compressor
 
-    try:
-        response = api_instance.submit_multi_array_udf(
-            namespace=namespace,
-            udf=udf_model,
-            async_req=True,
-            _preload_content=False,  # needed to avoid decoding binary data
-            **submit_kwargs,
-        )
-
-        return UDFResult(response, result_format=result_format)
-
-    except GenApiException as exc:
-        _maybe_set_last_udf_id(exc)
-        raise tiledb_cloud_error.check_exc(exc) from None
+    return client.send_udf_call(
+        api_instance.submit_multi_array_udf,
+        submit_kwargs,
+        results.Decoder(result_format),
+        id_callback=_maybe_set_last_udf_id,
+        store_results=store_results,
+    )
 
 
-@utils.signature_of(exec_multi_array_udf_async)
+@utils.signature_of(exec_multi_array_udf_base)
 def exec_multi_array_udf(*args, **kwargs) -> Any:
     """Apply a user-defined function to multiple arrays, synchronously.
 
-    All arguments are exactly as in :func:`exec_multi_array_udf_async`.
+    All arguments are exactly as in :func:`exec_multi_array_udf_base`.
     """
-    return exec_multi_array_udf_async(*args, **kwargs).get()
+    return exec_multi_array_udf_base(*args, **kwargs).result
+
+
+@utils.signature_of(exec_multi_array_udf_base)
+def exec_multi_array_udf_async(*args, **kwargs) -> results.AsyncResponse:
+    """Apply a user-defined function to multiple arrays, asynchronously.
+
+    All arguments are exactly as in :func:`exec_multi_array_udf_base`.
+    """
+    return client.client.wrap_async_base_call(
+        exec_multi_array_udf_base, *args, **kwargs
+    )
 
 
 def _pick_func(**kwargs: Union[str, Callable, None]) -> Union[str, Callable]:
@@ -722,14 +696,8 @@ def _pick_func(**kwargs: Union[str, Callable, None]) -> Union[str, Callable]:
     return result
 
 
-def _maybe_set_last_udf_id(exc: Exception) -> None:
+def _maybe_set_last_udf_id(task_id: Optional[uuid.UUID]) -> None:
     """Tries to set the last_udf_id from the exception, if present."""
     global last_udf_task_id
-    try:
-        hdrs = getattr(exc, "headers")
-        if hdrs:
-            task_id = hdrs.get(client.TASK_ID_HEADER)
-            if task_id:
-                last_udf_task_id = task_id
-    except KeyError:
-        pass
+    if task_id:
+        last_udf_task_id = str(task_id)

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -502,7 +502,7 @@ def apply_base(
         submit_kwargs,
         results.Decoder(result_format),
         id_callback=_maybe_set_last_udf_id,
-        store_results=store_results,
+        results_stored=store_results,
     )
 
 
@@ -646,7 +646,7 @@ def exec_multi_array_udf_base(
         submit_kwargs,
         results.Decoder(result_format),
         id_callback=_maybe_set_last_udf_id,
-        store_results=store_results,
+        results_stored=store_results,
     )
 
 

--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -1,36 +1,25 @@
 from tiledb.cloud import array
+from tiledb.cloud import results
 from tiledb.cloud import utils
 
 
 class CloudArray(object):
     @utils.signature_of(array.apply_async)
-    def apply_async(
-        self,
-        *args,
-        **kwargs,
-    ):
+    def apply_async(self, *args, **kwargs) -> results.AsyncResponse:
         """
         Apply a user-defined function to this array, asynchronously.
 
         Params are the same as :func:`array.apply_async`, but this instance
         provides the URI.
         """
-        return array.apply_async(
-            self.uri,  # pylint: disable=E1101
-            *args,
-            **kwargs,
-        )
+        return array.apply_async(self.uri, *args, **kwargs)  # pylint: disable=E1101
 
-    @utils.signature_of(apply_async)
-    def apply(
-        self,
-        *args,
-        **kwargs,
-    ):
+    @utils.signature_of(array.apply)
+    def apply(self, *args, **kwargs):
         """
-        Apply a user-defined function to this array, asynchronously.
+        Apply a user-defined function to this array, synchronously.
 
-        Params are the same as :func:`array.apply_async`, but this instance
+        Params are the same as :func:`array.apply`, but this instance
         provides the URI.
 
         **Example**
@@ -42,7 +31,4 @@ class CloudArray(object):
         ...   A.apply(median, [(0,5), (0,5)], attrs=["a", "b", "c"])
         2.0
         """
-        return self.apply_async(
-            *args,
-            **kwargs,
-        ).get()
+        return array.apply(self.uri, *args, **kwargs)  # pylint: disable=E1101

--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -1,18 +1,15 @@
 import json
 import os.path
-import sys
 from pathlib import Path
 
 from urllib3 import Retry
 
-from tiledb.cloud import rest_api
+from tiledb.cloud.rest_api import configuration
 
 default_host = "https://api.tiledb.com"
 
-config = rest_api.configuration.Configuration()
+config = configuration.Configuration()
 default_config_file = Path.joinpath(Path.home(), ".tiledb", "cloud.json")
-if sys.version_info < (3, 6):
-    default_config_file = str(default_config_file)
 
 
 def save_configuration(config_file):

--- a/tiledb/cloud/results.py
+++ b/tiledb/cloud/results.py
@@ -31,7 +31,7 @@ class Response:
     # The server-generated UUID of the task.
     task_id: Optional[uuid.UUID]
     # True if the results were stored, false otherwise.
-    store_results: bool
+    results_stored: bool
 
 
 class AsyncResponse:

--- a/tiledb/cloud/results.py
+++ b/tiledb/cloud/results.py
@@ -3,14 +3,69 @@
 import abc
 import dataclasses
 import json
-from typing import Any
+import threading
+import uuid
+from concurrent import futures
+from typing import Any, Optional, Union
 
 import cloudpickle
 import pandas
 import pyarrow
+import urllib3
 
+from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error as tce
 from tiledb.cloud.rest_api import models
+
+TASK_ID_HEADER = "X-TILEDB-CLOUD-TASK-ID"
+
+
+# Not frozen to avoid generating unsafe methods like `__hash__`,
+# but you should still *treat* it like it's frozen.
+@dataclasses.dataclass()
+class Response:
+    """A response from running a UDF."""
+
+    # The result that was returned.
+    result: Any
+    # The server-generated UUID of the task.
+    task_id: Optional[uuid.UUID]
+    # True if the results were stored, false otherwise.
+    store_results: bool
+
+
+class AsyncResponse:
+    """Asynchronous wrapper for compatibility with the old array.TaskResult."""
+
+    def __init__(self, future: "futures.Future[Response]"):
+        """Creates a new AsyncResponse wrapping the given Future."""
+        self._future = future
+        self._id_lock = threading.Lock()
+        self._task_id: Optional[uuid.UUID] = None
+        self._future.add_done_callback(self._set_task_id)
+
+    def get(self, timeout: Optional[float] = None) -> Any:
+        """Gets the result from this response, with Future's timeout rules."""
+        return self._future.result(timeout).result
+
+    @property
+    def task_id(self):
+        """Gets the task ID, or None if not complete or failed with no ID."""
+        with self._id_lock:
+            return self._task_id
+
+    def _set_task_id(self, _):
+        """Sets the task ID once the Future has completed."""
+        try:
+            res = self._future.result()
+        except rest_api.ApiException as exc:
+            with self._id_lock:
+                self._task_id = extract_task_id(exc)
+        except:  # noqa: E722 We don't care about other exceptions, period.
+            pass
+        else:
+            with self._id_lock:
+                self._task_id = res.task_id
 
 
 class AbstractDecoder(metaclass=abc.ABCMeta):
@@ -24,20 +79,21 @@ def _load_arrow(data: bytes):
     return reader.read_all()
 
 
+_DECODE_FNS = {
+    models.ResultFormat.NATIVE: cloudpickle.loads,
+    models.ResultFormat.JSON: json.loads,
+    models.ResultFormat.ARROW: _load_arrow,
+}
+
+
 @dataclasses.dataclass(frozen=True)
 class Decoder(AbstractDecoder):
 
     format: str
 
-    _DECODE_FNS = {
-        models.ResultFormat.NATIVE: cloudpickle.loads,
-        models.ResultFormat.JSON: json.loads,
-        models.ResultFormat.ARROW: _load_arrow,
-    }
-
     def decode(self, data: bytes) -> Any:
         try:
-            decoder = self._DECODE_FNS[self.format]
+            decoder = _DECODE_FNS[self.format]
         except KeyError:
             raise tce.TileDBCloudError(f"{self.format!r} is not a valid result format.")
         return decoder(data)
@@ -53,3 +109,21 @@ class PandasDecoder(AbstractDecoder):
             reader = pyarrow.RecordBatchStreamReader(data)
             return reader.read_pandas()
         return pandas.DataFrame(Decoder(self.format).decode(data))
+
+
+def extract_task_id(
+    thing: Union[rest_api.ApiException, urllib3.HTTPResponse],
+) -> Optional[uuid.UUID]:
+    """Pulls the task ID out of a response or an exception."""
+    id_hdr = thing.headers and thing.headers.get(TASK_ID_HEADER)
+    return _maybe_uuid(id_hdr)
+
+
+def _maybe_uuid(id_str: Optional[str]) -> Optional[uuid.UUID]:
+    """Parses a hex string into a UUID if present and valid."""
+    if not id_str:
+        return None
+    try:
+        return uuid.UUID(hex=id_str)
+    except ValueError:
+        return None

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -123,7 +123,7 @@ def exec_base(
         kwargs,
         decoder,
         id_callback=_maybe_set_last_task_id,
-        store_results=store_results,
+        results_stored=store_results,
     )
 
 

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -1,53 +1,39 @@
 import inspect
 import time
+import uuid
 import warnings
+from typing import Any, Optional, Sequence
 
 import tiledb
 from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import config
 from tiledb.cloud import rest_api
+from tiledb.cloud import results
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud.rest_api import models
-from tiledb.cloud.results import PandasDecoder
 
-last_sql_task_id = None
-
-
-class SQLResult(array.TaskResult):
-    def __init__(self, response, result_format, result_type="pandas"):
-        super().__init__(response, result_format)
-
-        if result_type == "pandas":
-            self.decoder = PandasDecoder(result_format)
-
-    def get(self, timeout=None):
-        res = super().get(timeout)
-
-        # Set last udf task id
-        global last_sql_task_id
-        last_sql_task_id = self.task_id
-
-        return res
+last_sql_task_id: Optional[str] = None
 
 
-def exec_async(
-    query,
-    output_uri=None,
-    output_schema=None,
-    namespace=None,
-    task_name=None,
-    output_array_name=None,
-    raw_results=False,
-    http_compressor="deflate",
-    init_commands=None,
-    parameters=None,
-    result_format=models.ResultFormat.ARROW,
+def exec_base(
+    query: str,
+    output_uri: Optional[str] = None,
+    output_schema: Optional[tiledb.ArraySchema] = None,
+    namespace: Optional[str] = None,
+    task_name: Optional[str] = None,
+    output_array_name: Optional[str] = None,
+    raw_results: bool = False,
+    http_compressor: Optional[str] = "deflate",
+    init_commands: Optional[Sequence[str]] = None,
+    parameters: Optional[Sequence[str]] = None,
+    result_format: str = models.ResultFormat.ARROW,
     result_format_version=None,
-):
-    """
-    Run a sql query asynchronous
+    store_results: bool = False,
+) -> results.Response:
+    """Run a Serverless SQL query, returning both the result and metadata.
+
     :param str query: query to run
     :param str output_uri: optional array to store results to, must be a tiledb:// registered array
     :param tiledb.ArraySchema output_schema: optional schema for creating output array if it does not exist
@@ -60,15 +46,15 @@ def exec_async(
     :param list parameters: optional list of sql parameters for use in query
     :param UDFResultType result_format: result serialization format
     :param str result_format_version: Deprecated and ignored.
-
-    :return: A SQLResult object which is a future for a pandas dataframe if no output array is given and query returns results
+    :param store_results: True to temporarily store results on the server side
+        for later retrieval (in addition to downloading them).
     """
 
     if result_format_version:
         warnings.warn(DeprecationWarning("result_format_version is unused."))
 
     # Make sure the output_uri is remote array
-    if not output_uri is None:
+    if output_uri:
         array.split_uri(output_uri)
 
     # If the namespace is not set, we will default to the user's namespace
@@ -114,40 +100,34 @@ def exec_async(
                 array_metadata=rest_api.models.ArrayInfoUpdate(name=output_array_name),
             )
 
-    try:
-        kwargs = {"_preload_content": False, "async_req": True}
-        if http_compressor is not None:
-            kwargs["accept_encoding"] = http_compressor
+    kwargs = dict(
+        namespace=namespace,
+        sql=rest_api.models.SQLParameters(
+            name=task_name,
+            query=query,
+            output_uri=output_uri,
+            init_commands=init_commands,
+            parameters=parameters,
+            result_format=result_format,
+            store_results=store_results,
+        ),
+    )
+    if http_compressor is not None:
+        kwargs["accept_encoding"] = http_compressor
 
-        response = api_instance.run_sql(
-            namespace=namespace,
-            sql=rest_api.models.SQLParameters(
-                name=task_name,
-                query=query,
-                output_uri=output_uri,
-                init_commands=init_commands,
-                parameters=parameters,
-                result_format=result_format,
-            ),
-            **kwargs
-        )
+    decoder_cls = results.Decoder if raw_results else results.PandasDecoder
+    decoder = decoder_cls(result_format)
 
-        return SQLResult(
-            response,
-            result_format,
-            result_type=None if raw_results else "pandas",
-        )
-
-    except rest_api.ApiException as exc:
-        if exc.headers:
-            task_id = exc.headers.get(client.TASK_ID_HEADER)
-            if task_id:
-                global last_sql_task_id
-                last_sql_task_id = task_id
-        raise tiledb_cloud_error.check_sql_exc(exc) from None
+    return client.send_udf_call(
+        api_instance.run_sql,
+        kwargs,
+        decoder,
+        id_callback=_maybe_set_last_task_id,
+        store_results=store_results,
+    )
 
 
-@utils.signature_of(exec_async)
+@utils.signature_of(exec_base)
 def exec_and_fetch(*args, **kwargs):
     """
     Run a sql query, results are not stored
@@ -175,11 +155,26 @@ def exec_and_fetch(*args, **kwargs):
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
-@utils.signature_of(exec_async)
-def exec(*args, **kwargs):
-    """
-    Run a SQL query, synchronously.
+@utils.signature_of(exec_base)
+def exec(*args, **kwargs) -> Any:
+    """Run a SQL query, synchronously.
 
-    All arguments are exactly as in :func:`exec_async`.
+    All arguments are exactly as in :func:`exec_base`.
     """
-    return exec_async(*args, **kwargs).get()
+    return exec_base(*args, **kwargs).result
+
+
+@utils.signature_of(exec_base)
+def exec_async(*args, **kwargs) -> results.AsyncResponse:
+    """Run a SQL query, asynchronously.
+
+    All arguments are exactly as in :func:`exec_base`. Returns an AsyncResponse,
+    a Future-like object.
+    """
+    return client.client.wrap_async_base_call(exec_base, *args, **kwargs)
+
+
+def _maybe_set_last_task_id(task_id: Optional[uuid.UUID]):
+    global last_sql_task_id
+    if task_id:
+        last_sql_task_id = str(task_id)

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -122,7 +122,7 @@ def exec_base(
         submit_kwargs,
         results.Decoder(result_format),
         id_callback=array._maybe_set_last_udf_id,
-        store_results=store_results,
+        results_stored=store_results,
     )
 
 

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -8,6 +8,7 @@ import cloudpickle
 from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import config
+from tiledb.cloud import results
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud.rest_api import ApiException as GenApiException
@@ -17,7 +18,7 @@ from tiledb.cloud.rest_api import models
 tiledb_cloud_protocol = utils.TILEDB_CLOUD_PROTOCOL
 
 
-def exec_async(
+def exec_base(
     func: Union[str, Callable, Any],
     *args: Any,
     name: Optional[str] = None,
@@ -28,9 +29,10 @@ def exec_async(
     task_name: Optional[str] = None,
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
+    store_results: bool = False,
     **kwargs,
-) -> array.UDFResult:
-    """Run a user defined function, asynchronously.
+) -> results.Response:
+    """Run a user defined function, returning the result and metadata.
 
     :param func: The function to call, either as a callable function, or as
         the name of a registered user-defined function. (If ``name`` is set,
@@ -49,8 +51,9 @@ def exec_async(
         for logging and audit purposes
     :param ResultFormat result_format: result serialization format
     :param str result_format_version: Deprecated and ignored.
+    :param store_results: True to temporarily store results on the server side
+        for later retrieval (in addition to downloading them).
     :param kwargs: named arguments to pass to function
-    :return: UDFResult, a future containing the results of the UDF
     """
 
     if result_format_version:
@@ -89,6 +92,7 @@ def exec_async(
     udf_model = models.GenericUDF(
         language=models.UDFLanguage.PYTHON,
         result_format=result_format,
+        store_results=store_results,
         version="{}.{}.{}".format(
             sys.version_info.major,
             sys.version_info.minor,
@@ -109,33 +113,35 @@ def exec_async(
     if arguments:
         udf_model.argument = utils.b64_pickle(arguments)
 
-    submit_kwargs = {}
+    submit_kwargs = dict(namespace=namespace, udf=udf_model)
     if http_compressor:
         submit_kwargs["accept_encoding"] = http_compressor
 
-    try:
-        response = api_instance.submit_generic_udf(
-            namespace=namespace,
-            udf=udf_model,
-            async_req=True,
-            _preload_content=False,  # needed to avoid decoding binary data
-            **submit_kwargs,
-        )
-        return array.UDFResult(response, result_format=result_format)
-
-    except GenApiException as exc:
-        array._maybe_set_last_udf_id(exc)
-        raise tiledb_cloud_error.check_exc(exc) from None
+    return client.send_udf_call(
+        api_instance.submit_generic_udf,
+        submit_kwargs,
+        results.Decoder(result_format),
+        id_callback=array._maybe_set_last_udf_id,
+        store_results=store_results,
+    )
 
 
-@utils.signature_of(exec_async)
+@utils.signature_of(exec_base)
 def exec(*args, **kwargs) -> Any:
-    """Run a user defined function, synchronously.
+    """Run a user defined function, synchronously, returning only the result.
 
-    Arguments are exactly as in :func:`exec_async`. Returns an immediate value
-    rather than a future.
+    Arguments are exactly as in :func:`exec_base`.
     """
-    return exec_async(*args, **kwargs).get()
+    return exec_base(*args, **kwargs).result
+
+
+@utils.signature_of(exec_base)
+def exec_async(*args, **kwargs) -> Any:
+    """Run a user defined function, asynchronously.
+
+    Arguments are exactly as in :func:`exec_base`.
+    """
+    return client.client.wrap_async_base_call(exec_base, *args, **kwargs)
 
 
 def register_udf(


### PR DESCRIPTION
Currently, the canonical implementation of UDFs is to use the generated
API’s asynchronous interface, and the synchronous version wraps that
and gets the result of the `multiprocessing.pool.TaskResult` returned by
the generated code. This will not work for our plans to avoid
round-tripping all task results when running DAGs.

This change instead makes a new `whatever_base` as the canonical base
implementation of a UDF caller, and bases the existing `whatever` and
`whatever_async` functions off of them, maintaining compatibility.
Additionally, we manage our own thread pool for async requests, which
avoids us having to use multiprocessing’s poorly-supported `TaskResult`
interface and gives us better control over how many threads we run.
UDF request management is fully moved into the `Client` object.

Results are returned by a new `results.Response` class, which includes
the important `task_id` information that will be needed to avoid
round-tripping requests in the future, and a `results.AsyncResponse`
class also wraps (a `futures.Future` of) that `Response` to provide
an API that is 100% compatible for callers currently expecting a
`UDFResult` or `SQLResult`.

Additional changes:

- Creates exactly 1 `ApiClient` to better reuse network connections.
- Cleans up API instance creation.