### PR TITLE
Regenerate generated API for task graph UUIDs.

### DIFF
--- a/tiledb/cloud/rest_api/docs/GenericUDF.md
+++ b/tiledb/cloud/rest_api/docs/GenericUDF.md
@@ -17,6 +17,8 @@ Name | Type | Description | Notes
 **store_results** | **bool** | store results for later retrieval | [optional] 
 **timeout** | **int** | UDF-type timeout in seconds (default: 900) | [optional] 
 **dont_download_results** | **bool** | Set to true to avoid downloading the results of this UDF. Useful for intermediate nodes in a task graph where you will not be using the results of your function. Defaults to false (\&quot;yes download results\&quot;). | [optional] 
+**task_graph_uuid** | **str** | If set, the ID of the log for the task graph that this was part of.  | [optional] 
+**client_node_uuid** | **str** | If set, the client-defined ID of the node within this task&#39;s graph.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tiledb/cloud/rest_api/docs/MultiArrayUDF.md
+++ b/tiledb/cloud/rest_api/docs/MultiArrayUDF.md
@@ -21,6 +21,8 @@ Name | Type | Description | Notes
 **buffers** | **list[str]** | List of buffers to fetch (attributes + dimensions). Deprecated; please set arrays with &#x60;UDFArrayDetails&#x60;. | [optional] 
 **arrays** | [**list[UDFArrayDetails]**](UDFArrayDetails.md) | Array ranges/buffer into to run UDF on | [optional] 
 **timeout** | **int** | UDF-type timeout in seconds (default: 900) | [optional] 
+**task_graph_uuid** | **str** | If set, the ID of the log for the task graph that this was part of.  | [optional] 
+**client_node_uuid** | **str** | If set, the client-defined ID of the node within this task&#39;s graph.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tiledb/cloud/rest_api/models/generic_udf.py
+++ b/tiledb/cloud/rest_api/models/generic_udf.py
@@ -46,6 +46,8 @@ class GenericUDF(object):
         "store_results": "bool",
         "timeout": "int",
         "dont_download_results": "bool",
+        "task_graph_uuid": "str",
+        "client_node_uuid": "str",
     }
 
     attribute_map = {
@@ -62,6 +64,8 @@ class GenericUDF(object):
         "store_results": "store_results",
         "timeout": "timeout",
         "dont_download_results": "dont_download_results",
+        "task_graph_uuid": "task_graph_uuid",
+        "client_node_uuid": "client_node_uuid",
     }
 
     def __init__(
@@ -79,6 +83,8 @@ class GenericUDF(object):
         store_results=None,
         timeout=None,
         dont_download_results=None,
+        task_graph_uuid=None,
+        client_node_uuid=None,
         local_vars_configuration=None,
     ):  # noqa: E501
         """GenericUDF - a model defined in OpenAPI"""  # noqa: E501
@@ -99,6 +105,8 @@ class GenericUDF(object):
         self._store_results = None
         self._timeout = None
         self._dont_download_results = None
+        self._task_graph_uuid = None
+        self._client_node_uuid = None
         self.discriminator = None
 
         if udf_info_name is not None:
@@ -127,6 +135,10 @@ class GenericUDF(object):
             self.timeout = timeout
         if dont_download_results is not None:
             self.dont_download_results = dont_download_results
+        if task_graph_uuid is not None:
+            self.task_graph_uuid = task_graph_uuid
+        if client_node_uuid is not None:
+            self.client_node_uuid = client_node_uuid
 
     @property
     def udf_info_name(self):
