### PR TITLE
Fix byte-encoding issue in vfs-enabled notebook upload

### DIFF
--- a/tiledb/cloud/notebook.py
+++ b/tiledb/cloud/notebook.py
@@ -138,10 +138,10 @@ def upload_notebook_from_file(
 
     vfs = tiledb.VFS(tiledb.cloud.Ctx().config())
     with tiledb.FileIO(vfs, ipynb_file_name, mode="rb") as fio:
-        ipynb_file_contents = fio.read().decode("utf-8")
+        ipynb_file_contents = fio.read()
 
     return upload_notebook_contents(
-        str(ipynb_file_contents),
+        str(ipynb_file_contents, "utf-8"),
         storage_path,
         array_name,
         namespace,


### PR DESCRIPTION
On discussion with @aaronwolen 

https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/193 had an inadequate test plan -- namely it checked uploading local-disk file A to TileDB Cloud, then tested downloading a _different_ file, B, from TileDB Cloud to local disk

# Test plan

## Upload

`$ cat upload-notebook-staging.py`
```
#!/usr/bin/env python

# ================================================================
# Setup:
# * https://console.dev.tiledb.io
# * Set my storage path and storage credential name in Settings
#
# Note: cannot be invoked from within the base directory of either the
# TileDB-Py or TileDB-Cloud-Py repos -- or any directory with a subdirectory
# named `tiledb` -- since `import tiledb` / `import tiledb.cloud` clashes
# with the existence of that subdirectory.
# ================================================================

import sys
import tiledb.cloud

tiledb.cloud.login(
    host="https://api.dev.tiledb.io/v1",
    username="johnkerl",
    password="theraininspain",
)

storage_path = "s3://tiledb-johnkerl"
storage_credential_name = "my-sandbox-creds"

if len(sys.argv) != 4:
    sys.stderr.write("Usage: %s {ipynb file name} {namespace} {array name}\n" % sys.argv[0])

ipynb_file_name = sys.argv[1]
namespace       = sys.argv[2]
array_name      = sys.argv[3]

tiledb_uri = tiledb.cloud.upload_notebook_from_file(
    ipynb_file_name,
    namespace,
    array_name,
    storage_path,
    storage_credential_name,
)

print("tiledb_uri=" + tiledb_uri)
```

`$ upload-notebook-staging.py foo.ipynb johnkerl testing-upload-054`
```
tiledb://johnkerl/testing-upload-054
```

## Check

Visit https://console.dev.tiledb.io/notebooks/details/johnkerl/testing-upload-054/preview and make sure it's renderable

## Download

`$ cat download-notebook-staging.py`
```
#!/usr/bin/env python

# ================================================================
# Setup:
# * https://console.dev.tiledb.io
# * Set my storage path and storage credential name in Settings
#
# Note: cannot be invoked from within the base directory of either the
# TileDB-Py or TileDB-Cloud-Py repos -- or any directory with a subdirectory
# named `tiledb` -- since `import tiledb` / `import tiledb.cloud` clashes
# with the existence of that subdirectory.
# ================================================================

import sys
import tiledb.cloud

tiledb.cloud.login(
    username='johnkerl',
    password='theraininspain',
    host='https://api.dev.tiledb.io'
)

if len(sys.argv) != 3:
    sys.stderr.write("Usage: %s {tiledb URI} {ipynb file name}\n" % sys.argv[0])

tiledb_uri      = sys.argv[1]
ipynb_file_name = sys.argv[2]

tiledb.cloud.download_notebook_to_file(
    tiledb_uri,
    ipynb_file_name,
)

print("Wrote " + ipynb_file_name)
```

`$ download-notebook-staging.py tiledb://johnkerl/testing-upload-054 readback-test.ipynb`
```
Wrote readback-test.ipynb
```

`$ diff foo.ipynb readback-test.ipynb`

`$ echo $?`
```
0
```

# Causes

* `vfs.open` traffics in bytes; Python system `open` in strings. More thorough testing was done in the initial implementaiton; less through on the move to `vfs`
* https://app.shortcut.com/tiledb-inc/story/11235/auto-test-upload-download-notebook is still very much alive (and underserved)