### PR TITLE
Add `copy`, `roots`, and `leaves` methods to DepGraph.

### DIFF
--- a/tests/taskgraphs/test_depgraph.py
+++ b/tests/taskgraphs/test_depgraph.py
@@ -119,7 +119,7 @@ class TestDepGraph(unittest.TestCase):
         self.assertEqual((True, False), g.leaves())
 
     def test_copy(self):
-        old = depgraph.DepGraph[int]()
+        old: depgraph.DepGraph[int] = depgraph.DepGraph()
         old.add_new_node(1, ())
         old.add_new_node(2, ())
         old.add_new_node(3, (1, 2))

--- a/tiledb/cloud/taskgraphs/depgraph.py
+++ b/tiledb/cloud/taskgraphs/depgraph.py
@@ -17,10 +17,35 @@ class DepGraph(Generic[_T]):
         self._topo_sorted: List[_T] = []
         """A topologically-sorted list of nodes."""
 
+    def copy(self) -> "DepGraph[_T]":
+        """Makes an independent "deep" copy of this DepGraph.
+
+        The new graph can be edited without affecting this graph.
+        """
+        new = DepGraph[_T]()
+        new._parent_to_children = {
+            k: set(v) for (k, v) in self._parent_to_children.items()
+        }
+        new._child_to_parents = {k: set(v) for (k, v) in self._child_to_parents.items()}
+        new._topo_sorted = list(self._topo_sorted)
+        return new
+
     @property
     def topo_sorted(self) -> Tuple[_T, ...]:
         """A topologically-sorted view of the dependency graph."""
         return tuple(self._topo_sorted)
+
+    def roots(self) -> Tuple[_T, ...]:
+        """Returns the nodes of this graph with no ancestors."""
+        return tuple(
+            n for (n, parents) in self._child_to_parents.items() if not parents
+        )
+
+    def leaves(self) -> Tuple[_T, ...]:
+        """Returns the nodes of this graph with no descendants."""
+        return tuple(
+            n for (n, children) in self._parent_to_children.items() if not children
+        )
 
     def add_new_node(self, child: _T, parents: Iterable[_T]) -> None:
         """Adds a new child to the graph, where all parents exist."""


### PR DESCRIPTION
Making a copy of a DepGraph means the copy can be mutated, so we can
use it to track execution progress while actively running a graph.
As execution continues, we can remove completed nodes from the graph
and use the `roots` to track nodes which are ready to run.