### PR TITLE
Do Not Pass to `make_range` if Range is a NumPy Array

### DIFF
--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -299,7 +299,6 @@ def array_activity(uri, async_req=False):
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
-
 def parse_ranges(ranges):
     """
     Takes a list of the following objects per dimension:
@@ -340,15 +339,16 @@ def parse_ranges(ranges):
             end = end.astype("int64").item()
 
         return [start, end]
-
+    
     result = list()
     for dim_idx, dim_range in enumerate(ranges):
         dim_list = []
-        # TODO handle numpy scalars here?
-        if isinstance(
+        if isinstance(dim_range, numpy.ndarray):
+            dim_list = dim_range.tolist()
+        elif isinstance(
             dim_range, (int, float, tuple, slice, numpy.datetime64, numpy.timedelta64)
         ):
-            dim_list.extend(make_range(dim_range))
+            dim_list = make_range(dim_range)
         elif isinstance(dim_range, list):
             for r in dim_range:
                 dim_list.extend(make_range(r))
@@ -360,7 +360,7 @@ def parse_ranges(ranges):
                 ", idx: '{}', value: '{}')".format(type(dim_range), dim_idx, dim_range)
             )
         result.append(dim_list)
-
+    
     return result
 
 

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -299,6 +299,7 @@ def array_activity(uri, async_req=False):
     except GenApiException as exc:
         raise tiledb_cloud_error.check_exc(exc) from None
 
+
 def parse_ranges(ranges):
     """
     Takes a list of the following objects per dimension:
@@ -339,7 +340,7 @@ def parse_ranges(ranges):
             end = end.astype("int64").item()
 
         return [start, end]
-    
+
     result = list()
     for dim_idx, dim_range in enumerate(ranges):
         dim_list = []
@@ -360,7 +361,7 @@ def parse_ranges(ranges):
                 ", idx: '{}', value: '{}')".format(type(dim_range), dim_idx, dim_range)
             )
         result.append(dim_list)
-    
+
     return result
 
 


### PR DESCRIPTION
* This is a shortcut way to optimize the `parse_range` function