### PR TITLE
Ensure that order is preserved for disconnected graphs.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -732,6 +732,12 @@ class TopoSortTest(unittest.TestCase):
                         self.assertCountEqual(perm, result)
                         self.assert_topo_sorted(result)
 
+    def test_preserves_order(self):
+        """Verifies that, for a disconnected graph, order is preserved."""
+        nodes = [self._node(str(n)) for n in range(100)]
+        result = dag_dag._topo_sort(nodes)
+        self.assertEqual(nodes, result)
+
     def test_cycle(self):
         with self.assertRaises(ValueError):
             dag_dag._topo_sort(

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -1188,7 +1188,9 @@ def _topo_sort(
         node.client_node_uuid: node for node in lst
     }
     in_degrees: Counter[str] = collections.Counter()
-    for node in lst:
+    # We reverse the input list so that when we reverse the output,
+    # it's in an order kind of close to what we were given.
+    for node in reversed(lst):
         # Ensure that we have an entry in the counter even for root nodes.
         in_degrees[node.client_node_uuid] += 0
         for dep_id in node.depends_on:


### PR DESCRIPTION
Currently, the way we sort nodes can have unpredictable results
when looking through task graph logs. This should make it a bit nicer
by ensuring that things are closer to the order they were submitted in.

---

Not sure what the deal is with server-side logs being out of order but hopefully this will make the nodes themselves a bit easier to keep track of.