### PR TITLE
Expand urllib3 connection pool along with the thread pool.

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -516,6 +516,12 @@ class Client:
         """Sets how we should retry requests and updates API instances."""
         mode = RetryMode.maybe_from(mode)
         config.config.retries = _RETRY_CONFIGS[mode]
+        # If users increase the size of the thread pool, increase the size
+        # of the connection pool to match. (The internal members of
+        # ThreadPoolExecutor are not exposed in the .pyi files, so we silence
+        # mypy's warning here.)
+        pool_size = self._thread_pool._max_workers  # type: ignore[attr-defined]
+        config.config.connection_pool_maxsize = pool_size
         client = rest_api.ApiClient(config.config)
 
         self.array_api = rest_api.ArrayApi(client)


### PR DESCRIPTION
If a user expanded the size of the client's async threadpool and then
made enough requests to completely fill it, it would result in
`urllib3.connectionpool` logging warnings.  It won't cause any actual
problems, but it is still probably better to expand the pool to avoid
running into that condition.