@@ -422,6 +434,52 @@ class GenericUDF(object):
         """
 
         self._dont_download_results = dont_download_results
+
+    @property
+    def task_graph_uuid(self):
+        """Gets the task_graph_uuid of this GenericUDF.  # noqa: E501
+
+        If set, the ID of the log for the task graph that this was part of.   # noqa: E501
+
+        :return: The task_graph_uuid of this GenericUDF.  # noqa: E501
+        :rtype: str
+        """
+        return self._task_graph_uuid
+
+    @task_graph_uuid.setter
+    def task_graph_uuid(self, task_graph_uuid):
+        """Sets the task_graph_uuid of this GenericUDF.
+
+        If set, the ID of the log for the task graph that this was part of.   # noqa: E501
+
+        :param task_graph_uuid: The task_graph_uuid of this GenericUDF.  # noqa: E501
+        :type: str
+        """
+
+        self._task_graph_uuid = task_graph_uuid
+
+    @property
+    def client_node_uuid(self):
+        """Gets the client_node_uuid of this GenericUDF.  # noqa: E501
+
+        If set, the client-defined ID of the node within this task's graph.   # noqa: E501
+
+        :return: The client_node_uuid of this GenericUDF.  # noqa: E501
+        :rtype: str
+        """
+        return self._client_node_uuid
+
+    @client_node_uuid.setter
+    def client_node_uuid(self, client_node_uuid):
+        """Sets the client_node_uuid of this GenericUDF.
+
+        If set, the client-defined ID of the node within this task's graph.   # noqa: E501
+
+        :param client_node_uuid: The client_node_uuid of this GenericUDF.  # noqa: E501
+        :type: str
+        """
+
+        self._client_node_uuid = client_node_uuid
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tiledb/cloud/rest_api/models/multi_array_udf.py
+++ b/tiledb/cloud/rest_api/models/multi_array_udf.py
@@ -50,6 +50,8 @@ class MultiArrayUDF(object):
         "buffers": "list[str]",
         "arrays": "list[UDFArrayDetails]",
         "timeout": "int",
+        "task_graph_uuid": "str",
+        "client_node_uuid": "str",
     }
 
     attribute_map = {
@@ -70,6 +72,8 @@ class MultiArrayUDF(object):
         "buffers": "buffers",
         "arrays": "arrays",
         "timeout": "timeout",
+        "task_graph_uuid": "task_graph_uuid",
+        "client_node_uuid": "client_node_uuid",
     }
 
     def __init__(
@@ -91,6 +95,8 @@ class MultiArrayUDF(object):
         buffers=None,
         arrays=None,
         timeout=None,
+        task_graph_uuid=None,
+        client_node_uuid=None,
         local_vars_configuration=None,
     ):  # noqa: E501
         """MultiArrayUDF - a model defined in OpenAPI"""  # noqa: E501
@@ -115,6 +121,8 @@ class MultiArrayUDF(object):
         self._buffers = None
         self._arrays = None
         self._timeout = None
+        self._task_graph_uuid = None
+        self._client_node_uuid = None
         self.discriminator = None
 
         if udf_info_name is not None:
@@ -151,6 +159,10 @@ class MultiArrayUDF(object):
             self.arrays = arrays
         if timeout is not None:
             self.timeout = timeout
+        if task_graph_uuid is not None:
+            self.task_graph_uuid = task_graph_uuid
+        if client_node_uuid is not None:
+            self.client_node_uuid = client_node_uuid
 
     @property
     def udf_info_name(self):
@@ -534,6 +546,52 @@ class MultiArrayUDF(object):
         """
 
         self._timeout = timeout
+
+    @property
+    def task_graph_uuid(self):
+        """Gets the task_graph_uuid of this MultiArrayUDF.  # noqa: E501
+
+        If set, the ID of the log for the task graph that this was part of.   # noqa: E501
+
+        :return: The task_graph_uuid of this MultiArrayUDF.  # noqa: E501
+        :rtype: str
+        """
+        return self._task_graph_uuid
+
+    @task_graph_uuid.setter
+    def task_graph_uuid(self, task_graph_uuid):
+        """Sets the task_graph_uuid of this MultiArrayUDF.
+
+        If set, the ID of the log for the task graph that this was part of.   # noqa: E501
+
+        :param task_graph_uuid: The task_graph_uuid of this MultiArrayUDF.  # noqa: E501
+        :type: str
+        """
+
+        self._task_graph_uuid = task_graph_uuid
+
+    @property
+    def client_node_uuid(self):
+        """Gets the client_node_uuid of this MultiArrayUDF.  # noqa: E501
+
+        If set, the client-defined ID of the node within this task's graph.   # noqa: E501
+
+        :return: The client_node_uuid of this MultiArrayUDF.  # noqa: E501
+        :rtype: str
+        """
+        return self._client_node_uuid
+
+    @client_node_uuid.setter
+    def client_node_uuid(self, client_node_uuid):
+        """Sets the client_node_uuid of this MultiArrayUDF.
+
+        If set, the client-defined ID of the node within this task's graph.   # noqa: E501
+
+        :param client_node_uuid: The client_node_uuid of this MultiArrayUDF.  # noqa: E501
+        :type: str
+        """
+
+        self._client_node_uuid = client_node_uuid
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tiledb/cloud/rest_api/test/test_generic_udf.py
+++ b/tiledb/cloud/rest_api/test/test_generic_udf.py
@@ -50,6 +50,8 @@ class TestGenericUDF(unittest.TestCase):
                 store_results=True,
                 timeout=56,
                 dont_download_results=True,
+                task_graph_uuid="0",
+                client_node_uuid="0",
             )
         else:
             return GenericUDF()

--- a/tiledb/cloud/rest_api/test/test_multi_array_udf.py
+++ b/tiledb/cloud/rest_api/test/test_multi_array_udf.py
@@ -96,6 +96,8 @@ class TestMultiArrayUDF(unittest.TestCase):
                     )
                 ],
                 timeout=56,
+                task_graph_uuid="0",
+                client_node_uuid="0",
             )
         else:
             return MultiArrayUDF()


### PR DESCRIPTION
https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/commit/a17cdfa2012e05bfd03ed173c7c38eaddb954491

Uses the same patch as 9200e98328dcf1a5814a9ed0c4602fb950c05c1e.