### PR TITLE
Add a `json_safe.Value` sentinel type for API serialization.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,7 @@ from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import tasks
 from tiledb.cloud import tiledb_cloud_error
+from tiledb.cloud._results import json_safe
 
 tiledb.cloud.login(
     token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
@@ -279,36 +280,36 @@ class BasicTests(unittest.TestCase):
 
 class RangesTest(unittest.TestCase):
     def test_parse_ranges(self):
-        parse_ranges = lambda x: array.parse_ranges(x)
+        parse_ranges = array.parse_ranges
 
         a = [1]
         b = [[1, 1]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [1, 2]
         b = [[1, 1], [2, 2]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [[1, 2], 3]
         b = [[1, 1, 2, 2], [3, 3]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         # tuples
         a = [1, (1, 2)]
         b = [[1, 1], [1, 2]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [1, [(1, 2)]]
         b = [[1, 1], [1, 2]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [1, [slice(1, 2)]]
         b = [[1, 1], [1, 2]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [1, slice(2, 3)], [(1, 2), 4]
         b = [[1, 1, 2, 3], [1, 2, 4, 4]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [
             [
@@ -324,7 +325,7 @@ class RangesTest(unittest.TestCase):
             ),
         ]
         b = [[15372, 18627, 25724, 25724], [1328140800000000000, 1609372800000000000]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [
             [
@@ -340,7 +341,7 @@ class RangesTest(unittest.TestCase):
             ),
         ]
         b = [[15372, 18627, 25724, 25724], [1328140800000000000, 1609372800000000000]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [
             [
@@ -356,30 +357,30 @@ class RangesTest(unittest.TestCase):
             ),
         ]
         b = [[2012, 2020, 6, 6], [1440000000000, 7200000000000]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         start = numpy.datetime64("2019-07-01T00:00:00")
         end = numpy.datetime64("2019-08-01T23:59:59")
         weeks = numpy.arange(start, end, np.timedelta64(1, "W"))
         a = [weeks[0], weeks[1]]
         b = [[1561939200, 1561939200], [1562544000, 1562544000]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [None, [(1, 2), 4]]
         b = [[], [1, 2, 4, 4]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [[], [(1, 2), 4]]
         b = [[], [1, 2, 4, 4]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [(), [(1, 2), 4]]
         b = [[], [1, 2, 4, 4]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         a = [[1, 2, 3], [(1, 2), 4]]
         b = [[1, 1, 2, 2, 3, 3], [1, 2, 4, 4]]
-        self.assertEqual(parse_ranges(a), b)
+        self.assertEqual(parse_ranges(a), json_safe.Value(b))
 
         with self.assertRaises(ValueError):
             parse_ranges(["idx"])

--- a/tiledb/cloud/_results/json_safe.py
+++ b/tiledb/cloud/_results/json_safe.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+import attrs
+
+
+@attrs.define(frozen=True, slots=True)
+class Value:
+    """Sentinel for a value that is known to be JSON-serializable.
+
+    In cases where you know we're generating JSON-safe values where the
+    generated API client does not need to recurse into this to look for more
+    values that need to be converted into JSON, you can wrap the variable
+    you're generating into this.
+    """
+
+    value: Any

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -9,6 +9,7 @@ from tiledb.cloud import client
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud._results import decoders
+from tiledb.cloud._results import json_safe
 from tiledb.cloud._results import results
 from tiledb.cloud._results import sender
 from tiledb.cloud.rest_api import ApiException as GenApiException
@@ -44,10 +45,10 @@ class ArrayList:
         elif layout.upper() == "U":
             converted_layout = "unordered"
 
-        parse_ranges(ranges)  # check that the ranges are parseable.
+        parsed = parse_ranges(ranges)  # check that the ranges are parseable.
         udf_array_details = models.UDFArrayDetails(
             uri=uri,
-            ranges=models.QueryRanges(layout=converted_layout, ranges=ranges),
+            ranges=models.QueryRanges(layout=converted_layout, ranges=parsed),
             buffers=buffers,
         )
         self.arrayList.append(udf_array_details)
@@ -361,7 +362,7 @@ def parse_ranges(ranges):
             )
         result.append(dim_list)
 
-    return result
+    return json_safe.Value(result)
 
 
 def apply_base(

--- a/tiledb/cloud/rest_api/api_client.py
+++ b/tiledb/cloud/rest_api/api_client.py
@@ -25,6 +25,7 @@ from dateutil.parser import parse
 from six.moves.urllib.parse import quote
 
 import tiledb.cloud.rest_api.models
+from tiledb.cloud._results import json_safe
 from tiledb.cloud.rest_api import rest
 from tiledb.cloud.rest_api.configuration import Configuration
 from tiledb.cloud.rest_api.exceptions import ApiException
@@ -251,6 +252,8 @@ class ApiClient(object):
         """
         if obj is None:
             return None
+        elif isinstance(obj, json_safe.Value):
+            return obj.value
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
         elif isinstance(obj, list):

--- a/update_generated.sh
+++ b/update_generated.sh
@@ -108,3 +108,29 @@ for command in isort black; do
     "${command}" "${ROOT}"
   fi
 done
+
+# Apply an api_client patch to avoid descending into known–JSON-safe values.
+git apply - <<EOF
+diff --git a/tiledb/cloud/rest_api/api_client.py b/tiledb/cloud/rest_api/api_client.py
+index 267385d..6d244a0 100644
+--- a/tiledb/cloud/rest_api/api_client.py
++++ b/tiledb/cloud/rest_api/api_client.py
+@@ -25,6 +25,7 @@ from dateutil.parser import parse
+ from six.moves.urllib.parse import quote
+ 
+ import tiledb.cloud.rest_api.models
++from tiledb.cloud._results import json_safe
+ from tiledb.cloud.rest_api import rest
+ from tiledb.cloud.rest_api.configuration import Configuration
+ from tiledb.cloud.rest_api.exceptions import ApiException
+@@ -251,6 +252,8 @@ class ApiClient(object):
+         """
+         if obj is None:
+             return None
++        elif isinstance(obj, json_safe.Value):
++            return obj.value
+         elif isinstance(obj, self.PRIMITIVE_TYPES):
+             return obj
+         elif isinstance(obj, list):
+EOF
+


### PR DESCRIPTION
This avoids the API client from descending through values that we know
are already validly prepared for JSON serialization (i.e., only dicts,
lists, strings, and numbers) to look for its own `models.*` types.
For instance, currently if we have a call like

    call_some_api(ranges=[list, of, a, million, ints, ...])

the generated client will look inside each of `ranges` to see if
any of those million ints are in fact some object that it knows about.
But with this change, we can say:

    call_some_api(
        ranges=json_safe.Value([list, of, a, million, ints, ...]),
    )

and the generated client will just use that list and assume that it has
already been sanitized.