### PR TITLE
Actually submit task graph logs and node IDs to the server.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 import tiledb.cloud
+from tiledb.cloud import client
 from tiledb.cloud import dag
 from tiledb.cloud import tasks
 from tiledb.cloud._results import decoders
@@ -35,7 +36,7 @@ class DAGClassTest(unittest.TestCase):
     maxDiff = None
 
     def test_simple_dag(self):
-        d = dag.DAG()
+        d = dag.DAG(name="a cool dag")
 
         node_1 = d.add_node(np.median, [1, 2, 3])
         node_1.name = "node_1"
@@ -73,6 +74,8 @@ class DAGClassTest(unittest.TestCase):
         self.assertEqual(
             d._build_log_structure(),
             models.TaskGraphLog(
+                name="a cool dag",
+                namespace=client.default_charged_namespace(),
                 nodes=[
                     models.TaskGraphNodeMetadata(
                         client_node_uuid=str(node_1.id),
@@ -200,6 +203,7 @@ class DAGClassTest(unittest.TestCase):
         self.assertEqual(
             d._build_log_structure(),
             models.TaskGraphLog(
+                namespace=client.default_charged_namespace(),
                 nodes=[
                     models.TaskGraphNodeMetadata(
                         client_node_uuid=str(node_1.id),

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -382,6 +382,8 @@ def apply_base(
     timeout: int = None,
     _download_results: bool = True,
     namespace: Optional[str] = None,
+    _server_graph_uuid: Optional[uuid.UUID] = None,
+    _client_node_uuid: Optional[uuid.UUID] = None,
     **kwargs: Any,
 ) -> results.RemoteResult:
     """Apply a user-defined function to an array, and return data and metadata.
@@ -412,6 +414,10 @@ def apply_base(
         False to not download results by default and only do so lazily
         (e.g. for an intermediate node in a graph).
     :param namespace: The namespace to execute the UDF under.
+    :param _server_graph_uuid: If this function is being executed within a DAG,
+        the server-generated ID of the graph's log. Otherwise, None.
+    :param _client_node_uuid: If this function is being executed within a DAG,
+        the ID of this function's node within the graph. Otherwise, None.
     :param kwargs: named arguments to pass to function
 
     **Example**
@@ -475,6 +481,8 @@ def apply_base(
         store_results=store_results,
         stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
         dont_download_results=not _download_results,
+        task_graph_uuid=_server_graph_uuid and str(_server_graph_uuid),
+        client_node_uuid=_client_node_uuid and str(_client_node_uuid),
     )
 
     if timeout is not None:
@@ -552,6 +560,8 @@ def exec_multi_array_udf_base(
     store_results: bool = False,
     stored_param_uuids: Iterable[uuid.UUID] = (),
     _download_results: bool = True,
+    _server_graph_uuid: Optional[uuid.UUID] = None,
+    _client_node_uuid: Optional[uuid.UUID] = None,
     **kwargs,
 ) -> results.RemoteResult:
     """
@@ -571,6 +581,10 @@ def exec_multi_array_udf_base(
     :param str result_format_version: Deprecated and ignored.
     :param store_results: True to temporarily store results on the server side
         for later retrieval (in addition to downloading them).
+    :param _server_graph_uuid: If this function is being executed within a DAG,
+        the server-generated ID of the graph's log. Otherwise, None.
+    :param _client_node_uuid: If this function is being executed within a DAG,
+        the ID of this function's node within the graph. Otherwise, None.
     :param kwargs: named arguments to pass to function
     :return: A future containing the results of the UDF.
     >>> import numpy as np
@@ -622,6 +636,8 @@ def exec_multi_array_udf_base(
         store_results=store_results,
         stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
         dont_download_results=not _download_results,
+        task_graph_uuid=_server_graph_uuid and str(_server_graph_uuid),
+        client_node_uuid=_client_node_uuid and str(_client_node_uuid),
     )
 
     if callable(user_func):

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -477,6 +477,10 @@ class Client:
         """
         Initialize api clients
         """
+        # If users increase the size of the thread pool, increase the size
+        # of the connection pool to match. (The internal members of
+        # ThreadPoolExecutor are not exposed in the .pyi files, so we silence
+        # mypy's warning here.)
         pool_size = self._thread_pool._max_workers  # type: ignore[attr-defined]
         config.config.connection_pool_maxsize = pool_size
         client = rest_api.ApiClient(config.config)
@@ -489,6 +493,7 @@ class Client:
         self.notebook_api = rest_api.NotebookApi(client)
         self.organization_api = rest_api.OrganizationApi(client)
         self.sql_api = rest_api.SqlApi(client)
+        self.task_graph_logs_api = rest_api.TaskGraphLogsApi(client)
         self.tasks_api = rest_api.TasksApi(client)
         self.udf_api = rest_api.UdfApi(client)
         self.user_api = rest_api.UserApi(client)
@@ -506,10 +511,6 @@ class Client:
         """Sets how we should retry requests and updates API instances."""
         mode = RetryMode.maybe_from(mode)
         config.config.retries = _RETRY_CONFIGS[mode]
-        # If users increase the size of the thread pool, increase the size
-        # of the connection pool to match. (The internal members of
-        # ThreadPoolExecutor are not exposed in the .pyi files, so we silence
-        # mypy's warning here.)
         self.__init_clients()
 
     def set_threads(self, threads: Optional[int] = None):

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -378,9 +378,13 @@ class DAG:
                 except rest_api.ApiException as apix:
                     # There was a problem submitting the task graph for logging.
                     # This should not abort the task graph.
-                    warnings.warn(
-                        UserWarning(f"Error submitting task graph logging info: {apix}")
-                    )
+
+                    # TODO: Start warning once the server actually accepts
+                    # task graph logging data.
+                    pass
+                    # warnings.warn(
+                    #     UserWarning(f"Error submitting task graph logging info: {apix}")
+                    # )
                 else:
                     try:
                         self.server_graph_uuid = uuid.UUID(hex=result.uuid)

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -1029,7 +1029,7 @@ class _StoredParamReplacer(visitor.ReplacingVisitor):
 def _topo_sort(
     lst: Sequence[rest_api.TaskGraphNodeMetadata],
 ) -> Sequence[rest_api.TaskGraphNodeMetadata]:
-    """Topographically sorts the list of node metadatas."""
+    """Topologically sorts the list of node metadatas."""
     by_uuid: Dict[str, rest_api.TaskGraphNodeMetadata] = {
         node.client_node_uuid: node for node in lst
     }

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -33,6 +33,8 @@ def exec_base(
     result_format_version=None,
     store_results: bool = False,
     _download_results: bool = True,
+    _server_graph_uuid: Optional[uuid.UUID] = None,
+    _client_node_uuid: Optional[uuid.UUID] = None,
 ) -> "results.RemoteResult":
     """Run a Serverless SQL query, returning both the result and metadata.
 
@@ -50,6 +52,10 @@ def exec_base(
     :param str result_format_version: Deprecated and ignored.
     :param store_results: True to temporarily store results on the server side
         for later retrieval (in addition to downloading them).
+    :param _server_graph_uuid: If this function is being executed within a DAG,
+        the server-generated ID of the graph's log. Otherwise, None.
+    :param _client_node_uuid: If this function is being executed within a DAG,
+        the ID of this function's node within the graph. Otherwise, None.
     :param _download_results: True to download and parse results eagerly.
         False to not download results by default and only do so lazily
         (e.g. for an intermediate node in a graph).
@@ -110,6 +116,7 @@ def exec_base(
             result_format=result_format,
             store_results=store_results,
             dont_download_results=not _download_results,
+            # TODO: Add graph ID parameters here.
         ),
     )
     if http_compressor is not None:

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -35,6 +35,8 @@ def exec_base(
     stored_param_uuids: Iterable[uuid.UUID] = (),
     timeout: int = None,
     _download_results: bool = True,
+    _server_graph_uuid: Optional[uuid.UUID] = None,
+    _client_node_uuid: Optional[uuid.UUID] = None,
     **kwargs,
 ) -> "results.RemoteResult":
     """Run a user defined function, returning the result and metadata.
@@ -62,6 +64,10 @@ def exec_base(
     :param _download_results: True to download and parse results eagerly.
         False to not download results by default and only do so lazily
         (e.g. for an intermediate node in a graph).
+    :param _server_graph_uuid: If this function is being executed within a DAG,
+        the server-generated ID of the graph's log. Otherwise, None.
+    :param _client_node_uuid: If this function is being executed within a DAG,
+        the ID of this function's node within the graph. Otherwise, None.
     :param kwargs: named arguments to pass to function
     """
 
@@ -105,6 +111,8 @@ def exec_base(
         task_name=task_name,
         stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
         dont_download_results=not _download_results,
+        task_graph_uuid=_server_graph_uuid and str(_server_graph_uuid),
+        client_node_uuid=_client_node_uuid and str(_client_node_uuid),
     )
 
     if timeout is not None:


### PR DESCRIPTION
This comprises most (all?) of the rest of the client-side work for
logging the activities of client-driven task graphs.

- We build the task graph structure and submit it to the server.
- For each graph execution step, we include the node metadata.
- When the graph finishes, submit that we are complete.