### PR TITLE
Update interchange format for less verbosity and nesting.

### DIFF
--- a/tests/taskgraphs/test_codec.py
+++ b/tests/taskgraphs/test_codec.py
@@ -17,69 +17,54 @@ class TestUnescaper(unittest.TestCase):
                 "nested pickle",
                 """
                     {
-                      "__tiledb_sentinel__": {
-                        "__escape__": {
-                          "a": "b",
-                          "__tiledb_sentinel__": {
-                            "__tiledb_sentinel__": {
-                              "immediate": {
-                                "format": "python_pickle",
-                                "base64_data": "gASVEgAAAAAAAACMBGpzb26UjAVsb2Fkc5STlC4="
-                              }
-                            }
-                          }
+                      "__tdbudf__": "__escape__",
+                      "__escape__": {
+                        "a": "b",
+                        "__tdbudf__": {
+                          "__tdbudf__": "immediate",
+                          "format": "python_pickle",
+                          "base64_data": "gASVEgAAAAAAAACMBGpzb26UjAVsb2Fkc5STlC4="
                         }
                       }
                     }
                 """,
                 {
                     "a": "b",
-                    "__tiledb_sentinel__": json.loads,
+                    "__tdbudf__": json.loads,
                 },
             ),
             (
                 "complex",
                 """
                     {
-                      "__tiledb_sentinel__": {
-                        "__escape__": {
-                          "c": "d",
-                          "__tiledb_sentinel__": {
-                            "__tiledb_sentinel__": {
-                              "__escape__": {
-                                "e": null,
-                                "__tiledb_sentinel__": 6,
-                                "f": {
-                                  "__tiledb_sentinel__": {
-                                    "immediate": {
-                                      "format": "bytes",
-                                      "base64_data": "YXNkbGtmamFzZGxm"
-                                    }
-                                  }
-                                },
-                                "g": [
-                                  "here",
-                                  "there",
-                                  "everywhere",
-                                  {
-                                    "__tiledb_sentinel__": {
-                                      "immediate": {
-                                        "format": "python_pickle",
-                                        "base64_data": "gASVNwAAAAAAAACMCGRhdGV0aW1llIwIdGltZXpvbmWUk5RoAIwJdGltZWRlbHRhlJOUSwBLAEsAh5RSlIWUUpQu"
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "__tiledb_sentinel__": {
-                                      "immediate": {
-                                        "format": "python_pickle",
-                                        "base64_data": "gASVFAAAAAAAAACMCGJ1aWx0aW5zlIwDbGVulJOULg=="
-                                      }
-                                    }
-                                  }
-                                ]
+                      "__tdbudf__": "__escape__",
+                      "__escape__": {
+                        "c": "d",
+                        "__tdbudf__": {
+                          "__tdbudf__": "__escape__",
+                          "__escape__": {
+                            "e": null,
+                            "__tdbudf__": 6,
+                            "f": {
+                              "__tdbudf__": "immediate",
+                              "format": "bytes",
+                              "base64_data": "YXNkbGtmamFzZGxm"
+                            },
+                            "g": [
+                              "here",
+                              "there",
+                              "everywhere",
+                              {
+                                "__tdbudf__": "immediate",
+                                "format": "python_pickle",
+                                "base64_data": "gASVNwAAAAAAAACMCGRhdGV0aW1llIwIdGltZXpvbmWUk5RoAIwJdGltZWRlbHRhlJOUSwBLAEsAh5RSlIWUUpQu"
+                              },
+                              {
+                                "__tdbudf__": "immediate",
+                                "format": "python_pickle",
+                                "base64_data": "gASVFAAAAAAAAACMCGJ1aWx0aW5zlIwDbGVulJOULg=="
                               }
-                            }
+                            ]
                           }
                         }
                       }
@@ -87,9 +72,9 @@ class TestUnescaper(unittest.TestCase):
                 """,
                 {
                     "c": "d",
-                    "__tiledb_sentinel__": {
+                    "__tdbudf__": {
                         "e": None,
-                        "__tiledb_sentinel__": 6,
+                        "__tdbudf__": 6,
                         "f": b"asdlkfjasdlf",
                         "g": [
                             "here",
@@ -105,12 +90,9 @@ class TestUnescaper(unittest.TestCase):
                 "just a range",
                 """
                     {
-                      "__tiledb_sentinel__": {
-                        "immediate": {
-                          "format": "python_pickle",
-                          "base64_data": "gASVIQAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAE2aAksBh5RSlC4="
-                        }
-                      }
+                      "__tdbudf__": "immediate",
+                      "format": "python_pickle",
+                      "base64_data": "gASVIQAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAE2aAksBh5RSlC4="
                     }
                 """,
                 range(666),
@@ -120,10 +102,6 @@ class TestUnescaper(unittest.TestCase):
         for name, inp, expected in cases:
             with self.subTest(name):
                 decoded_input = json.loads(inp)
-                import sys
-
-                json.dump(decoded_input, sys.stderr, indent=2)
-                print(file=sys.stderr)
                 unesc = _codec.Unescaper()
                 actual = unesc.visit(decoded_input)
                 self.assertEqual(expected, actual)

--- a/tiledb/cloud/taskgraphs/_codec.py
+++ b/tiledb/cloud/taskgraphs/_codec.py
@@ -9,7 +9,7 @@ from tiledb.cloud._results import visitor
 
 _T = TypeVar("_T")
 TOrDict = Union[_T, Dict[str, Any]]
-_SENTINEL_KEY = "__tiledb_sentinel__"
+_SENTINEL_KEY = "__tdbudf__"
 _ESCAPE_CODE = "__escape__"
 
 
@@ -27,47 +27,40 @@ class Unescaper(visitor.ReplacingVisitor):
             return None
         if _SENTINEL_KEY not in arg:
             return None
-        sentinel_value: Dict[str, Any] = arg[_SENTINEL_KEY]
-        count = len(sentinel_value)
-        if count != 1:
-            entries = tuple(sentinel_value)
-            raise ValueError(
-                f"A sentinel value may have only one key. Had {count}: {entries!r}"
-            )
-        key, value = next(iter(sentinel_value.items()))
-        return self._replace_sentinel(key, value)
+        sentinel_name = arg[_SENTINEL_KEY]
+        return self._replace_sentinel(sentinel_name, arg)
 
     def _replace_sentinel(
         self,
-        inner_key: str,
-        inner_value: Any,
+        kind: str,
+        value: Dict[str, Any],
     ) -> Optional[visitor.Replacement]:
         """The base implementation of a sentinel-replacer.
 
-        It is passed the ``inner_key`` and ``inner_value`` of a
-        ``__tiledb_sentinel__``–containing object::
+        It is passed the kind and value of a ``__tdbudf__``–containing object::
 
             # Given this:
-            {"__tiledb_sentinel__": {"node_data": "qwerty"}}
+            the_object = {"__tdbudf__": "node_data", "data": "abc"}
             # This will be called:
-            self._replace_sentinel("node_data", "qwerty")
+            self._replace_sentinel("node_data", the_object)
 
         This implementation handles replacing values that do not require any
         external information. Derived implementations should handle their own
         keys and end with a call to
-        ``return super()._replace_sentinel(inner_key, inner_value)``.
+        ``return super()._replace_sentinel(kind, value)``.
         """
-        if inner_key == _ESCAPE_CODE:
-            # A value that looks like {sentinel: {escape: [something]}}
+        if kind == _ESCAPE_CODE:
+            # An escaped value.
+            inner_value = value[_ESCAPE_CODE]
             return visitor.Replacement(
                 {k: self.visit(v) for (k, v) in inner_value.items()}
             )
-        if inner_key == "immediate":
-            fmt = inner_value["format"]
-            base64d = inner_value["base64_data"]
+        if kind == "immediate":
+            fmt = value["format"]
+            base64d = value["base64_data"]
             data = base64.b64decode(base64d)
             return visitor.Replacement(_LOADERS[fmt](data))
-        raise ValueError(f"Unknown sentinel key {inner_key!r}")
+        raise ValueError(f"Unknown sentinel type {kind!r}")
 
 
 # TODO: Move these to decoders._DECODE_FNS functions once our API is firmed up.
@@ -75,5 +68,6 @@ _LOADERS = {
     "arrow": decoders._load_arrow,
     "bytes": bytes,
     "json": json.loads,
+    "native": cloudpickle.loads,
     "python_pickle": cloudpickle.loads,
 }


### PR DESCRIPTION
The previously-devised interchange format required lots of nested
objects, which became particularly acute for nested values.
As a simple example:

    {
      "__tiledb_sentinel__": {
        "some_kind": {"inner": "data"},
      }
    }

This update simplifies it by removing the inner nesting and shortening
the replacement key:

    {
      "__tdbudf__": "some_kind",
      "inner": "data"
    }

The old format has not actually been used by any other code, so changing
will *not* break anything. The new format can encode all data that the
old could.