### PR TITLE
Create basic types and codec for task graph registration.

### DIFF
--- a/tests/taskgraphs/test_codec.py
+++ b/tests/taskgraphs/test_codec.py
@@ -5,8 +5,8 @@ import unittest
 from tiledb.cloud.taskgraphs import _codec
 
 
-class TestUnescaper(unittest.TestCase):
-    def test_unescaping(self):
+class EscapingTest(unittest.TestCase):
+    def test_bidirectional(self):
         cases = (
             (
                 "simple",
@@ -99,9 +99,74 @@ class TestUnescaper(unittest.TestCase):
             ),
         )
 
-        for name, inp, expected in cases:
-            with self.subTest(name):
-                decoded_input = json.loads(inp)
+        for name, json_text, native_value in cases:
+            json_data = json.loads(json_text)
+            with self.subTest(f"unescaping {name}"):
                 unesc = _codec.Unescaper()
-                actual = unesc.visit(decoded_input)
-                self.assertEqual(expected, actual)
+                actual = unesc.visit(json_data)
+                self.assertEqual(native_value, actual)
+
+            with self.subTest(f"escaping {name}"):
+                esc = _codec.Escaper()
+                actual = esc.visit(native_value)
+                self.assertEqual(json_data, actual)
+
+    def test_json_encodable(self):
+        data = _codec.BinaryResult("bytes", b"now")
+        esc = _codec.Escaper()
+        in_data = ["one", data, 2]
+        expected = [
+            "one",
+            {"__tdbudf__": "immediate", "format": "bytes", "base64_data": "bm93"},
+            2,
+        ]
+        self.assertEqual(expected, esc.visit(in_data))
+
+
+class BinaryResultTest(unittest.TestCase):
+    def test_binary_result_of(self):
+        cases = (
+            (b"possession", _codec.BinaryResult("bytes", b"possession")),
+            (
+                frozenset(),
+                _codec.BinaryResult(
+                    "python_pickle",
+                    b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00(\x91\x94.",
+                ),
+            ),
+        )
+        for inval, expected in cases:
+            with self.subTest(inval):
+                self.assertEqual(expected, _codec.BinaryResult.of(inval))
+
+
+class JSONableTest(unittest.TestCase):
+    def test_yes(self):
+        cases = [
+            "I'm a string",
+            1234,
+            999.999,
+            True,
+            dict(),
+            None,
+            {"string key": frozenset()},
+            ["a", len],
+            (),
+        ]
+        for case in cases:
+            with self.subTest(case):
+                self.assertTrue(_codec.is_jsonable_shallow(case))
+
+    def test_no(self):
+        cases = [
+            b"i am bytes",
+            set(),
+            {b"non-string key": object()},
+            object(),
+            range(1000),
+            complex(1, 2),
+            Ellipsis,
+        ]
+        for case in cases:
+            with self.subTest(case):
+                self.assertFalse(_codec.is_jsonable_shallow(case))

--- a/tests/taskgraphs/test_codec.py
+++ b/tests/taskgraphs/test_codec.py
@@ -130,7 +130,13 @@ class BinaryResultTest(unittest.TestCase):
     def test_binary_result_of(self):
         cases = (
             (b"possession", _codec.BinaryResult("bytes", b"possession")),
-            (set(), _codec.BinaryResult("python_pickle", b"\x80\x04\x8f\x94.")),
+            (
+                frozenset(),
+                _codec.BinaryResult(
+                    "python_pickle",
+                    b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00(\x91\x94.",
+                ),
+            ),
             (pyarrow.Table.from_pydict({}), _codec.BinaryResult("arrow", b"")),
         )
         for inval, expected in cases:

--- a/tests/taskgraphs/test_types.py
+++ b/tests/taskgraphs/test_types.py
@@ -1,0 +1,9 @@
+import unittest
+
+from tiledb.cloud.taskgraphs import types
+
+
+class TestTypes(unittest.TestCase):
+    def test_args(self):
+        args = types.args(1, "A", b=frozenset())
+        self.assertEqual(args, types.Arguments((1, "A"), {"b": frozenset()}))

--- a/tests/taskgraphs/test_types.py
+++ b/tests/taskgraphs/test_types.py
@@ -5,5 +5,9 @@ from tiledb.cloud.taskgraphs import types
 
 class TestTypes(unittest.TestCase):
     def test_args(self):
-        args = types.args(1, "A", b=frozenset())
-        self.assertEqual(args, types.Arguments((1, "A"), {"b": frozenset()}))
+        args = types.args(1, "A", b=frozenset(), c=b"d")
+        self.assertEqual(
+            args,
+            types.Arguments((1, "A"), {"b": frozenset(), "c": b"d"}),
+        )
+        self.assertEqual("args(1, 'A', b=frozenset(), c=b'd')", repr(args))

--- a/tiledb/cloud/taskgraphs/_codec.py
+++ b/tiledb/cloud/taskgraphs/_codec.py
@@ -142,7 +142,7 @@ class BinaryResult(TDBJSONEncodable):
     """
 
     format: str
-    """The format of the data."""
+    """The TileDB Cloud name of the data's format (see ``_MIME_TO_FORMAT``)."""
     data: bytes
     """The binary data itself."""
 

--- a/tiledb/cloud/taskgraphs/_codec.py
+++ b/tiledb/cloud/taskgraphs/_codec.py
@@ -1,33 +1,54 @@
+import abc
 import base64
 import json
 from typing import Any, Dict, Optional, TypeVar, Union
 
+import attrs
 import cloudpickle
+import pyarrow
+import urllib3
 
 from tiledb.cloud._results import decoders
 from tiledb.cloud._results import visitor
+from tiledb.cloud.taskgraphs import types
 
 _T = TypeVar("_T")
 TOrDict = Union[_T, Dict[str, Any]]
-_SENTINEL_KEY = "__tdbudf__"
-_ESCAPE_CODE = "__escape__"
+
+_PICKLE_PROTOCOL = 4
+_ARROW_VERSION = pyarrow.MetadataVersion.V5
+SENTINEL_KEY = "__tdbudf__"
+ESCAPE_CODE = "__escape__"
+
+
+class TDBJSONEncodable(metaclass=abc.ABCMeta):
+    """Interface defining a type that can be encoded into TileDB JSON."""
+
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def _tdb_to_json(self):
+        """Converts this object to a JSON-serializable form."""
+        raise NotImplementedError()
 
 
 class Unescaper(visitor.ReplacingVisitor):
     """A general-purpose replacer to unescape sentinel-containing structures.
 
     This descends through data structures and replaces dictionaries containing
-    ``__tiledb_sentinel__`` values with the unescaped values. This base
-    implementation handles only the basics; you can create a derived version
-    to handle specific situations (building arguments, replacing values, etc.).s
+    ``__tdbudf__`` values with the unescaped values. This base implementation
+    handles only the basics; you can create a derived version to handle specific
+    situations (building arguments, replacing values, etc.).
+
+    The data that is returned from this is generally a ``types.NativeValue``.
     """
 
     def maybe_replace(self, arg) -> Optional[visitor.Replacement]:
         if not isinstance(arg, dict):
             return None
-        if _SENTINEL_KEY not in arg:
+        if SENTINEL_KEY not in arg:
             return None
-        sentinel_name = arg[_SENTINEL_KEY]
+        sentinel_name = arg[SENTINEL_KEY]
         return self._replace_sentinel(sentinel_name, arg)
 
     def _replace_sentinel(
@@ -49,9 +70,9 @@ class Unescaper(visitor.ReplacingVisitor):
         keys and end with a call to
         ``return super()._replace_sentinel(kind, value)``.
         """
-        if kind == _ESCAPE_CODE:
+        if kind == ESCAPE_CODE:
             # An escaped value.
-            inner_value = value[_ESCAPE_CODE]
+            inner_value = value[ESCAPE_CODE]
             return visitor.Replacement(
                 {k: self.visit(v) for (k, v) in inner_value.items()}
             )
@@ -63,6 +84,44 @@ class Unescaper(visitor.ReplacingVisitor):
         raise ValueError(f"Unknown sentinel type {kind!r}")
 
 
+class Escaper(visitor.ReplacingVisitor):
+    """Turns arbitrary Python values into TileDB JSON.
+
+    This escapes arbitrary native values so that they can be JSON-serialized.
+    It should only be used with ``NativeValue``s—that is, values that are
+    already JSON-serializable, like ``RegisteredArg``s or ``CallArg``s, should
+    *not* be passed to an ``Escaper``. The base implementation will return
+    fully self-contained JSON-serializable objects, i.e. ``CallArg``s.
+    """
+
+    def maybe_replace(self, arg) -> Optional[visitor.Replacement]:
+        if isinstance(arg, TDBJSONEncodable):
+            return visitor.Replacement(arg._tdb_to_json())
+        if is_jsonable_shallow(arg):
+            if isinstance(arg, dict):
+                if SENTINEL_KEY in arg:
+                    return visitor.Replacement(
+                        {
+                            SENTINEL_KEY: ESCAPE_CODE,
+                            ESCAPE_CODE: {k: self.visit(v) for (k, v) in arg.items()},
+                        }
+                    )
+            return None
+        return visitor.Replacement(BinaryResult.of(arg)._tdb_to_json())
+
+
+_MIME_TO_FORMAT = {
+    "application/octet-stream": "bytes",
+    "application/json": "json",
+    "application/vnd.tiledb.python-pickle": "python_pickle",
+    "application/vnd.tiledb.r-serialization": "r_serialization",
+    "application/vnd.apache.arrow.stream": "arrow",
+    # TODO: The server should stop returning "udf-native" as a type soon.
+    # After that, we can remove this entry, since it's ambiguous for non-Python
+    # UDFs.
+    "application/vnd.tiledb.udf-native": "python_pickle",
+}
+
 # TODO: Move these to decoders._DECODE_FNS functions once our API is firmed up.
 _LOADERS = {
     "arrow": decoders._load_arrow,
@@ -71,3 +130,102 @@ _LOADERS = {
     "native": cloudpickle.loads,
     "python_pickle": cloudpickle.loads,
 }
+
+
+@attrs.define(frozen=True, slots=False)
+class BinaryResult(TDBJSONEncodable):
+    """Container for a binary-encoded value, decoded on-demand.
+
+    This is used to store results obtained from the server, such that it is not
+    necessary to decode them between stages, and they only are decoded upon
+    request.
+    """
+
+    format: str
+    """The format of the data."""
+    data: bytes
+    """The binary data itself."""
+
+    @classmethod
+    def from_response(cls, resp: urllib3.HTTPResponse) -> "BinaryResult":
+        """Reads a urllib3 response into an encoded result."""
+        full_mime = resp.getheader("Content-type", "application/octet-stream")
+        mime, _, _ = full_mime.partition(";")
+        mime = mime.strip()
+        format = _MIME_TO_FORMAT.get(mime, "mime:" + mime)
+        data = resp.data
+        return cls(format, data)
+
+    def decode(self) -> types.NativeValue:
+        """Decodes this result into native Python data."""
+        # This is not lock-protected because we're ok with decoding twice.
+        try:
+            return self.__dict__["_decoded"]
+        except KeyError:
+            pass
+        try:
+            loader = _LOADERS[self.format]
+        except KeyError:
+            raise ValueError(f"Cannot decode {self.format!r} data")
+        self.__dict__["_decoded"] = loader(self.data)
+        return self.__dict__["_decoded"]
+
+    def _tdb_to_json(self) -> types.CallArg:
+        return {
+            "__tdbudf__": "immediate",
+            "format": self.format,
+            "base64_data": base64.b64encode(self.data).decode("ascii"),
+        }
+
+    @classmethod
+    def of(cls, obj: Any) -> "BinaryResult":
+        """Turns a non–JSON-encodable object into a ``BinaryResult``."""
+        if isinstance(obj, bytes):
+            return cls("bytes", obj)
+        if isinstance(obj, pyarrow.Table):
+            return cls("arrow", _arrow_to_bytes(obj))
+        return cls("python_pickle", pickle(obj))
+
+
+def _arrow_to_bytes(tbl: pyarrow.Table) -> bytes:
+    sink = pyarrow.BufferOutputStream()
+    writer = pyarrow.RecordBatchStreamWriter(
+        sink,
+        tbl.schema,
+        options=pyarrow.ipc.IpcWriteOptions(
+            metadata_version=_ARROW_VERSION,
+            compression="zstd",
+        ),
+    )
+    writer.write(tbl)
+    return sink.getvalue()
+
+
+def pickle(obj) -> bytes:
+    return cloudpickle.dumps(obj, protocol=_PICKLE_PROTOCOL)
+
+
+def b64_str(val: bytes) -> str:
+    return base64.b64encode(val).decode("ascii")
+
+
+_NATIVE_JSONABLE = (
+    str,
+    int,
+    bool,
+    float,
+    type(None),
+    list,
+    tuple,
+)
+"""Types whose direct values can always be turned into JSON."""
+
+
+def is_jsonable_shallow(obj) -> bool:
+    if isinstance(obj, _NATIVE_JSONABLE):
+        return True
+    if not isinstance(obj, dict):
+        # Apart from the above types, only dicts are JSONable.
+        return False
+    # For a dict to be JSONable, all keys must be strings.
+    return all(isinstance(key, str) for key in obj)

--- a/tiledb/cloud/taskgraphs/types.py
+++ b/tiledb/cloud/taskgraphs/types.py
@@ -1,5 +1,6 @@
 """User-facing types used in task graphs."""
 
+import itertools
 from typing import Any, Dict, List, Tuple, TypeVar, Union
 
 import attrs
@@ -51,8 +52,25 @@ class Arguments:
 
     @classmethod
     def of(cls, *args, **kwargs) -> "Arguments":
-        """Creates an Arguments object representing the given call."""
+        """Creates an Arguments object representing the given call.
+
+        Calling this with any parameters will give you an ``Arguments``
+        representing that call:
+
+        >>> Arguments.of(1, 2, a=1, b="two", **{"c": b"four"})
+        args(1, 2, a=1, b="two", c=b"four")
+
+        """
         return cls(args, kwargs)
+
+    def __repr__(self):
+        """A representation of this which looks like a function call."""
+        parts = itertools.chain(
+            map(repr, self.args),
+            (f"{k}={v!r}" for (k, v) in self.kwargs.items()),
+        )
+        joined = ", ".join(parts)
+        return f"args({joined})"
 
 
 args = Arguments.of

--- a/tiledb/cloud/taskgraphs/types.py
+++ b/tiledb/cloud/taskgraphs/types.py
@@ -1,0 +1,58 @@
+"""User-facing types used in task graphs."""
+
+from typing import Any, Dict, List, Tuple, TypeVar, Union
+
+import attrs
+
+_T = TypeVar("_T")
+NativeSequence = Union[Tuple[_T, ...], List[_T]]
+"""Either of Python's built-in sequences."""
+
+# Aliases to clarify how data is managed through the lifecycle of building
+# and executing a task graph.
+
+NativeValue = Any
+"""Any *native* Python value, as opposed to one encoded into JSON."""
+
+RegisteredArg = Any
+"""JSON-encodable values ready for writing into a registered task graph.
+
+These values are JSON-encodable and may contain
+``{"__tdbudf__": "node_output"}`` dictionaries as references to upstream nodes
+in their graph.
+"""
+
+CallArgStoredParams = Any
+"""JSON-encodable params ready for calling the server (with stored params).
+
+These values are JSON-encodable and may contain
+``{"__tdbudf__": "stored_param"}`` dictionaries as references to
+previously-executed task graph nodes.
+"""
+
+CallArg = Any
+"""JSON-encodable params ready for calling the server (with values).
+
+These values are JSON-encoded but will have all the information necessary
+to decode them contained within their data.
+"""
+
+
+@attrs.define(frozen=True, slots=True)
+class Arguments:
+    """The arguments and keyword arguments that can be sent to a function.
+
+    You usually shouldn't call the constructor directly; instead use
+    :meth:``of``.
+    """
+
+    args: tuple = ()
+    kwargs: Dict[str, Any] = attrs.Factory(dict)
+
+    @classmethod
+    def of(cls, *args, **kwargs) -> "Arguments":
+        """Creates an Arguments object representing the given call."""
+        return cls(args, kwargs)
+
+
+args = Arguments.of


### PR DESCRIPTION
This change introduces the basic types that will be used throughout the
task graph registration process, and some basic codecs to transform
Python data back and forth into JSON. The types defined here support
the major encoding needs of a task graph:

- `RegisteredArg`

  "At-rest" encoding, where the nodes are serialized into a
  `RegisteredTaskGraph`. In this case, parameters are stored with
  references to previous nodes in the form of:

      {"__tdbudf__": "node_output", "client_node_id": "..."}

  This allows an executor to reconstruct the graph and substitute in
  stored values when necessary.

- `CallArgStoredParams`

  "Stored parameter" encoding, where nodes are referred to by the
  server-provided execution ID.

      {"__tdbudf__": "stored_param", "task_id": "..."}

  The `task_id` here is the server-generated task ID from performing
  the query. Parameters may also include arrays:

      {"__tdbudf__": "udf_array_details", "udf_array_details": {...}}

  When a UDF is executed, these are sent by the client to the server.

- `CallArg`

  An alternate encoding for when stored parameters are not available.
  Data encoded in this format does not include any `stored_param`
  objects (but still may include `udf_array_details`, since those are
  guaranteed to be loaded by the server). Beyond the
  `udf_array_details`, an `Unescaper` should be able to deserialize
  `CallArg` data on its own.

This builds upon the format first defined in
2c3312e70b76efc21cdd339b03f7fa4b4766cd09.

---

[ch-14031]