### PR TITLE
Create the thing that builds task graphs.

### DIFF
--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -1,6 +1,10 @@
+import operator
+import sys
 import unittest
 import uuid
 from unittest import mock
+
+import numpy
 
 from tiledb.cloud import testonly
 from tiledb.cloud import utils
@@ -193,3 +197,269 @@ class TestBuilder(unittest.TestCase):
             self.assertEqual(expected, grf._tdb_to_json())
             with self.assertRaises(depgraph.CyclicGraphError):
                 grf.add_dep(parent=result, child=length)
+
+    def test_complex(self):
+        uuid_factory = testonly.sequential_uuids("0badc0de-dead-beef-cafe-000000000000")
+        with mock.patch.object(uuid, "uuid4", side_effect=uuid_factory):
+            grf = builder.TaskGraphBuilder("it's complicated")
+
+            # All the functions we use in this test are from other modules.
+            # This means that they can be serialized by name rather than value.
+            # Using lambdas or other functions introduces environment-dependent
+            # file/line numbers into the pickles.  Verifying that user-written
+            # functions are properly serialized and executed takes place with a
+            # builder-to-executor round trip test.
+
+            # Use a user-provided input in the array read.
+            array_uri = grf.input("array_uri", "tiledb://TileDB-Inc/quickstart_dense")
+            array_query = grf.array_read(
+                array_uri,
+                raw_ranges=[[1, 1, 2, 4], []],
+                name="read an array",
+            )
+
+            # a chain equivalent to `lambda x: int(numpy.sum(x["a"]))`
+            get_a = grf.udf(operator.itemgetter("a"), types.args(array_query))
+            sum_it = grf.udf(numpy.sum, types.args(get_a))
+            intify = grf.udf(int, types.args(sum_it))
+
+            format_it = grf.udf(
+                "sum of {name!r} is {sum!r}".format,
+                types.args(name=array_uri, sum=intify),
+            )
+
+            # Execute an SQL query with parameterized input.
+            sql_input = grf.input("sql_value")
+            sql_node = grf.sql(
+                "select 2 * ? as doubleit",
+                parameters=[sql_input],
+                result_format="json",
+            )
+            # Artificially constrain `format_it` to run after `sql_node`.
+            grf.add_dep(parent=sql_node, child=format_it)
+
+            summary = grf.udf(
+                "array {!r} gave result {}; sql gave {}".format,
+                types.args(
+                    array_uri,
+                    format_it,
+                    sql_node,
+                ),
+                name="output",
+            )
+
+            grf.udf(
+                "TileDB-Inc/example_registration",
+                types.args(summary),
+                name="hello world",
+            )
+
+        # The pickle of the `itemgetter("a")` object above changes at py3.9.
+        # Both of these represent the same thing.
+        itemgetter_pickle = (
+            "gASVIgAAAAAAAACMCG9wZXJhdG9ylIwKaXRlbWdldHRlcpSTlIwBYZSFlFIu"
+            if sys.version_info < (3, 9)
+            else "gASVIwAAAAAAAACMCG9wZXJhdG9ylIwKaXRlbWdldHRlcpSTlIwBYZSFlFKULg=="
+        )
+
+        expected = {
+            "name": "it's complicated",
+            "nodes": [
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000000",
+                    "depends_on": [],
+                    "input_node": {
+                        "default_value": "tiledb://TileDB-Inc/quickstart_dense"
+                    },
+                    "name": "array_uri",
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000006",
+                    "depends_on": [],
+                    "input_node": {},
+                    "name": "sql_value",
+                },
+                {
+                    "array_node": {
+                        "buffers": None,
+                        "parameter_id": "0badc0de-dead-beef-cafe-000000000001",
+                        "ranges": [[1, 1, 2, 4], []],
+                        "uri": {
+                            "__tdbudf__": "node_output",
+                            "client_node_id": "0badc0de-dead-beef-cafe-000000000000",
+                        },
+                    },
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000001",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000000"],
+                    "name": "read an array",
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000007",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000006"],
+                    "name": None,
+                    "sql_node": {
+                        "init_commands": (),
+                        "parameters": [
+                            {
+                                "__tdbudf__": "node_output",
+                                "client_node_id": "0badc0de-dead-beef-cafe-000000000006",
+                            }
+                        ],
+                        "query": "select 2 * ? as doubleit",
+                        "result_format": "json",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000002",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000001"],
+                    "name": None,
+                    "udf_node": {
+                        "args": [
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000001",
+                                }
+                            }
+                        ],
+                        "environment": {
+                            "language": "python",
+                            "language_version": utils.PYTHON_VERSION,
+                        },
+                        "executable_code": itemgetter_pickle,
+                        "result_format": "python_pickle",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000003",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000002"],
+                    "name": None,
+                    "udf_node": {
+                        "args": [
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000002",
+                                }
+                            }
+                        ],
+                        "environment": {
+                            "language": "python",
+                            "language_version": utils.PYTHON_VERSION,
+                        },
+                        "executable_code": "gASVEQAAAAAAAACMBW51bXB5lIwDc3VtlJOULg==",
+                        "result_format": "python_pickle",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000004",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000003"],
+                    "name": None,
+                    "udf_node": {
+                        "args": [
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000003",
+                                }
+                            }
+                        ],
+                        "environment": {
+                            "language": "python",
+                            "language_version": utils.PYTHON_VERSION,
+                        },
+                        "executable_code": "gASVFAAAAAAAAACMCGJ1aWx0aW5zlIwDaW50lJOULg==",
+                        "result_format": "python_pickle",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000005",
+                    "depends_on": [
+                        "0badc0de-dead-beef-cafe-000000000000",
+                        "0badc0de-dead-beef-cafe-000000000004",
+                        "0badc0de-dead-beef-cafe-000000000007",
+                    ],
+                    "name": None,
+                    "udf_node": {
+                        "args": [
+                            {
+                                "name": "name",
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000000",
+                                },
+                            },
+                            {
+                                "name": "sum",
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000004",
+                                },
+                            },
+                        ],
+                        "environment": {
+                            "language": "python",
+                            "language_version": utils.PYTHON_VERSION,
+                        },
+                        "executable_code": "gASVQgAAAAAAAACMCGJ1aWx0aW5zlIwHZ2V0YXR0cpSTlIwac3VtIG9mIHtuYW1lIXJ9IGlzIHtzdW0hcn2UjAZmb3JtYXSUhpRSlC4=",
+                        "result_format": "python_pickle",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000008",
+                    "depends_on": [
+                        "0badc0de-dead-beef-cafe-000000000000",
+                        "0badc0de-dead-beef-cafe-000000000005",
+                        "0badc0de-dead-beef-cafe-000000000007",
+                    ],
+                    "name": "output",
+                    "udf_node": {
+                        "args": [
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000000",
+                                }
+                            },
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000005",
+                                }
+                            },
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000007",
+                                }
+                            },
+                        ],
+                        "environment": {
+                            "language": "python",
+                            "language_version": utils.PYTHON_VERSION,
+                        },
+                        "executable_code": "gASVTgAAAAAAAACMCGJ1aWx0aW5zlIwHZ2V0YXR0cpSTlIwmYXJyYXkgeyFyfSBnYXZlIHJlc3VsdCB7fTsgc3FsIGdhdmUge32UjAZmb3JtYXSUhpRSlC4=",
+                        "result_format": "python_pickle",
+                    },
+                },
+                {
+                    "client_node_id": "0badc0de-dead-beef-cafe-000000000009",
+                    "depends_on": ["0badc0de-dead-beef-cafe-000000000008"],
+                    "name": "hello world",
+                    "udf_node": {
+                        "args": [
+                            {
+                                "value": {
+                                    "__tdbudf__": "node_output",
+                                    "client_node_id": "0badc0de-dead-beef-cafe-000000000008",
+                                }
+                            }
+                        ],
+                        "environment": {},
+                        "registered_udf_name": "TileDB-Inc/example_registration",
+                        "result_format": "python_pickle",
+                    },
+                },
+            ],
+        }
+        self.assertEqual(expected, grf._tdb_to_json())

