### PR TITLE
Use ordered sets in depgraph for consistent tests and RPCs.

### DIFF
--- a/tests/common/test_ordered.py
+++ b/tests/common/test_ordered.py
@@ -1,0 +1,77 @@
+import itertools
+import unittest
+
+from tiledb.cloud._common import ordered
+
+
+class TestSets(unittest.TestCase):
+    def test_frozen(self):
+        s = ordered.FrozenSet(
+            ("one", "two", "three", "two", "three", "four", "a billion")
+        )
+        self.assertEqual(5, len(s))
+        self.assertEqual(("one", "two", "three", "four", "a billion"), tuple(s))
+        self.assertIn("one", s)
+        self.assertNotIn("threeve", s)
+
+        other = ordered.FrozenSet(("one", "three", "two", "four", "a billion"))
+        # For compatibility, ordering is not considered when comparing OFSs.
+        self.assertEqual(other, s)
+        self.assertEqual(hash(other), hash(s))
+        # You can also compare an OrderedFrozenSet with a regular frozenset.
+        self.assertEqual(frozenset(("one", "two", "three", "four", "a billion")), s)
+
+        self.assertIs(s, s.copy())
+
+        self.assertEqual(
+            "FrozenSet(('one', 'two', 'three', 'four', 'a billion'))",
+            repr(s),
+        )
+        self.assertEqual("FrozenSet((1,))", repr(ordered.FrozenSet((1,))))
+
+    def test_mutable(self):
+        s = ordered.Set((b"bytes", b"MORE BYTES"))
+        self.assertEqual(2, len(s))
+        s.add(b"bytes")
+        s.add(b"different")
+        self.assertEqual(3, len(s))
+        self.assertEqual((b"bytes", b"MORE BYTES", b"different"), tuple(s))
+        self.assertEqual({b"bytes", b"different", b"MORE BYTES"}, s)
+
+        self.assertEqual(
+            "Set((b'bytes', b'MORE BYTES', b'different'))",
+            repr(s),
+        )
+
+        s.remove(b"MORE BYTES")
+        with self.assertRaises(KeyError):
+            s.remove(b"bogus")
+        s.discard(b"bogus")  # doesn't error
+        self.assertEqual(2, len(s))
+        self.assertEqual((b"bytes", b"different"), tuple(s))
+
+        self.assertEqual(b"different", s.pop())
+        self.assertIn(b"bytes", s)
+        self.assertNotIn(b"missing", s)
+
+        s.clear()
+        self.assertEqual(0, len(s))
+        self.assertEqual((), tuple(s))
+
+        with self.assertRaises(TypeError):
+            hash(s)
+
+        s2 = s.copy()
+        s2.add(b"hello")
+        self.assertEqual((), tuple(s))
+        self.assertEqual((b"hello",), tuple(s2))
+        self.assertEqual("Set((b'hello',))", repr(s2))
+
+    def test_permutations(self):
+        """Detailed insertion order test."""
+        for cls in (ordered.FrozenSet, ordered.Set):
+            with self.subTest(cls):
+                for perm in itertools.permutations((1, 2, 3, 4)):
+                    with self.subTest(perm):
+                        perm_set = cls(perm)
+                        self.assertEqual(perm, tuple(perm_set))

--- a/tests/taskgraphs/test_depgraph.py
+++ b/tests/taskgraphs/test_depgraph.py
@@ -52,14 +52,15 @@ class TestDepGraph(unittest.TestCase):
         expected_parents_children = {
             "root": ([], ["child", "child 2", "last"]),
             "child": (["root", "child 2"], ["last"]),
-            "child 2": (["root"], ["child", "last"]),
+            "child 2": (["root"], ["last", "child"]),
             "last": (["root", "child", "child 2"], []),
             "floater": ([], []),
         }
         for node, (parents, children) in expected_parents_children.items():
             with self.subTest(f"{node!r} relationships"):
-                self.assertEqual(frozenset(parents), g.parents_of(node))
-                self.assertEqual(frozenset(children), g.children_of(node))
+                # Order is important here.
+                self.assertEqual(parents, list(g.parents_of(node)))
+                self.assertEqual(children, list(g.children_of(node)))
 
         with self.assertRaises(KeyError):
             g.children_of("no")

--- a/tiledb/cloud/_common/ordered.py
+++ b/tiledb/cloud/_common/ordered.py
@@ -1,0 +1,82 @@
+"""Implementations of Python sets that remember their order."""
+
+from typing import AbstractSet, Iterable, Iterator, MutableSet, TypeVar
+
+_T = TypeVar("_T")
+_T_co = TypeVar("_T_co", covariant=True)
+_Self = TypeVar("_Self", bound="FrozenSet")
+"""Annotation for returning an object of your own type.
+
+See https://peps.python.org/pep-0673/.
+"""
+
+
+class FrozenSet(AbstractSet[_T_co]):
+    """A frozenset that remembers the insertion order of elements.
+
+    Unlike dicts, Python sets don't remember insertion order. This class
+    is useful for situations where you want to have a consistent order
+    of set elements, like when iteration order is important or to make
+    tests consistent.
+
+    The ordering this set has is the order that elements were inserted,
+    just like a dict has insertion order. Apart from this, it behaves
+    exactly as a frozenset. This notably includes that *comparisons are
+    order-independent*. Two differently-ordered OrderedFrozenSets are
+    considered equal.
+    """
+
+    def __init__(self, source: Iterable[_T_co] = ()):
+        self._dict = {x: None for x in source}
+
+    def copy(self: _Self) -> _Self:
+        """Returns itself, because it's immutable."""
+        return self
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __contains__(self, item) -> bool:
+        return item in self._dict
+
+    def __iter__(self) -> Iterator[_T_co]:
+        return iter(self._dict)
+
+    def __hash__(self) -> int:
+        return self._hash()  # type: ignore[attr-defined] # (false alarm)
+
+    def __repr__(self) -> str:
+        contents = ", ".join(map(repr, self))
+        if len(self) == 1:
+            contents += ","
+        return f"{type(self).__name__}(({contents}))"
+
+
+class Set(FrozenSet[_T], MutableSet[_T]):
+    """An :class:`_OrderedFrozenSet`, but this time it's mutable."""
+
+    def copy(self: _Self) -> _Self:
+        """Returns a shallow copy of this set. Equivalent to ``set.copy()``."""
+        return type(self)(self)
+
+    def add(self, val: _T) -> None:
+        self._dict[val] = None
+
+    def discard(self, val: _T) -> None:
+        try:
+            self.remove(val)
+        except KeyError:
+            pass
+
+    def remove(self, val: _T) -> None:
+        del self._dict[val]
+
+    def pop(self) -> _T:
+        """Drops and returns the most recently-added item."""
+        return self._dict.popitem()[0]
+
+    def clear(self) -> None:
+        self._dict.clear()
+
+    __hash__ = None  # type: ignore[assignment]
+    """This is mutable, so it's not hashable."""


### PR DESCRIPTION
This updates the dependency graph to use ordered sets for storing
parent–child relationships. This allows us to have consistent,
predictable (insertion-order–based) ordering for both RPCs that we send
and tests that we perform.

The set classes themselves live in the `ordered` package and use the
standard Python abstract base classes, which provide most of the
mechanics of being a Set given only a few method implementations.