### PR TITLE
Use TILEDB_REST_TOKEN to store TileDB Cloud login info.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pytest -s -v --junitxml=junit/test-results.xml --cov=tiledb/cloud/ --cov-report=xml --cov-report=html
         env:
-          TILEDB_CLOUD_HELPER_VAR: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
+          TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import uuid
 
@@ -13,11 +12,6 @@ from tiledb.cloud import client
 from tiledb.cloud import tasks
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud._results import json_safe
-
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
 
 
 class BasicTests(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -2,7 +2,6 @@ import base64
 import collections
 import collections.abc as cabc
 import itertools
-import os
 import pickle
 import threading
 import time
@@ -25,11 +24,6 @@ from tiledb.cloud._results import stored_params as sp
 from tiledb.cloud._results import visitor
 from tiledb.cloud.dag import dag as dag_dag
 from tiledb.cloud.rest_api import models
-
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
 
 
 class DAGClassTest(unittest.TestCase):

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -1,4 +1,3 @@
-import os
 import time
 import unittest
 
@@ -10,11 +9,6 @@ from tiledb.cloud.compute import Delayed
 from tiledb.cloud.compute import DelayedArrayUDF
 from tiledb.cloud.compute import DelayedSQL
 from tiledb.cloud.compute import Status
-
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
 
 
 class DelayedClassTest(unittest.TestCase):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,11 +5,6 @@ import unittest
 import tiledb
 import tiledb.cloud
 
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
-
 
 class FileTests(unittest.TestCase):
     def test_simple_file_export(self):

--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import unittest
 
@@ -13,11 +12,6 @@ from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import udf
 from tiledb.cloud import utils
 from tiledb.cloud.rest_api import models
-
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
 
 
 class GenericUDFTest(unittest.TestCase):

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,21 +1,7 @@
-import os
-import platform
-import sys
 import unittest
-
-import numpy as np
 
 import tiledb
 import tiledb.cloud
-from tiledb.cloud import array
-from tiledb.cloud import client
-from tiledb.cloud import tasks
-from tiledb.cloud import tiledb_cloud_error
-
-tiledb.cloud.login(
-    token=os.environ["TILEDB_CLOUD_HELPER_VAR"],
-    host=os.environ.get("TILEDB_CLOUD_REST_HOST", None),
-)
 
 
 class BasicTests(unittest.TestCase):


### PR DESCRIPTION
Removes the need for the special `TILEDB_CLOUD_HELPER_VAR` environment
variable and makes it possible to run unit tests that do not use
the network without them failing.