### PR TITLE
Add a function to download the server-side logs for a whole DAG.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -94,6 +94,8 @@ class DAGClassTest(unittest.TestCase):
             ),
         )
 
+        self.assertIsNone(dag_dag.server_logs(d))
+
     def test_simple_cloud_dag(self):
         d = dag.DAG(name="a cool server dag")
 
@@ -164,6 +166,11 @@ class DAGClassTest(unittest.TestCase):
                 ],
             ),
         )
+
+        actual_log = dag_dag.server_logs(d)
+        self.assertEqual("a cool server dag", actual_log.name)
+        self.assertEqual(3, len(actual_log.nodes))
+        self.assertEqual("succeeded", actual_log.status)
 
     def _remote_result(self, node: dag_dag.Node) -> results.RemoteResult:
         """Extracts the RemoteResult out of the Node's future."""

--- a/tiledb/cloud/dag/__init__.py
+++ b/tiledb/cloud/dag/__init__.py
@@ -5,10 +5,12 @@ from tiledb.cloud.dag import status
 DAG = dag.DAG
 Node = dag.Node
 Status = status.Status
+server_logs = dag.server_logs
 
 
 __all__ = (
     "DAG",
     "Node",
     "Status",
+    "server_logs",
 )


### PR DESCRIPTION
Adds `dag.server_logs`, which downloads all the server-side logging
information for a DAG, whether incomplete or in-progress.