### PR TITLE
Only cancel descendants of failed DAG nodes

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -960,9 +960,7 @@ class ReplaceNodesTest(unittest.TestCase):
 def _node(val):
     """Creates a completed node with the given value."""
     n = dag.Node(lambda: None)
-    n._future = futures.Future()
     n._future.set_result(results.LocalResult(val))
-    n.status = dag.Status.COMPLETED
     return n
 
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -4,6 +4,7 @@ import collections.abc as cabc
 import itertools
 import pickle
 import threading
+import time
 import unittest
 import uuid
 from concurrent import futures
@@ -166,6 +167,9 @@ class DAGClassTest(unittest.TestCase):
             ),
         )
 
+        # The status is set asynchronously so there may be a slight delay
+        # between when we send a request and when it's actually recorded.
+        time.sleep(0.5)
         actual_log = dag_dag.server_logs(d)
         self.assertEqual("a cool server dag", actual_log.name)
         self.assertEqual(3, len(actual_log.nodes))

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -444,10 +444,10 @@ class DAGFailureTest(unittest.TestCase):
         def fail():
             raise Exception("expected")
 
-        definitely_failed = futures.Future()
+        definitely_failed = threading.Barrier(2, timeout=5)
 
         def wait(something):
-            definitely_failed.result(1)
+            definitely_failed.wait()
             return something
 
         fail_node = d.submit_local(fail)
@@ -458,7 +458,7 @@ class DAGFailureTest(unittest.TestCase):
         d.compute()
 
         fail_node.wait(1)
-        definitely_failed.set_result(None)
+        definitely_failed.wait()
 
         with self.assertRaisesRegex(Exception, r"^expected$"):
             d.wait(5)

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -1,4 +1,3 @@
-import time
 import unittest
 from concurrent import futures
 
@@ -123,24 +122,33 @@ class DelayedFailureTest(unittest.TestCase):
 
 class DelayedCancelTest(unittest.TestCase):
     def test_cancel(self):
-        node = Delayed(time.sleep, local=True, name="multi_node_2")(3)
-        node_2 = Delayed(np.mean, local=True, name="multi_node_2")([1, 1])
-        node_2.depends_on(node)
+        in_node = futures.Future()
+        leave_node = futures.Future()
 
-        with self.assertRaises(TimeoutError):
-            # Set timeout to 1 second, the dependency on node will wait for 3 seconds,
-            # so we'll timeout and cancel
+        def rendezvous(value):
+            in_node.set_result(None)
+            leave_node.result()
+            return value
+
+        node = Delayed(rendezvous, local=True, name="multi_node")(3)
+        node_2 = Delayed(np.mean, local=True, name="multi_node_2")([node, node])
+
+        with self.assertRaises(futures.TimeoutError):
             node_2.set_timeout(1)
             node_2.compute()
 
+        in_node.result(1)
         node_2.dag.cancel()
+        leave_node.set_result(None)
+
+        node_2.dag.wait(1)
 
         self.assertIs(node.dag, node_2.dag)
         self.assertEqual(node.dag.status, Status.CANCELLED)
 
         # Because an already-running node can't be cancelled, the sleep will
         # still run to completion.
-        self.assertEqual(node.result(), None)
+        self.assertEqual(node.result(), 3)
 
         self.assertEqual(node_2.status, Status.CANCELLED)
         with self.assertRaises(futures.CancelledError):


### PR DESCRIPTION
When a DAG fails, it currently immediately aborts every single node in its structure, even if they have no dependency upon the failed node. This is not needed; we only need to cancel those nodes which depend upon the failed node. This change does that.

In order to support doing so, it also restructures the way that Node works to handle its entire lifecycle with a Future, using that as the only source of truth for its status and results.