### PR TITLE
Move `testonly` package from `tiledb.cloud` into `tests`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 PACKAGES = ["tiledb.cloud"]
 PACKAGES.extend(
-    "tiledb.cloud." + x for x in find_packages("./tiledb/cloud", exclude=("testonly",))
+    "tiledb.cloud." + x for x in find_packages("./tiledb/cloud")
 )
 VIZ_REQUIRES = ["networkx>=2", "pydot"]
 TILEDB_VIZ_REQUIRES = ["tiledb-plot-widget>=0.1.7", *VIZ_REQUIRES]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,8 +1,3 @@
-"""This module should only be imported from tests.
-
-IT WILL NOT BE INCLUDED when installing TileDB Cloud.
-"""
-
 import contextlib
 import random
 import string

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import tiledb.cloud
-from tiledb.cloud import testonly
+from tests import helpers
 from tiledb.cloud.compute import Delayed
 from tiledb.cloud.compute import DelayedArrayUDF
 from tiledb.cloud.compute import DelayedSQL
@@ -162,7 +162,7 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
             return numpy.sum(x["a"])
 
-        with testonly.register_udf(sum_a) as sum_a_name:
+        with helpers.register_udf(sum_a) as sum_a_name:
             node = DelayedArrayUDF(uri, sum_a_name, name="node")([(1, 4), (1, 4)])
 
             # Add timeout so we don't wait forever in CI
@@ -264,7 +264,7 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
             return numpy.sum(x["a"])
 
-        with testonly.register_udf(sum_a) as sum_a_name:
+        with helpers.register_udf(sum_a) as sum_a_name:
             node_array_apply = DelayedArrayUDF(
                 uri_sparse, sum_a_name, name="node_array_apply"
             )([(1, 4), (1, 4)])

--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -5,9 +5,9 @@ import numpy as np
 import urllib3
 
 import tiledb.cloud
+from tests import helpers
 from tiledb.cloud import client
 from tiledb.cloud import config
-from tiledb.cloud import testonly
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import udf
 from tiledb.cloud import utils
@@ -54,7 +54,7 @@ class GenericUDFTest(unittest.TestCase):
             """Function created to call by name in unit tests."""
             return f"called with {args!r} {kwargs!r}"
 
-        with testonly.register_udf(show) as udf_name:
+        with helpers.register_udf(show) as udf_name:
             got = udf.exec(udf_name, 1, 2, 3, easy_as="abc")
         self.assertEqual(got, "called with (1, 2, 3) {'easy_as': 'abc'}")
 
@@ -63,7 +63,7 @@ class GenericUDFTest(unittest.TestCase):
             """Function created to call by name in unit tests."""
             return f"called with {args!r} {kwargs!r}"
 
-        with testonly.register_udf(show) as udf_name:
+        with helpers.register_udf(show) as udf_name:
             first = udf.exec_base(
                 udf_name,
                 1,


### PR DESCRIPTION
I'm not sure if I just missed doing this when I was first creating it
or doing this didn't work right with pytest at the time, but this does
work now, and it means we no longer pollute `tiledb.cloud` with
code that should not be used by end users.