### PR TITLE
Allow nodes from old DAGs to be used in new DAGs.

### DIFF
--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -66,6 +66,17 @@ class DelayedClassTest(unittest.TestCase):
         self.assertEqual(node_5.result(), 8)
         self.assertEqual(node_6.result(), 24)
 
+    def test_two_delayeds(self):
+        node_1 = Delayed(len)([1, 2, 3])
+        node_1.set_timeout(30)
+        node_1.compute()
+        self.assertEqual(node_1.result(), 3)
+
+        node_2 = Delayed("result was {}".format)(node_1)
+        node_2.set_timeout(30)
+        node_2.compute()
+        self.assertEqual(node_2.result(), "result was 3")
+
 
 class DelayedFailureTest(unittest.TestCase):
     def test_failure(self):


### PR DESCRIPTION
Previously, if you ran a DAG either via DAG or Delayed and passed in a
Node from a previous graph, it would either not work at all or give you
a bizarre error message (like "graph does not have any root nodes").
With this change, you can pass Nodes from a completed DAG to a new DAG
and they will be used as a caller would expect as parameters.

---

This is an issue that Chad ran into earlier that caused him problems, and also fixes a longstanding issue [sc-11457] where if you executed a `Delayed` and attempted to pass it into a later `Delayed`, that would fail as well.