### PR TITLE
Put the Node's name into the task name so it's recorded.

### DIFF
--- a/tiledb/cloud/compute/delayed.py
+++ b/tiledb/cloud/compute/delayed.py
@@ -106,11 +106,6 @@ class Delayed(DelayedBase):
                 "and not the registered name of a UDF."
             )
 
-        # Set name of task if it won't interfere with user args
-        if not self.local_mode:
-            if "task_name" not in self.kwargs:
-                self.kwargs["task_name"] = self.name
-
     def __call__(self, *args, **kwargs):
         if not self.local_mode:
             self.args = [self.func_exec, *args]
@@ -118,11 +113,6 @@ class Delayed(DelayedBase):
             self.args = args
         self.kwargs.update(kwargs)
         self._find_deps()
-
-        # Set name of task if it won't interfere with user args
-        if not self.local_mode:
-            if "task_name" not in self.kwargs:
-                self.kwargs["task_name"] = self.name
 
         return self
 

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -78,7 +78,7 @@ class Node(Generic[_T]):
         :param kwargs: dictionary for keyword arguments
         """
         self.id = uuid.uuid4()
-        self.name = name or str(self.id)
+        self._name = name
 
         self.error: Optional[BaseException] = None
         self.status = st.Status.NOT_STARTED
@@ -127,6 +127,14 @@ class Node(Generic[_T]):
 
     def __ne__(self, other):
         return not (self == other)
+
+    @property
+    def name(self) -> str:
+        return self._name or str(self.id)
+
+    @name.setter
+    def name(self, to: Optional[str]) -> None:
+        self._name = to
 
     def _find_deps(self):
         """Finds Nodes this depends on and adds them to our dependency list."""
@@ -231,6 +239,8 @@ class Node(Generic[_T]):
                 _server_graph_uuid=self.dag.server_graph_uuid,
                 _client_node_uuid=self.id,
             )
+            if self._name:
+                kwargs.setdefault("task_name", self._name)
             if namespace:
                 kwargs["namespace"] = namespace
 


### PR DESCRIPTION
While our Nodes have `name` fields, that was not correctly connected
with the `task_name` argument to the `whatever_base` functions, so they
were not recorded correctly in the logs. This plumbs that all the way
through.