### PR TITLE
Be less paitent when waiting for a DAG to complete.

### DIFF
--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -670,7 +670,7 @@ class DAG:
         if timeout is not None:
             end_time = start_time + timeout
         while not self.done():
-            time.sleep(0.5)
+            time.sleep(0.01)
             if end_time is not None and time.time() >= end_time:
                 raise TimeoutError(
                     "timeout of {} reached and dag is not complete".format(timeout)


### PR DESCRIPTION
Because we're only waiting on ourselves, it's completely reasonable to
poll for completion fairly frequently. It's extremely cheap and it's
not interfering with anybody else.

The ideal solution would be to use an Event that was set, but getting
that to work would be much more invasive.