--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -1,0 +1,62 @@
+import unittest
+import uuid
+from unittest import mock
+
+from tiledb.cloud import testonly
+from tiledb.cloud.taskgraphs import builder
+
+
+class TestEscaper(unittest.TestCase):
+    maxDiff = None
+
+    def test_no_nodes(self):
+        cases = [
+            ("simple str", "simple str"),
+            (
+                b"blinding lights",
+                {
+                    "__tdbudf__": "immediate",
+                    "format": "bytes",
+                    "base64_data": "YmxpbmRpbmcgbGlnaHRz",
+                },
+            ),
+            (
+                {complex(1, 1): "complex"},
+                {
+                    "__tdbudf__": "immediate",
+                    "format": "python_pickle",
+                    "base64_data": (
+                        "gASVOwAAAAAAAAB9lIwIYnVpbHRpbnOUjAdjb21wbGV4lJOURz/"
+                        "wAAAAAAAARz/wAAAAAAAAhpRSlIwHY29tcGxleJRzLg=="
+                    ),
+                },
+            ),
+            (
+                {"__tdbudf__": "has tdbudf"},
+                {
+                    "__tdbudf__": "__escape__",
+                    "__escape__": {"__tdbudf__": "has tdbudf"},
+                },
+            ),
+        ]
+        for inval, expected in cases:
+            with self.subTest(inval):
+                self._do_test(inval, expected, ())
+
+    def _do_test(self, inval, expected, nodes):
+        esc = builder._ParameterEscaper()
+        actual = esc.visit(inval)
+        self.assertEqual(expected, actual)
+        self.assertEqual(frozenset(nodes), frozenset(esc.seen_nodes))
+
+
+class TestBuilder(unittest.TestCase):
+    maxDiff = None
+
+    def test_basic(self):
+        uuid_factory = testonly.sequential_uuids("09f91102-9d74-e35b-d841-000000000000")
+        with mock.patch.object(uuid, "uuid4", side_effect=uuid_factory):
+            grf = builder.TaskGraphBuilder(name="my cool task graph")
+            self.assertEqual(
+                {"name": "my cool task graph", "nodes": []}, grf._tdb_to_json()
+            )

