### PR TITLE
Update warning message when unable to submit task graph logs.

### DIFF
--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -394,7 +394,7 @@ class DAG:
                     # This should not abort the task graph.
 
                     warnings.warn(
-                        UserWarning(f"Error submitting task graph logging info: {apix}")
+                        UserWarning(f"Could not submit logging metadata: {apix}")
                     )
                 else:
                     try:


### PR DESCRIPTION
Failing to submit a task graph log is not a hard failure, but the error
message might have made it look like the graph could not be executed.