### PR TITLE
Add warnings on task graph log submit failure and other TODOs.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -566,13 +566,13 @@ class DAGCloudApplyTest(unittest.TestCase):
             numpy.sum(orig["a"]),
             tasks.fetch_results(node_array_apply.task_id()),
         )
-        # TODO: The server does not currently actually store SQL queries,
-        # even when we ask it to. Re-enable when that fix is deployed.
-        if False:
-            self.assertEqual(
-                numpy.sum(orig_dense["a"]),
-                tasks.fetch_results_pandas(node_sql.task_id()),
-            )
+        self.assertEqual(
+            numpy.sum(orig_dense["a"]),
+            tasks.fetch_results_pandas(
+                node_sql.task_id(),
+                result_format=tiledb.cloud.ResultFormat.ARROW,
+            ).iat[0, 0],
+        )
         self.assertEqual(
             numpy.mean([numpy.sum(orig["a"]), numpy.sum(orig_dense["a"])]),
             tasks.fetch_results(node_exec.task_id()),

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -379,12 +379,9 @@ class DAG:
                     # There was a problem submitting the task graph for logging.
                     # This should not abort the task graph.
 
-                    # TODO: Start warning once the server actually accepts
-                    # task graph logging data.
-                    pass
-                    # warnings.warn(
-                    #     UserWarning(f"Error submitting task graph logging info: {apix}")
-                    # )
+                    warnings.warn(
+                        UserWarning(f"Error submitting task graph logging info: {apix}")
+                    )
                 else:
                     try:
                         self.server_graph_uuid = uuid.UUID(hex=result.uuid)
@@ -547,9 +544,6 @@ class DAG:
             sql.exec_base,
             *args,
             _internal_accepts_stored_params=False,
-            # TODO: Remove _download_results once the server starts honoring
-            # store_results for SQL queries.
-            _download_results=True,
             **kwargs,
         )
 


### PR DESCRIPTION
- Raises a warning when task graph log submission fails. This does not
  block execution.
- Remove workarounds from when server did not honor `store_results`
  for SQL queries.