### PR TITLE
At long last, actually substitute in stored parameters.

### DIFF
--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -523,7 +523,7 @@ def apply(*args, **kwargs) -> Any:
     >>> tiledb.cloud.array.apply("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"])
     2.0
     """
-    return apply_base(*args, **kwargs).result
+    return apply_base(*args, **kwargs).decode()
 
 
 def apply_async(*args, **kwargs) -> results.AsyncResponse:
@@ -656,7 +656,7 @@ def exec_multi_array_udf(*args, **kwargs) -> Any:
 
     All arguments are exactly as in :func:`exec_multi_array_udf_base`.
     """
-    return exec_multi_array_udf_base(*args, **kwargs).result
+    return exec_multi_array_udf_base(*args, **kwargs).decode()
 
 
 @utils.signature_of(exec_multi_array_udf_base)

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -2,7 +2,7 @@ import sys
 import urllib
 import uuid
 import warnings
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
 import numpy
 
@@ -394,8 +394,9 @@ def apply_base(
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
     store_results: bool = False,
+    stored_param_uuids: Iterable[uuid.UUID] = (),
     **kwargs: Any,
-) -> results.Response:
+) -> results.RemoteResult:
     """Apply a user-defined function to an array, and return data and metadata.
 
     :param uri: The ``tiledb://...`` URI of the array to apply the function to.
@@ -475,6 +476,7 @@ def apply_base(
         task_name=task_name,
         result_format=result_format,
         store_results=store_results,
+        stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
     )
 
     if callable(user_func):
@@ -523,10 +525,10 @@ def apply(*args, **kwargs) -> Any:
     >>> tiledb.cloud.array.apply("tiledb://TileDB-Inc/quickstart_dense", median, [(0,5), (0,5)], attrs=["a", "b", "c"])
     2.0
     """
-    return apply_base(*args, **kwargs).decode()
+    return apply_base(*args, **kwargs).get()
 
 
-def apply_async(*args, **kwargs) -> results.AsyncResponse:
+def apply_async(*args, **kwargs) -> results.AsyncResult:
     """Apply a user-defined function to an array, asynchronously.
 
     All arguments are exactly as in :func:`apply_base`, but this returns
@@ -548,8 +550,9 @@ def exec_multi_array_udf_base(
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
     store_results: bool = False,
+    stored_param_uuids: Iterable[uuid.UUID] = (),
     **kwargs,
-) -> results.Response:
+) -> results.RemoteResult:
     """
     Apply a user defined function to multiple arrays.
 
@@ -622,6 +625,7 @@ def exec_multi_array_udf_base(
         task_name=task_name,
         result_format=result_format,
         store_results=store_results,
+        stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
     )
 
     if callable(user_func):
