### PR TITLE
Don't run tests on releases

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -21,6 +21,7 @@ jobs:
 
   run-tests:
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name != 'release' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
When we cut a tag for a release we should skip tests and go to publishing.