### PR TITLE
Add required Content-type parameter to generated API call.

### DIFF
--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -274,6 +274,7 @@ def delete_array(uri, *, async_req=False):
         return api_instance.delete_array(
             namespace=namespace,
             array=array_name,
+            content_type="application/json",
             async_req=async_req,
         )
     except GenApiException as exc:


### PR DESCRIPTION
Content-type is marked as a required property in all calls to any
array-related code, so even if we don't require one from the caller,
we still have to pass one to the generated code.