### PR TITLE
Add support for local file export

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+import unittest
+
+import tiledb
+import tiledb.cloud
+
+tiledb.cloud.login(
+    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
+    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
+)
+
+
+class FileTests(unittest.TestCase):
+    def test_simple_file_export(self):
+        test_file = "tiledb://TileDB-Inc/VLDB17_TileDB"
+
+        with tempfile.TemporaryDirectory() as dirpath:
+            output_path = os.path.join(dirpath, "VLDB17_TileDB.pdf")
+            tiledb.cloud.file.export_file_local(test_file, output_path)
+
+            self.assertTrue(os.path.exists(output_path))
+            self.assertGreater(os.path.getsize(output_path), 0)

--- a/tiledb/cloud/file.py
+++ b/tiledb/cloud/file.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from typing import Tuple, Union, Optional
 
+import tiledb
+from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud.rest_api import ApiException as GenApiException
 from tiledb.cloud.rest_api import models
-from tiledb.cloud import array
-import tiledb
 
 
 def create_file(
@@ -94,17 +94,7 @@ def export_file(
 
         api_instance = client.client.file_api
 
-        local = True
-        if (
-            uri.startswith("tiledb://")
-            or uri.startswith("s3://")
-            or uri.startswith("azure://")
-            or uri.startswith("gcs://")
-            or uri.startswith("obs://")
-        ):
-            local = False
-
-        if local:
+        if uri.startswith("file://") or "://" not in uri:
             return export_file_local(uri, output_uri, async_req)
 
         file_export = models.FileExport(

--- a/tiledb/cloud/file.py
+++ b/tiledb/cloud/file.py
@@ -45,7 +45,7 @@ def create_file(
 def export_file_local(
     uri: str,
     output_uri: str,
-    timestamp: Optional[tuple] = None,
+    timestamp: Union[Tuple[int, int], int, None] = None,
     async_req: bool = False,
 ) -> models.FileExported:
     """

--- a/tiledb/cloud/file.py
+++ b/tiledb/cloud/file.py
@@ -5,6 +5,7 @@ from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud.rest_api import ApiException as GenApiException
 from tiledb.cloud.rest_api import models
 from tiledb.cloud import array
+import tiledb
 
 
 def create_file(
@@ -41,6 +42,41 @@ def create_file(
         raise tiledb_cloud_error.check_exc(exc) from None
 
 
+def export_file_local(
+    uri: str,
+    output_uri: str,
+    timestamp: Optional[tuple] = None,
+    async_req: bool = False,
+) -> models.FileExported:
+    """
+    Exports a TileDB File back to its original file format
+    :param uri: The ``tiledb://...`` URI of the file to export
+    :param output_uri: output file uri
+    :param tuple timestamp: (default None) If int, open the array at a given TileDB
+        timestamp. If tuple, open at the given start and end TileDB timestamps.
+    :param async_req: return future instead of results for async support
+    :return: FileExported details, including output_uri
+    """
+    try:
+        ctx = client.Ctx()
+        vfs = tiledb.VFS(ctx=ctx)
+        with tiledb.open(uri, ctx=ctx, timestamp=timestamp) as A:
+            file_size = A.meta["file_size"]
+            # Row major partial export of single attribute
+            iterable = A.query(
+                attrs=["contents"], return_incomplete=True, order="C"
+            ).multi_index[0:file_size]
+
+            fh = vfs.open(output_uri, "wb")
+            for part in iterable:
+                vfs.write(fh, part["contents"])
+
+            vfs.close(fh)
+
+    except GenApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc) from None
+
+
 def export_file(
     uri: str,
     output_uri: str,
@@ -57,6 +93,19 @@ def export_file(
         (namespace, name) = array.split_uri(uri)
 
         api_instance = client.client.file_api
+
+        local = True
+        if (
+            uri.startswith("tiledb://")
+            or uri.startswith("s3://")
+            or uri.startswith("azure://")
+            or uri.startswith("gcs://")
+            or uri.startswith("obs://")
+        ):
+            local = False
+
+        if local:
+            return export_file_local(uri, output_uri, async_req)
 
         file_export = models.FileExport(
             output_uri=output_uri,

--- a/tiledb/cloud/rest_api/models/file_type.py
+++ b/tiledb/cloud/rest_api/models/file_type.py
@@ -31,6 +31,7 @@ class FileType(object):
     NOTEBOOK = "notebook"
     USER_DEFINED_FUNCTION = "user_defined_function"
     ML_MODEL = "ml_model"
+    FILE = "file"
 
     allowable_values = [NOTEBOOK, USER_DEFINED_FUNCTION, ML_MODEL]  # noqa: E501
 


### PR DESCRIPTION
The export_file command now support running the export through TileDB cloud directly to S3 and exporting locally.