### PR TITLE
Fix error with zero-length Arrow response bodies.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import uuid
 
 import numpy
 import numpy as np
+import pyarrow
 
 import tiledb
 import tiledb.cloud
@@ -264,7 +265,16 @@ class BasicTests(unittest.TestCase):
             with tiledb.open(
                 "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
             ) as A:
-                A.apply_async(test, [(1, 4), (1, 4)], timeout=1).get(),
+                A.apply_async(test, [(1, 4), (1, 4)], timeout=1).get()
+
+    def test_empty_arrow(self):
+        def test():
+            import pyarrow
+
+            return pyarrow.Table.from_pydict({})
+
+        tbl = tiledb.cloud.udf.exec(test, result_format="arrow")
+        self.assertIsInstance(tbl, pyarrow.Table)
 
 
 class RangesTest(unittest.TestCase):

--- a/tiledb/cloud/_results/decoders.py
+++ b/tiledb/cloud/_results/decoders.py
@@ -24,6 +24,12 @@ class AbstractDecoder(Generic[_T], metaclass=abc.ABCMeta):
 
 
 def _load_arrow(data: bytes) -> pyarrow.Table:
+    # If a UDF didn't return any rows, there will not have been any batches
+    # of data to write to the output, and thus it will not include any content
+    # at all. (SQL queries will include headers.)
+    if not data:
+        # In this case, we need to return an empty table.
+        return pyarrow.Table.from_pydict({})
     reader = pyarrow.RecordBatchStreamReader(data)
     return reader.read_all()
 

--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -101,7 +101,7 @@ class RemoteResult(Result[_T], Generic[_T]):
         del attribute, value  # unused
         if self.results_stored and not self.task_id:
             raise ValueError("task_id must be set for stored results")
-        if not self.results_stored and not self._body:
+        if not self.results_stored and self._body is None:
             raise ValueError(
                 "no way to access Node results;"
                 " they must be either stored or downloaded"


### PR DESCRIPTION
For situations where a UDF was successful but for whatever reason
the result returned was a zero-length body, we would mistakenly assume
that the body was not provided, rather than recognizing it as a valid
but zero-length body. We now distinguish between no body and a
zero-length body, and properly handle zero-length Arrow bodies.

We had previously tested against empty Arrow bodies with SQL queries.
SQL queries include a schema in their results, and thus have nonzero
response length. However, empty UDF responses which are written in Arrow
format would not have any write calls at all, meaning the response was
completely empty.

Also adds a test for this situation.

---

Thanks to @ckrilow for finding this bug!