### PR TITLE
Fix VFS I/O from PR #188

### DIFF
--- a/tiledb/cloud/notebook.py
+++ b/tiledb/cloud/notebook.py
@@ -68,8 +68,8 @@ def download_notebook_to_file(
         tiledb_uri,
     )
     vfs = tiledb.VFS(tiledb.cloud.Ctx().config())
-    with vfs.open(ipynb_file_name, "w") as handle:
-        handle.write(ipynb_file_contents)
+    with tiledb.FileIO(vfs, ipynb_file_name, mode="wb") as fio:
+        fio.write(bytes(ipynb_file_contents, "utf-8"))
 
 
 def download_notebook_contents(
@@ -137,11 +137,11 @@ def upload_notebook_from_file(
     """
 
     vfs = tiledb.VFS(tiledb.cloud.Ctx().config())
-    with vfs.open(ipynb_file_name, "r") as handle:
-        ipynb_file_contents = handle.read()
+    with tiledb.FileIO(vfs, ipynb_file_name, mode="rb") as fio:
+        ipynb_file_contents = fio.read()
 
     return upload_notebook_contents(
-        ipynb_file_contents,
+        str(ipynb_file_contents),
         storage_path,
         array_name,
         namespace,


### PR DESCRIPTION
# Context

https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/188 / sc-10506

# Test upload

```
import sys
import tiledb.cloud

tiledb.cloud.login(
    host="https://api.dev.tiledb.io/v1",
    username="********",
    password="*****************",
)

ipynb_file_name = "./foo.ipynb"
namespace = "johnkerl"
array_name = "testing-upload-041"
storage_path = "s3://tiledb-johnkerl"
storage_credential_name = "my-sandbox-creds"

tiledb_uri = tiledb.cloud.upload_notebook_from_file(
    ipynb_file_name,
    namespace,
    array_name,
    storage_path,
    storage_credential_name,
)

print("tiledb_uri=" + tiledb_uri)
```

# Test download

```
import sys
import tiledb.cloud

config = tiledb.Config()
config["rest.username"] = "********"
config["rest.password"] = "****************"
# API endpoint used by https://console.dev.tiledb.io:
config["rest.server_address"] = "api.dev.tiledb.io"

# This is the array-URI format in TileDB Cloud:
tiledb_uri = "tiledb://seth/Voila-Covid-Demo"
ipynb_file_name = "./foo.ipynb"

tiledb.cloud.download_notebook_to_file(
    tiledb_uri,
    ipynb_file_name,
)

print("Wrote " + ipynb_file_name)
```