### PR TITLE
Optional requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "dirty-tag"
+write_to = "tiledb/cloud/version.py"

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ REQUIRES = [
     "certifi",
     "python-dateutil",
     "cloudpickle==1.4.1",
-    "setuptools>=18.0",
-    "setuptools_scm>=1.5.4",
     "pandas<1.3",  # As of 2021-07-06, the runtime (pinned to 1.1) is incompatible with 1.3.
     "plotly>= 4.0.0",
     "networkx>= 2.0.0",
@@ -57,11 +55,6 @@ setup(
     packages=PACKAGES,
     include_package_data=True,
     zip_safe=False,  # Force folder install; egg doesn't work for namespace
-    use_scm_version={
-        "version_scheme": "guess-next-dev",
-        "local_scheme": "dirty-tag",
-        "write_to": "tiledb/cloud/version.py",
-    },
     long_description="""\
     TileDB Cloud Platform Python API # noqa: E501
     """,

--- a/setup.py
+++ b/setup.py
@@ -7,31 +7,6 @@
 from setuptools import find_packages  # noqa: H301
 from setuptools import setup
 
-NAME = "tiledb-cloud"
-
-# To install the library, run the following
-#
-# python setup.py install
-#
-# prerequisite: setuptools
-# http://pypi.python.org/pypi/setuptools
-
-REQUIRES = [
-    "attrs>=21.4.0",
-    "tiledb>=0.5.0",
-    "urllib3>=1.26",
-    "six>=1.10",
-    "certifi",
-    "python-dateutil",
-    "cloudpickle==1.4.1",
-    "pandas<1.3",  # As of 2021-07-06, the runtime (pinned to 1.1) is incompatible with 1.3.
-    "plotly>= 4.0.0",
-    "networkx>= 2.0.0",
-    "pydot",
-    "tiledb-plot-widget>=0.1.7",
-    "pyarrow==3.0.0",
-]
-
 # NOTE: we cannot use an __init__.py file in the tiledb/ directory, because it is supplied
 #       by core tiledb-py. Therefore, `find_packages` at the root directory does not find
 #       any sub-packages. We must explicitly iterate the `tiledb/cloud` subdirectory
@@ -41,17 +16,34 @@ REQUIRES = [
 #       '[].nspkg.pth' pointer file, which breaks imports of tiledb.cloud.
 # 3) https://stackoverflow.com/a/50301070
 
-PACKAGES = ("tiledb.cloud",) + tuple(
+PACKAGES = ["tiledb.cloud"]
+PACKAGES.extend(
     "tiledb.cloud." + x for x in find_packages("./tiledb/cloud", exclude=("testonly",))
 )
+VIZ_REQUIRES = ["networkx>=2", "pydot"]
 
 setup(
-    name=NAME,
+    name="tiledb-cloud",
     description="TileDB Cloud Platform Python Client",
     author_email="",
     url="https://tiledb.io",
     keywords=["TileDB", "cloud"],
-    install_requires=REQUIRES,
+    install_requires=[
+        "attrs>=21.4.0",
+        "tiledb>=0.5.0",
+        "urllib3>=1.26",
+        "six>=1.10",
+        "certifi",
+        "python-dateutil",
+        "cloudpickle==1.4.1",
+        # as of 2021-07-06, the runtime (pinned to 1.1) is incompatible with 1.3
+        "pandas<1.3",
+        "pyarrow==3.0.0",
+    ],
+    extras_require={
+        "viz-tiledb": ["tiledb-plot-widget>=0.1.7", *VIZ_REQUIRES],
+        "viz-plotly": ["plotly>=4", *VIZ_REQUIRES],
+    },
     packages=PACKAGES,
     include_package_data=True,
     zip_safe=False,  # Force folder install; egg doesn't work for namespace

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ PACKAGES.extend(
     "tiledb.cloud." + x for x in find_packages("./tiledb/cloud", exclude=("testonly",))
 )
 VIZ_REQUIRES = ["networkx>=2", "pydot"]
+TILEDB_VIZ_REQUIRES = ["tiledb-plot-widget>=0.1.7", *VIZ_REQUIRES]
+PLOTLY_VIZ_REQUIRES = ["plotly>=4", *VIZ_REQUIRES]
+ALL_REQUIRES = list(set(TILEDB_VIZ_REQUIRES + PLOTLY_VIZ_REQUIRES))
 
 setup(
     name="tiledb-cloud",
@@ -41,8 +44,9 @@ setup(
         "pyarrow==3.0.0",
     ],
     extras_require={
-        "viz-tiledb": ["tiledb-plot-widget>=0.1.7", *VIZ_REQUIRES],
-        "viz-plotly": ["plotly>=4", *VIZ_REQUIRES],
+        "viz-tiledb": TILEDB_VIZ_REQUIRES,
+        "viz-plotly": PLOTLY_VIZ_REQUIRES,
+        "all": ALL_REQUIRES,
     },
     packages=PACKAGES,
     include_package_data=True,

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -22,8 +22,6 @@ from typing import (
     TypeVar,
 )
 
-import networkx as nx
-
 from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
@@ -705,7 +703,8 @@ class DAG:
         }
 
     def networkx_graph(self):
-        # Build networkx graph
+        import networkx as nx
+
         graph = nx.DiGraph()
 
         for n in self.nodes.values():

--- a/tiledb/cloud/dag/visualization.py
+++ b/tiledb/cloud/dag/visualization.py
@@ -1,8 +1,6 @@
 import json
 import random
 
-import networkx as nx
-
 from tiledb.cloud.dag import status as st
 
 
@@ -130,6 +128,8 @@ def hierarchy_pos(
 
     xcenter: horizontal location of root
     """
+    import networkx as nx
+
     if not nx.is_tree(G):
         raise TypeError("cannot use hierarchy_pos on a graph that is not a tree")
 


### PR DESCRIPTION
Make the visualization dependencies optional since they pull a bunch of indirect dependencies (especially `tiledb-plot-widget`), which increases the environment footprint and increases the chance of version conflicts.

To preserve the current behavior when installing use `pip install tiledb-cloud[all]==0.7.22` (adjust for latest version).