@@ -656,11 +660,11 @@ def exec_multi_array_udf(*args, **kwargs) -> Any:
 
     All arguments are exactly as in :func:`exec_multi_array_udf_base`.
     """
-    return exec_multi_array_udf_base(*args, **kwargs).decode()
+    return exec_multi_array_udf_base(*args, **kwargs).get()
 
 
 @utils.signature_of(exec_multi_array_udf_base)
-def exec_multi_array_udf_async(*args, **kwargs) -> results.AsyncResponse:
+def exec_multi_array_udf_async(*args, **kwargs) -> results.AsyncResult:
     """Apply a user-defined function to multiple arrays, asynchronously.
 
     All arguments are exactly as in :func:`exec_multi_array_udf_base`.

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -477,16 +477,9 @@ def send_udf_call(
     if id_callback:
         id_callback(task_id)
 
-    try:
-        result = decoder.decode(http_response.data)
-    except ValueError as ve:
-        inner_msg = f": {ve.args[0]}" if ve.args else ""
-        raise tiledb_cloud_error.TileDBCloudError(
-            f"Error decoding response from TileDB Cloud{inner_msg}"
-        ) from ve
-
     return results.Response(
-        result=result,
+        body=http_response.data,
+        decoder=decoder,
         task_id=task_id,
         results_stored=results_stored,
     )

--- a/tiledb/cloud/cloudarray.py
+++ b/tiledb/cloud/cloudarray.py
@@ -5,7 +5,7 @@ from tiledb.cloud import utils
 
 class CloudArray(object):
     @utils.signature_of(array.apply_async)
-    def apply_async(self, *args, **kwargs) -> results.AsyncResponse:
+    def apply_async(self, *args, **kwargs) -> results.AsyncResult:
         """
         Apply a user-defined function to this array, asynchronously.
 

--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -117,16 +117,7 @@ class Delayed(DelayedBase):
         else:
             self.args = args
         self.kwargs.update(kwargs)
-
-        # Loop through non-default parameters and find any Node objects
-        # Node objects will be used to automatically add dependencies
-        if self.args is not None:
-            super()._build_dependencies_list(self.args)
-
-        # Loop through defaulted named parameters and find any Node objects
-        # Node objects will be used to automatically add dependencies
-        if self.kwargs is not None:
-            super()._build_dependencies_list(self.kwargs)
+        self._find_deps()
 
         # Set name of task if it won't interfere with user args
         if not self.local_mode:
@@ -180,15 +171,7 @@ class DelayedArrayUDF(DelayedBase):
     def __call__(self, *args, **kwargs):
         self.args = [self.uri, self.func_exec, *args]
         self.kwargs.update(kwargs)
-        # Loop through non-default parameters and find any Node objects
-        # Node objects will be used to automatically add dependencies
-        if self.args is not None:
-            super()._build_dependencies_list(self.args)
-
-        # Loop through defaulted named parameters and find any Node objects
-        # Node objects will be used to automatically add dependencies
-        if self.kwargs is not None:
-            super()._build_dependencies_list(self.kwargs)
+        self._find_deps()
 
         # Set name of task if it won't interfere with user args
         if "task_name" not in self.kwargs:

--- a/tiledb/cloud/dag/stored_params.py
+++ b/tiledb/cloud/dag/stored_params.py
@@ -3,13 +3,15 @@
 import base64
 import dataclasses
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Generic, TypeVar
 
-from tiledb.cloud import results
+from tiledb.cloud import decoders
+
+_T = TypeVar("_T")
 
 
 @dataclasses.dataclass(frozen=True)
-class StoredParam:
+class StoredParam(Generic[_T]):
     """The information needed to identify and decode a stored parameter.
 
     This type is used as a sentinel for stored params in Python UDF parameters.
@@ -23,9 +25,9 @@ class StoredParam:
     task_id: uuid.UUID
 
     # The Decoder that will be used to turn the bytes into a useful value.
-    decoder: results.AbstractDecoder
+    decoder: decoders.AbstractDecoder[_T]
 
-    def decode(self, binary_data: bytes) -> Any:
+    def decode(self, binary_data: bytes) -> _T:
         return self.decoder.decode(binary_data)
 
 

--- a/tiledb/cloud/decoders.py
+++ b/tiledb/cloud/decoders.py
@@ -1,0 +1,60 @@
+"""Classes that know how to decode UDF results."""
+
+import abc
+import dataclasses
+import json
+from typing import Any, Generic, TypeVar
+
+import cloudpickle
+import pandas
+import pyarrow
+
+from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud.rest_api import models
+
+_T = TypeVar("_T")
+
+
+class AbstractDecoder(Generic[_T], metaclass=abc.ABCMeta):
+    """Interface for something that knows how to decode a byte response."""
+
+    @abc.abstractmethod
+    def decode(self, data: bytes) -> Any:
+        raise NotImplementedError()
+
+
+def _load_arrow(data: bytes) -> pyarrow.Table:
+    reader = pyarrow.RecordBatchStreamReader(data)
+    return reader.read_all()
+
+
+_DECODE_FNS = {
+    models.ResultFormat.NATIVE: cloudpickle.loads,
+    models.ResultFormat.JSON: json.loads,
+    models.ResultFormat.ARROW: _load_arrow,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Decoder(AbstractDecoder[_T], Generic[_T]):
+
+    format: str
+
+    def decode(self, data: bytes) -> _T:
+        try:
+            decoder = _DECODE_FNS[self.format]
+        except KeyError:
+            raise tce.TileDBCloudError(f"{self.format!r} is not a valid result format.")
+        return decoder(data)
+
+
+@dataclasses.dataclass(frozen=True)
+class PandasDecoder(AbstractDecoder[pandas.DataFrame]):
+
+    format: str
+
+    def decode(self, data: bytes) -> pandas.DataFrame:
+        if self.format == models.ResultFormat.ARROW:
+            reader = pyarrow.RecordBatchStreamReader(data)
+            return reader.read_pandas()
+        return pandas.DataFrame(Decoder(self.format).decode(data))

--- a/tiledb/cloud/results.py
+++ b/tiledb/cloud/results.py
@@ -1,38 +1,57 @@
-"""Handles the tracking and decoding of task results."""
+"""Things that help you keep track of task results and how to decode them."""
 
 import abc
 import dataclasses
-import json
 import threading
 import uuid
 from concurrent import futures
-from typing import Any, Optional, Union
+from typing import Callable, Generic, Optional, TypeVar, Union
 
-import cloudpickle
-import pandas
-import pyarrow
 import urllib3
 
+from tiledb.cloud import decoders
 from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error as tce
-from tiledb.cloud.rest_api import models
+from tiledb.cloud.dag import stored_params
 
 TASK_ID_HEADER = "X-TILEDB-CLOUD-TASK-ID"
+_T = TypeVar("_T")
 
 
-class AbstractDecoder(metaclass=abc.ABCMeta):
+class Result(Generic[_T], metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def decode(self, data: bytes) -> Any:
+    def get(self) -> _T:
+        """Gets the value stored in this Result."""
         raise NotImplementedError()
+
+    def to_stored_param(self) -> stored_params.StoredParam:
+        raise TypeError("This result cannot be converted to a StoredParam.")
 
 
 # Not frozen to avoid generating unsafe methods like `__hash__`,
-# but you should still *treat* it like it's frozen.
-@dataclasses.dataclass()
-class Response:
-    """A response from running a UDF."""
+# but you should still *treat* these subclasses like they're frozen.
 
-    def decode(self) -> Any:
+
+@dataclasses.dataclass()
+class LocalResult(Result[_T], Generic[_T]):
+    """A result from running a function in a Node locally."""
+
+    it: _T
+
+    def get(self) -> _T:
+        return self.it
+
+    @classmethod
+    def wrap(cls, func: Callable[..., _T]) -> Callable[..., Result[_T]]:
+        return lambda *args, **kwargs: cls(func(*args, **kwargs))
+
+
+@dataclasses.dataclass()
+class RemoteResult(Result[_T], Generic[_T]):
+    """A response from running a UDF remotely."""
+
+    def get(self) -> _T:
+        """Decodes the response from the server."""
         try:
             return self.decoder.decode(self.body)
         except ValueError as ve:
@@ -41,33 +60,40 @@ class Response:
                 f"Error decoding response from TileDB Cloud{inner_msg}"
             ) from ve
 
+    def to_stored_param(self) -> stored_params.StoredParam:
+        if not (self.results_stored and self.task_id):
+            raise ValueError("A result must be stored to create a StoredParam.")
+        return stored_params.StoredParam(
+            decoder=self.decoder,
+            task_id=self.task_id,
+        )
 
     # The HTTP content of the body that was returned.
     body: bytes
     # The server-generated UUID of the task.
     task_id: Optional[uuid.UUID]
     # The decoder that was used to decode the results.
-    decoder: AbstractDecoder
+    decoder: decoders.AbstractDecoder[_T]
     # True if the results were stored, false otherwise.
     results_stored: bool
 
 
-class AsyncResponse:
+class AsyncResult(Generic[_T]):
     """Asynchronous wrapper for compatibility with the old array.TaskResult."""
 
-    def __init__(self, future: "futures.Future[Response]"):
+    def __init__(self, future: "futures.Future[Result[_T]]"):
         """Creates a new AsyncResponse wrapping the given Future."""
         self._future = future
         self._id_lock = threading.Lock()
         self._task_id: Optional[uuid.UUID] = None
         self._future.add_done_callback(self._set_task_id)
 
-    def get(self, timeout: Optional[float] = None) -> Any:
+    def get(self, timeout: Optional[float] = None) -> _T:
         """Gets the result from this response, with Future's timeout rules."""
-        return self._future.result(timeout).decode()
+        return self._future.result(timeout).get()
 
     @property
-    def task_id(self):
+    def task_id(self) -> Optional[uuid.UUID]:
         """Gets the task ID, or None if not complete or failed with no ID."""
         with self._id_lock:
             return self._task_id
@@ -86,43 +112,6 @@ class AsyncResponse:
                 self._task_id = res.task_id
 
 
-def _load_arrow(data: bytes):
-    reader = pyarrow.RecordBatchStreamReader(data)
-    return reader.read_all()
-
-
-_DECODE_FNS = {
-    models.ResultFormat.NATIVE: cloudpickle.loads,
-    models.ResultFormat.JSON: json.loads,
-    models.ResultFormat.ARROW: _load_arrow,
-}
-
-
-@dataclasses.dataclass(frozen=True)
-class Decoder(AbstractDecoder):
-
-    format: str
-
-    def decode(self, data: bytes) -> Any:
-        try:
-            decoder = _DECODE_FNS[self.format]
-        except KeyError:
-            raise tce.TileDBCloudError(f"{self.format!r} is not a valid result format.")
-        return decoder(data)
-
-
-@dataclasses.dataclass(frozen=True)
-class PandasDecoder(AbstractDecoder):
-
-    format: str
-
-    def decode(self, data: bytes) -> pandas.DataFrame:
-        if self.format == models.ResultFormat.ARROW:
-            reader = pyarrow.RecordBatchStreamReader(data)
-            return reader.read_pandas()
-        return pandas.DataFrame(Decoder(self.format).decode(data))
-
-
 def extract_task_id(
     thing: Union[rest_api.ApiException, urllib3.HTTPResponse],
 ) -> Optional[uuid.UUID]:
@@ -139,3 +128,20 @@ def _maybe_uuid(id_str: Optional[str]) -> Optional[uuid.UUID]:
         return uuid.UUID(hex=id_str)
     except ValueError:
         return None
+
+
+# Compatibility aliases.
+# Until a version with decoders.py is deployed to the UDF environment,
+# these need to be defined here so that they can be instantiated
+# by the name here when pickled and unpickled.
+#
+# After that, they can be removed, provided this feature has not yet been
+# provided in a formal release.
+
+
+class Decoder(decoders.Decoder):
+    pass
+
+
+class PandasDecoder(decoders.PandasDecoder):
+    pass

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -31,7 +31,7 @@ def exec_base(
     result_format: str = models.ResultFormat.ARROW,
     result_format_version=None,
     store_results: bool = False,
-) -> results.Response:
+) -> "results.RemoteResult":
     """Run a Serverless SQL query, returning both the result and metadata.
 
     :param str query: query to run
@@ -161,11 +161,11 @@ def exec(*args, **kwargs) -> Any:
 
     All arguments are exactly as in :func:`exec_base`.
     """
-    return exec_base(*args, **kwargs).decode()
+    return exec_base(*args, **kwargs).get()
 
 
 @utils.signature_of(exec_base)
-def exec_async(*args, **kwargs) -> results.AsyncResponse:
+def exec_async(*args, **kwargs) -> "results.AsyncResult":
     """Run a SQL query, asynchronously.
 
     All arguments are exactly as in :func:`exec_base`. Returns an AsyncResponse,

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -161,7 +161,7 @@ def exec(*args, **kwargs) -> Any:
 
     All arguments are exactly as in :func:`exec_base`.
     """
-    return exec_base(*args, **kwargs).result
+    return exec_base(*args, **kwargs).decode()
 
 
 @utils.signature_of(exec_base)

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -1,7 +1,8 @@
 import base64
 import sys
+import uuid
 import warnings
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Union
 
 import cloudpickle
 
@@ -30,8 +31,9 @@ def exec_base(
     result_format: str = models.ResultFormat.NATIVE,
     result_format_version=None,
     store_results: bool = False,
+    stored_param_uuids: Iterable[uuid.UUID] = (),
     **kwargs,
-) -> results.Response:
+) -> "results.RemoteResult":
     """Run a user defined function, returning the result and metadata.
 
     :param func: The function to call, either as a callable function, or as
@@ -100,6 +102,7 @@ def exec_base(
         ),
         image_name=image_name,
         task_name=task_name,
+        stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
     )
 
     if callable(user_func):
@@ -132,7 +135,7 @@ def exec(*args, **kwargs) -> Any:
 
     Arguments are exactly as in :func:`exec_base`.
     """
-    return exec_base(*args, **kwargs).decode()
+    return exec_base(*args, **kwargs).get()
 
 
 @utils.signature_of(exec_base)

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -132,7 +132,7 @@ def exec(*args, **kwargs) -> Any:
 
     Arguments are exactly as in :func:`exec_base`.
     """
-    return exec_base(*args, **kwargs).result
+    return exec_base(*args, **kwargs).decode()
 
 
 @utils.signature_of(exec_base)


### PR DESCRIPTION
Here it is, the monster change that actually implements stored parameters. A major reason that it's so complicated is the fact that `Node` and company have a very large API surface, so users may access it in any number of good or bad ways.

Most of what else goes here would be essentially a description of what is in the commit messages, so you should probably just read those. It is likely that there are things that are unclear, but at least the tests all pass?