### PR TITLE
Move non–result-specific code to a new `_common` module.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,7 +11,7 @@ from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import tasks
 from tiledb.cloud import tiledb_cloud_error
-from tiledb.cloud._results import json_safe
+from tiledb.cloud._common import json_safe
 
 
 class BasicTests(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -19,10 +19,10 @@ from tiledb.cloud import client
 from tiledb.cloud import dag
 from tiledb.cloud import tasks
 from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud._common import visitor
 from tiledb.cloud._results import decoders
 from tiledb.cloud._results import results
 from tiledb.cloud._results import stored_params as sp
-from tiledb.cloud._results import visitor
 from tiledb.cloud.dag import dag as dag_dag
 from tiledb.cloud.rest_api import models
 

--- a/tiledb/cloud/_common/__init__.py
+++ b/tiledb/cloud/_common/__init__.py
@@ -1,0 +1,4 @@
+"""Common utility modules used across multiple parts of TileDB Cloud.
+
+This is intended for internal consumption only.
+"""

--- a/tiledb/cloud/_common/json_safe.py
+++ b/tiledb/cloud/_common/json_safe.py
@@ -1,10 +1,14 @@
-from typing import Any
+from typing import Generic, TypeVar
 
 import attrs
 
+_T_co = TypeVar("_T_co", covariant=True)
 
-@attrs.define(frozen=True, slots=True)
-class Value:
+
+# This really should be a `slots` class, but setting `slots=True` breaks things
+# in python 3.6.
+@attrs.define(frozen=True, slots=False)
+class Value(Generic[_T_co]):
     """Sentinel for a value that is known to be JSON-serializable.
 
     In cases where you know we're generating JSON-safe values where the
@@ -13,4 +17,4 @@ class Value:
     you're generating into this.
     """
 
-    value: Any
+    value: _T_co

--- a/tiledb/cloud/_common/visitor.py
+++ b/tiledb/cloud/_common/visitor.py
@@ -2,19 +2,24 @@
 
 import abc
 import collections.abc as cabc
-import dataclasses
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar
+
+import attrs
+
+_T_co = TypeVar("_T_co", covariant=True)
 
 
-@dataclasses.dataclass(frozen=True)
-class Replacement:
+# This really should be a `slots` class, but setting `slots=True` breaks things
+# in python 3.6.
+@attrs.define(frozen=True, slots=False)
+class Replacement(Generic[_T_co]):
     """A sentinel return value to indicate that the value should be replaced.
 
     This wrapper ensures that we are able to replace nodes with `None`
     or other falsey values if needed.
     """
 
-    value: Any
+    value: _T_co
 
 
 class ReplacingVisitor(metaclass=abc.ABCMeta):

--- a/tiledb/cloud/_results/decoders.py
+++ b/tiledb/cloud/_results/decoders.py
@@ -42,7 +42,7 @@ _DECODE_FNS = {
 
 
 @dataclasses.dataclass(frozen=True)
-class Decoder(AbstractDecoder[_T], Generic[_T]):
+class Decoder(AbstractDecoder[_T]):
     """General decoder for the formats we support.
 
     The exact name and location of this class is important, because instances

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -7,8 +7,8 @@ import numpy
 from tiledb.cloud import client
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
+from tiledb.cloud._common import json_safe
 from tiledb.cloud._results import decoders
-from tiledb.cloud._results import json_safe
 from tiledb.cloud._results import results
 from tiledb.cloud._results import sender
 from tiledb.cloud.rest_api import ApiException as GenApiException

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -28,9 +28,9 @@ from tiledb.cloud import rest_api
 from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error as tce
 from tiledb.cloud import udf
+from tiledb.cloud._common import visitor
 from tiledb.cloud._results import results
 from tiledb.cloud._results import stored_params
-from tiledb.cloud._results import visitor
 from tiledb.cloud.dag import status as st
 from tiledb.cloud.dag import visualization as viz
 

--- a/tiledb/cloud/rest_api/api_client.py
+++ b/tiledb/cloud/rest_api/api_client.py
@@ -25,7 +25,7 @@ from dateutil.parser import parse
 from six.moves.urllib.parse import quote
 
 import tiledb.cloud.rest_api.models
-from tiledb.cloud._results import json_safe
+from tiledb.cloud._common import json_safe
 from tiledb.cloud.rest_api import rest
 from tiledb.cloud.rest_api.configuration import Configuration
 from tiledb.cloud.rest_api.exceptions import ApiException

--- a/tiledb/cloud/taskgraphs/_codec.py
+++ b/tiledb/cloud/taskgraphs/_codec.py
@@ -8,8 +8,8 @@ import cloudpickle
 import pyarrow
 import urllib3
 
+from tiledb.cloud._common import visitor
 from tiledb.cloud._results import decoders
-from tiledb.cloud._results import visitor
 from tiledb.cloud.taskgraphs import types
 
 _T = TypeVar("_T")

--- a/update_generated.sh
+++ b/update_generated.sh
@@ -119,7 +119,7 @@ index 267385d..6d244a0 100644
  from six.moves.urllib.parse import quote
  
  import tiledb.cloud.rest_api.models
-+from tiledb.cloud._results import json_safe
++from tiledb.cloud._common import json_safe
  from tiledb.cloud.rest_api import rest
  from tiledb.cloud.rest_api.configuration import Configuration
  from tiledb.cloud.rest_api.exceptions import ApiException


### PR DESCRIPTION
To reduce the pollution of the `_results` namespace, this moves common
stuff that is not result-specific into its own internal-only module.
Also adds and cleans up some generic types.

Most of what remains in `_results` is specific to resultset handling,
and much of it cannot be moved due to the need to maintain pickle
compatibility for v1 UDFs.