### PR TITLE
Don't crash when trying to get the source of a built-in function.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,9 @@ class SourceLinesTest(unittest.TestCase):
             os.remove(testfile)
             self.assertIsNone(utils.getsourcelines(bogus.unimportant_function))
 
+    def test_builtin(self):
+        self.assertIsNone(utils.getsourcelines(dir))
+
 
 class PickleTest(unittest.TestCase):
     def test_roundtrip(self):

--- a/tiledb/cloud/utils.py
+++ b/tiledb/cloud/utils.py
@@ -11,8 +11,15 @@ TILEDB_CLOUD_PROTOCOL = 4
 logger = logging.getLogger("tiledb.cloud")
 
 
+_builtin_function = type(len)
+"""The type of functions implemented in C."""
+
+
 def getsourcelines(func: Callable) -> Optional[str]:
     """Attempt to extract the source code of ``func``, but accept failure."""
+    if isinstance(func, _builtin_function):
+        # Built-in functions have no accessible source code.
+        return None
     try:
         # Attempt to find and serialize the original source...
         return "".join(inspect.getsourcelines(func)[0])


### PR DESCRIPTION
This allows users to pass built-in functions (i.e. those implemented
in C) to UDFs.