### PR TITLE
Support TILEDB_REST_IGNORE_SSL_VALIDATION env var

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -254,24 +254,17 @@ class BasicTests(unittest.TestCase):
             tasks.fetch_results(uuid.uuid4())
 
     def test_timeout(self):
-        def test():
+        def test(_):
             import time
 
             time.sleep(10)
 
         with self.assertRaises(tiledb_cloud_error.TileDBCloudError):
 
-            def test():
-                import time
-
-                time.sleep(10)
-
             with tiledb.open(
                 "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
             ) as A:
-                A.apply_async(
-                    lambda x: numpy.sum(x["a"]), [(1, 4), (1, 4)], timeout=1
-                ).get(),
+                A.apply_async(test, [(1, 4), (1, 4)], timeout=1).get(),
 
 
 class RangesTest(unittest.TestCase):

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -1,4 +1,5 @@
 import enum
+import os
 import threading
 import urllib.parse
 import uuid
@@ -70,7 +71,7 @@ def login(
     username=None,
     password=None,
     host=None,
-    verify_ssl=True,
+    verify_ssl=None,
     no_session=False,
     threads=None,
 ):
@@ -102,13 +103,18 @@ def login(
     ):
         raise Exception("Username and Password are both required")
 
-    kwargs = {
-        "username": username,
-        "password": password,
-        "host": host,
-        "verify_ssl": verify_ssl,
-        "api_key": {},
-    }
+    if verify_ssl is None:
+        verify_ssl = not config.parse_bool(
+            os.getenv("TILEDB_REST_IGNORE_SSL_VALIDATION", "False")
+        )
+
+        kwargs = {
+            "username": username,
+            "password": password,
+            "host": host,
+            "verify_ssl": verify_ssl,
+            "api_key": {},
+        }
     # Is user logs in with username/password we need to create a session
     if (token is None or token == "") and not no_session:
         config.setup_configuration(**kwargs)

--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -12,6 +12,10 @@ config = configuration.Configuration()
 default_config_file = Path.joinpath(Path.home(), ".tiledb", "cloud.json")
 
 
+def _parse_bool(s: str) -> bool:
+    return s.lower() in ["true", "1", "on"]
+
+
 def save_configuration(config_file):
     config_path = os.path.dirname(config_file)
     if not os.path.exists(config_path):
@@ -53,7 +57,9 @@ def load_configuration(config_path):
     # default username/password to empty strings
     username = os.getenv("TILEDB_REST_USERNAME", None)
     password = os.getenv("TILEDB_REST_PASSWORD", None)
-    verify_ssl = True
+    verify_ssl = not _parse_bool(
+        os.getenv("TILEDB_REST_IGNORE_SSL_VALIDATION", "False")
+    )
 
     if os.path.isfile(config_path):
         with open(config_path, "r") as f:

--- a/tiledb/cloud/config.py
+++ b/tiledb/cloud/config.py
@@ -12,7 +12,7 @@ config = configuration.Configuration()
 default_config_file = Path.joinpath(Path.home(), ".tiledb", "cloud.json")
 
 
-def _parse_bool(s: str) -> bool:
+def parse_bool(s: str) -> bool:
     return s.lower() in ["true", "1", "on"]
 
 
@@ -57,9 +57,7 @@ def load_configuration(config_path):
     # default username/password to empty strings
     username = os.getenv("TILEDB_REST_USERNAME", None)
     password = os.getenv("TILEDB_REST_PASSWORD", None)
-    verify_ssl = not _parse_bool(
-        os.getenv("TILEDB_REST_IGNORE_SSL_VALIDATION", "False")
-    )
+    verify_ssl = not parse_bool(os.getenv("TILEDB_REST_IGNORE_SSL_VALIDATION", "False"))
 
     if os.path.isfile(config_path):
         with open(config_path, "r") as f:
@@ -96,7 +94,9 @@ def load_configuration(config_path):
                 and config_obj["api_key"] != ""
             ):
                 token = config_obj["api_key"]
-            verify_ssl = config_obj["verify_ssl"]
+
+            if "verify_ssl" in config_obj:
+                verify_ssl = config_obj["verify_ssl"]
 
     if (token is None or token == "") and (username is None or username == ""):
         return "You must first login before you can run commands"

--- a/tiledb/cloud/rest_api/rest.py
+++ b/tiledb/cloud/rest_api/rest.py
@@ -94,7 +94,7 @@ class RESTClientObject(object):
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
                 proxy_headers=configuration.proxy_headers,
-                **addition_pool_args
+                **addition_pool_args,
             )
         else:
             self.pool_manager = urllib3.PoolManager(
@@ -104,7 +104,7 @@ class RESTClientObject(object):
                 ca_certs=ca_certs,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
-                **addition_pool_args
+                **addition_pool_args,
             )
 
     def request(


### PR DESCRIPTION
Support `TILEDB_REST_IGNORE_SSL_VALIDATION` env variable for toggling verify_ssl settings. This is the setting the core library support for disabling ssl validation for curl/REST requests.

The logic here is reverse so we negate the env variable if set.