--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -43,6 +43,61 @@ class TestEscaper(unittest.TestCase):
             with self.subTest(inval):
                 self._do_test(inval, expected, ())
 
+    def test_sub_nodes(self):
+        fake_id = uuid.UUID("6E767267-6F6E-6E61-6776-65796F757570")
+        with mock.patch.object(uuid, "uuid4", return_value=fake_id):
+            the_node = builder._InputNode("hello", "world")
+
+        self._do_test(
+            inval=["one", "two", the_node],
+            expected=[
+                "one",
+                "two",
+                {
+                    "__tdbudf__": "node_output",
+                    "client_node_id": "6e767267-6f6e-6e61-6776-65796f757570",
+                },
+            ],
+            nodes=(the_node,),
+        )
+
+    def test_many_nodes(self):
+        fake_ids = [
+            uuid.UUID("abcdef12-1234-1234-1234-34567890abcd"),
+            uuid.UUID("98765432-abcd-abcd-abcd-111111111111"),
+        ]
+        with mock.patch.object(uuid, "uuid4", side_effect=fake_ids):
+            node_a = builder._InputNode("in_a", "one")
+            node_b = builder._InputNode("in_b", builder._NOTHING)
+
+        self._do_test(
+            inval={
+                "__tdbudf__": "this must be escaped",
+                "sublist": [node_a, node_a, node_b],
+            },
+            expected={
+                "__tdbudf__": "__escape__",
+                "__escape__": {
+                    "__tdbudf__": "this must be escaped",
+                    "sublist": [
+                        {
+                            "__tdbudf__": "node_output",
+                            "client_node_id": "abcdef12-1234-1234-1234-34567890abcd",
+                        },
+                        {
+                            "__tdbudf__": "node_output",
+                            "client_node_id": "abcdef12-1234-1234-1234-34567890abcd",
+                        },
+                        {
+                            "__tdbudf__": "node_output",
+                            "client_node_id": "98765432-abcd-abcd-abcd-111111111111",
+                        },
+                    ],
+                },
+            },
+            nodes=(node_a, node_b),
+        )
+
     def _do_test(self, inval, expected, nodes):
         esc = builder._ParameterEscaper()
         actual = esc.visit(inval)
@@ -60,3 +115,16 @@ class TestBuilder(unittest.TestCase):
             self.assertEqual(
                 {"name": "my cool task graph", "nodes": []}, grf._tdb_to_json()
             )
