### PR TITLE
rest.creation_access_credentials_name should not be set for notebook downloads

### DIFF
--- a/tiledb/cloud/notebook.py
+++ b/tiledb/cloud/notebook.py
@@ -87,11 +87,7 @@ def download_notebook_contents(
       user's account settings.
     :return: contents of the notebook file as a string, nominally in JSON format.
     """
-    ctx = tiledb.cloud.Ctx(
-        {
-            "rest.creation_access_credentials_name": storage_credential_name,
-        }
-    )
+    ctx = tiledb.cloud.Ctx({})
     with tiledb.open(tiledb_uri, "r", ctx=ctx) as arr:
         size = arr.meta["file_size"]
         data = arr.query(attrs=["contents"])[slice(0, size)]


### PR DESCRIPTION
Per @Shelnutt2 on https://app.shortcut.com/tiledb-inc/story/10506/fixes-for-notebook-uploading-downloading