### PR TITLE
Add utils.PYTHON_VERSION and test UUID generator.

### DIFF
--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import numpy as np
@@ -87,11 +86,7 @@ class GenericUDFTest(unittest.TestCase):
             udf_req = models.GenericUDF(
                 language=models.UDFLanguage.PYTHON,
                 result_format=models.ResultFormat.JSON,
-                version="{}.{}.{}".format(
-                    sys.version_info.major,
-                    sys.version_info.minor,
-                    sys.version_info.micro,
-                ),
+                version=utils.PYTHON_VERSION,
                 image_name="default",
                 udf_info_name=udf_name,
                 argument=pickled,

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -1,4 +1,3 @@
-import sys
 import uuid
 import warnings
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
@@ -473,11 +472,7 @@ def apply_base(
                 buffers=attrs,
             )
         ],
-        version="{}.{}.{}".format(
-            sys.version_info.major,
-            sys.version_info.minor,
-            sys.version_info.micro,
-        ),
+        version=utils.PYTHON_VERSION,
         image_name=image_name,
         task_name=task_name,
         result_format=result_format,
@@ -628,11 +623,7 @@ def exec_multi_array_udf_base(
     udf_model = models.MultiArrayUDF(
         language=models.UDFLanguage.PYTHON,
         arrays=arrays,
-        version="{}.{}.{}".format(
-            sys.version_info.major,
-            sys.version_info.minor,
-            sys.version_info.micro,
-        ),
+        version=utils.PYTHON_VERSION,
         image_name=image_name,
         task_name=task_name,
         result_format=result_format,

--- a/tiledb/cloud/testonly.py
+++ b/tiledb/cloud/testonly.py
@@ -6,10 +6,19 @@ IT WILL NOT BE INCLUDED when installing TileDB Cloud.
 import contextlib
 import random
 import string
+import uuid
 from typing import Callable, Iterator
 
 from tiledb.cloud import client
 from tiledb.cloud import udf
+
+
+def sequential_uuids(start: str) -> Iterator[uuid.UUID]:
+    """Generator for sequential UUIDs for use in mocks."""
+    current = uuid.UUID(hex=start)
+    while True:
+        yield current
+        current = uuid.UUID(int=current.int + 1)
 
 
 @contextlib.contextmanager

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -1,5 +1,4 @@
 import base64
-import sys
 import uuid
 import warnings
 from typing import Any, Callable, Iterable, Optional, Union
@@ -102,11 +101,7 @@ def exec_base(
         language=models.UDFLanguage.PYTHON,
         result_format=result_format,
         store_results=store_results,
-        version="{}.{}.{}".format(
-            sys.version_info.major,
-            sys.version_info.minor,
-            sys.version_info.micro,
-        ),
+        version=utils.PYTHON_VERSION,
         image_name=image_name,
         task_name=task_name,
         stored_param_uuids=list(str(uuid) for uuid in stored_param_uuids),
@@ -198,11 +193,7 @@ def register_udf(
         udf_model = models.UDFInfoUpdate(
             name=name,
             language=models.UDFLanguage.PYTHON,
-            version="{}.{}.{}".format(
-                sys.version_info.major,
-                sys.version_info.minor,
-                sys.version_info.micro,
-            ),
+            version=utils.PYTHON_VERSION,
             image_name=image_name,
             type=type,
             _exec=pickledUDF,
@@ -356,11 +347,7 @@ def update_udf(
         udf_model = models.UDFInfoUpdate(
             name=update_udf_name,
             language=models.UDFLanguage.PYTHON,
-            version="{}.{}.{}".format(
-                sys.version_info.major,
-                sys.version_info.minor,
-                sys.version_info.micro,
-            ),
+            version=utils.PYTHON_VERSION,
             image_name=image_name,
             license_id=license_text,
             license_text=license_id,

--- a/tiledb/cloud/utils.py
+++ b/tiledb/cloud/utils.py
@@ -1,6 +1,7 @@
 import base64
 import inspect
 import logging
+import sys
 import urllib
 from typing import Any, Callable, Optional, TypeVar
 
@@ -74,3 +75,7 @@ def b64_pickle(obj: Any) -> str:
     """Pickles the given object, then base64 encodes the pickle."""
     pickle = cloudpickle.dumps(obj, protocol=TILEDB_CLOUD_PROTOCOL)
     return base64.b64encode(pickle).decode("ascii")
+
+
+PYTHON_VERSION = ".".join(map(str, sys.version_info[:3]))
+"""The Python version as an ``X.Y.Z`` string."""


### PR DESCRIPTION
A small bit of prework for upcoming changes:

- Centralize construction of `X.Y.Z` Python version string.
- Create `testonly.sequential_uuids` generator function for mocks
  so that tests can have consistent UUIDs.