+            grf.input("start", "value")
+            expected = {
+                "name": "my cool task graph",
+                "nodes": [
+                    {
+                        "client_node_id": "09f91102-9d74-e35b-d841-000000000000",
+                        "depends_on": [],
+                        "input_node": {"default_value": "value"},
+                        "name": "start",
+                    },
+                ],
+            }
+            self.assertEqual(expected, grf._tdb_to_json())

--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -71,7 +71,7 @@ class TestEscaper(unittest.TestCase):
         ]
         grf = builder.TaskGraphBuilder()
         with mock.patch.object(uuid, "uuid4", side_effect=fake_ids):
-            node_a = grf.input("in_a", "one")
+            node_a = grf.array_read("tiledb://uri/i", raw_ranges=[], buffers=["here"])
             node_b = grf.udf(len)
 
         self._do_test(

--- a/tiledb/cloud/taskgraphs/builder.py
+++ b/tiledb/cloud/taskgraphs/builder.py
@@ -1,0 +1,181 @@
+"""The code to build task graphs for later registration and execution."""
+
+import abc
+import uuid
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+import numpy as np
+
+from tiledb.cloud._common import ordered
+from tiledb.cloud._common import visitor
+from tiledb.cloud.taskgraphs import _codec
+from tiledb.cloud.taskgraphs import depgraph
+from tiledb.cloud.taskgraphs import types
+
+_T = TypeVar("_T")
+"""A generic type."""
+ValOrNode = Union[_T, "Node[_T]"]
+"""Type indicating that you can pass either a direct value or an input node."""
+ValOrNodeSeq = Union[
+    ValOrNode[types.NativeSequence[_T]],
+    types.NativeSequence[ValOrNode[_T]],
+]
+"""Either a Node that yields a sequence or a sequence that may contain nodes."""
+ArrayMultiIndex = Dict[str, np.ndarray]
+"""Type returned from an array query."""
+Funcable = Union[str, Callable[..., _T]]
+"""Either a Python function or the name of a registered UDF."""
+
+
+class TaskGraphBuilder:
+    """The thing you use to build a task graph.
+
+    This class only *builds* task graphs. The graphs it builds are static and
+    only represent the steps to run (the recipe). The actual execution will be
+    later performed by the executor.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+    ):
+        self.name = name
+        """A name for this graph. Read-only."""
+        self._by_id: Dict[uuid.UUID, Node] = {}
+        """The nodes in the graph."""
+        self._by_name: Dict[str, Node] = {}
+        """The named nodes in the graph, by name."""
+        self._deps = depgraph.DepGraph[Node]()
+        """A mapping from child to set of parents."""
+
+    def add_dep(self, *, parent: "Node", child: "Node") -> None:
+        """Manually requires that the ``parent`` must happen before ``child``.
+
+        This should rarely be necessary; including a parent node within
+        the parameter list of a child node automatically adds a dependency.
+        """
+        self._deps.add_edge(child=child, parent=parent)
+
+    def _add_node(self, node: "Node") -> "Node":
+        self._deps.add_new_node(node, node.deps)
+        self._by_id[node.id] = node
+        if node.name is not None:
+            if self._by_name.setdefault(node.name, node) is not node:
+                self._deps.remove(node)
+                raise ValueError(f"A node named {node.name!r} already exists.")
+
+        return node
+
+    def _tdb_to_json(self):
+        """Converts this task graph to a registerable/executable format."""
+        nodes = self._deps.topo_sorted
+        node_jsons = [n.to_registration_json() for n in nodes]
+        for n, n_json in zip(nodes, node_jsons):
+            n_json["depends_on"] = [
+                str(parent.id) for parent in self._deps.parents_of(n)
+            ]
+        return dict(
+            name=self.name,
+            nodes=node_jsons,
+        )
+
+
+class Node(_codec.TDBJSONEncodable, Generic[_T]):
+    """The root type of a Node when building a task graph.
+
+    The basic building block of a task graph. Nodes represent the data and
+    execution steps within a TileDB task graph.
+
+    ``builder.Node``s themselves are inert; they only represent the steps that
+    will be taken by an Executor implementation to run the task graph. They
+    should be treated as opaque and immutable; the Executor's node objects
+    are the ones that can be interacted with to get status and results.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str],
+        deps: Iterable["Node"],
+        *,
+        fallback_name: Optional[str] = None,
+    ):
+        self.id = uuid.uuid4()
+        """A unique ID for this node."""
+        self.name = name
+        """The name of the node. If present, the node is unnamed."""
+        self.deps: AbstractSet[Node] = ordered.FrozenSet(deps)
+        """The nodes that this node depends upon directly."""
+        self._fallback_name = fallback_name or type(self).__name__
+        """A string to use to generate a display name if the node is unnamed."""
+
+    @property
+    def display_name(self) -> str:
+        """A friendly name for the Node."""
+        if self.name is not None:
+            return self.name
+        id_clip = str(self.id)[-12:]
+        return f"{self._fallback_name} ({id_clip})"
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.display_name}>"
+
+    def _tdb_to_json(self) -> types.RegisteredArg:
+        """Converts this to the format that will be used in parameter lists.
+
+        This is used when a Node is used as an input to another Node::
+
+            child = dag.udf(..., types.args(parent_node))
+        """
+        return {
+            "__tdbudf__": "node_output",
+            "client_node_id": str(self.id),
+        }
+
+    @abc.abstractmethod
+    def to_registration_json(self) -> Dict[str, Any]:
+        """Converts this node to the form used when registering the graph.
+
+        This is the form of the Node that will be used to represent it in the
+        ``RegisteredTaskGraph`` object, i.e. a ``RegisteredTaskGraphNode``.
+        """
+        return {
+            "client_node_id": str(self.id),
+            "name": self.name,
+        }
+
+
+class _ParameterEscaper(_codec.Escaper):
+    """Converts Python arguments passed into Nodes into serializable format.
+
+    The input to this ``Escaper`` is a ``NativeValue``, i.e. any Python value.
+    The output is a ``RegisteredArg``, used to serialize the Node's arguments
+    for registration or passing to an Executor.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.seen_nodes = ordered.Set[Node]()
+        """The Nodes we have found when visiting our input(s)."""
+
+    def maybe_replace(self, arg) -> Optional[visitor.Replacement]:
+        if isinstance(arg, Node):
+            self.seen_nodes.add(arg)
+        return super().maybe_replace(arg)
+
+    def arguments_to_json(self, arg: types.Arguments) -> types.RegisteredArg:
+        arg_outputs = [{"value": self.visit(val)} for val in arg.args]
+        kwarg_outputs = [
+            {"name": name, "value": self.visit(value)}
+            for (name, value) in arg.kwargs.items()
+        ]
+        return arg_outputs + kwarg_outputs


### PR DESCRIPTION
At last! We're getting to the meat! Things are finally happening.

This creates the initial version of the task graph builder. It consists
of only the part which builds a graph. Execution will come later.

The API is based on the existing `tiledb.cloud.dag` API, but with
better separation of concerns, and significantly streamlined. Some
features will be added in a follow-up, but the existing API is enough
to construct all but the most specialized task graphs.

Each function on the `TaskGraphBuilder` returns a specific type of
`Node` which, like the existing API, represents a step to be executed.
These `Node`s are inert and only represent the actions that will be
later executed by an Executor and have no state of their own.

`Node`s are capable of accepting other nodes as input not only in the
traditional UDF argument slots (i.e. those passed into user code),
but also in selected parameters of other functions where users may wish
to pass in parameters: array queries, SQL parameters, and a few others.

---

A few things that are worth pointing out:

- Naming of the functions that you call on a graph to add a new node. I went with things that look like `grf.udf(...)` when called here, but I am wondering whether it might be better to include an `add_` or maybe a `_node` in the name.

- Using nodes as non-argument parameters. I've included it because it's something we currently support (if accidentally), and I can see wanting parameterizable configuration of e.g. query ranges. But is this something we explicitly want? My impression is "yes" but I want to make sure…

- The way we accept ranges. The current implementation only accepts ranges in the form that is directly used by the backend. The difficulty with making it work the same way as the current `parse_ranges` implementation is that:

  - `parse_ranges` distinguishes between lists and tuples, which we can't do after JSON serialization.
  - If users want to pass in node outputs into ranges, we can't necessarily parse them that way.
  - Whatever interchange format we use should be implementation-independent, so that we can make an executor in another language (e.g. server-side) in the future.

  These are the reasons that I'm currently only handling the `[[start, end, start2, end2], [startB, endB, ...], ...]` format of range specification, because designing an API for that is an even larger task.

[sc-14031]