### PR TITLE
Support REST API at subpath instead of subdomain

### DIFF
--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -33,10 +33,14 @@ def Config(cfg_dict=None):
         if r in cfg_dict:
             raise ValueError(f"Unexpected config parameter '{r}' to cloud.Config")
 
-    host_parsed = urllib.parse.urlparse(config.config.host)
-    cfg_dict["rest.server_address"] = urllib.parse.urlunparse(
-        (host_parsed.scheme, host_parsed.netloc, "", "", "", "")
-    )
+    # Remove any ending `/v1` paths
+    host = config.config.host
+    if host.endswith("/v1"):
+        host = host[: -len("/v1")]
+    elif host.endswith("/v1/"):
+        host = host[: -len("/v1/")]
+
+    cfg_dict["rest.server_address"] = host
     cfg = tiledb.Config(cfg_dict)
 
     if (

--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -16,10 +16,19 @@ def save_configuration(config_file):
     config_path = os.path.dirname(config_file)
     if not os.path.exists(config_path):
         os.makedirs(config_path)
+
     with open(config_file, "w") as f:
         global config
+
+        # Remove any ending `/v1` paths to store the base url only in the on disk config
+        host = config.host
+        if host.endswith("/v1"):
+            host = host[: -len("/v1")]
+        elif host.endswith("/v1/"):
+            host = host[: -len("/v1/")]
+
         config_to_save = {
-            "host": config.host,
+            "host": host,
             "verify_ssl": config.verify_ssl,
         }
 


### PR DESCRIPTION
This allows flexibility in where the REST server is deployed by no stripping out the paths from the host url. Instead we only remove the `/v1` path if it exists. This `/v1` path is used by the auto-generated client as the client's base is for `/v1` API calls.