### PR TITLE
Start the executor and implement the first Node type.

### DIFF
--- a/tests/taskgraphs/test_client_executor.py
+++ b/tests/taskgraphs/test_client_executor.py
@@ -1,0 +1,133 @@
+import unittest
+import uuid
+from typing import Optional
+
+import attrs
+
+from tiledb.cloud._common import ordered
+from tiledb.cloud.taskgraphs import client_executor
+
+
+class UDFParamReplacerTest(unittest.TestCase):
+    def test_no_nodes(self):
+        input = {
+            "here": "there",
+            "up": "down",
+            "list": [
+                {"__tdbudf__": "bogus"},
+                {
+                    "__tdbudf__": "__escape__",
+                    "__escape__": {"__tdbudf__": [True, False]},
+                },
+            ],
+        }
+        replacer = client_executor._UDFParamReplacer(
+            {}, client_executor._ParamFormat.STORED_PARAMS
+        )
+        output = replacer.visit(input)
+        self.assertEqual(input, output)
+        self.assertEqual(replacer.seen_nodes, ordered.Set())
+
+    def test_with_nodes(self):
+        input = {
+            "here": "there",
+            "first": {
+                "__tdbudf__": "node_output",
+                "client_node_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            },
+            "second": [
+                {
+                    "__tdbudf__": "__escape__",
+                    "__escape__": {
+                        "__tdbudf__": "value",
+                        "dont_visit": {
+                            "__tdbudf__": "bogus",
+                            "value": {"__tdbudf__": "node_output"},
+                        },
+                        "do_visit": {
+                            "__tdbudf__": "node_output",
+                            "client_node_id": "00000000-1111-2222-3333-444444444444",
+                        },
+                    },
+                },
+            ],
+        }
+
+        expected = {
+            "here": "there",
+            "first": (
+                "encoded 55555555-5555-5555-5555-555555555555 "
+                "in _ParamFormat.STORED_PARAMS"
+            ),
+            "second": [
+                {
+                    "__tdbudf__": "__escape__",
+                    "__escape__": {
+                        "__tdbudf__": "value",
+                        "dont_visit": {
+                            "__tdbudf__": "bogus",
+                            "value": {"__tdbudf__": "node_output"},
+                        },
+                        "do_visit": (
+                            "encoded ffffffff-ffff-ffff-ffff-ffffffffffff "
+                            "in _ParamFormat.STORED_PARAMS"
+                        ),
+                    },
+                },
+            ],
+        }
+        visitor = client_executor._UDFParamReplacer(
+            {
+                uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"): _TestNode(
+                    uuid.UUID("55555555-5555-5555-5555-555555555555")
+                ),
+                uuid.UUID("00000000-1111-2222-3333-444444444444"): _TestNode(
+                    uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+                ),
+            },
+            client_executor._ParamFormat.STORED_PARAMS,
+        )
+        self.assertEqual(expected, visitor.visit(input))
+        self.assertEqual(
+            ordered.Set(
+                (
+                    _TestNode(uuid.UUID("55555555-5555-5555-5555-555555555555")),
+                    _TestNode(uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+                )
+            ),
+            visitor.seen_nodes,
+        )
+
+    def test_small(self):
+        input = {
+            "__tdbudf__": "node_output",
+            "client_node_id": "99999999-9999-9999-9999-999999999999",
+        }
+
+        visitor = client_executor._UDFParamReplacer(
+            {
+                uuid.UUID("99999999-9999-9999-9999-999999999999"): _TestNode(
+                    uuid.UUID("33333333-3333-3333-3333-333333333333")
+                )
+            },
+            client_executor._ParamFormat.VALUES,
+        )
+        expected = "encoded 33333333-3333-3333-3333-333333333333 in _ParamFormat.VALUES"
+        self.assertEqual(expected, visitor.visit(input))
+        self.assertEqual(
+            ordered.Set([_TestNode(uuid.UUID("33333333-3333-33333333--333333333333"))]),
+            visitor.seen_nodes,
+        )
+
+
+@attrs.define(frozen=True, slots=True)
+class _TestNode:
+    """A dummy class which implements just what _UDFParamReplacer uses."""
+
+    _task_id: Optional[uuid.UUID] = None
+
+    def _encode_for_param(self, mode):
+        return f"encoded {self._task_id} in {mode}"
+
+    def task_id(self):
+        return self._task_id

--- a/tiledb/cloud/taskgraphs/client_executor.py
+++ b/tiledb/cloud/taskgraphs/client_executor.py
@@ -1,0 +1,225 @@
+"""A client-side implementation of a task graph Executor.
+
+This module implements a task graph Executor that coordinates the execution of
+graph nodes on the client side.
+"""
+
+import abc
+import enum
+import queue
+import threading
+import uuid
+from concurrent import futures
+from typing import Any, Dict, Optional, Set, TypeVar
+
+from tiledb.cloud import client
+from tiledb.cloud.taskgraphs import executor
+
+Status = executor.Status
+_T = TypeVar("_T")
+"""Value that a Node yields."""
+
+
+class LocalExecutor(executor.Executor["Node"]):
+    """Coordinates the execution of a task graph locally."""
+
+    def __init__(
+        self,
+        graph: executor.GraphStructure,
+        namespace: Optional[str] = None,
+        api_client: Optional[client.Client] = None,
+        name: Optional[str] = None,
+    ):
+        super().__init__(graph)
+        self.name = name
+        self._namespace = namespace or client.default_charged_namespace()
+        self._done_node_queue: "queue.Queue[Node]" = queue.Queue()
+        """Queue where completed nodes are added as they are done.
+
+        This acts as the event loop for ``_exec_loop.``
+        """
+        self._inputs: Dict[uuid.UUID, Any] = {}
+        self._client = api_client or client.client
+
+        self._active_deps = self._deps.copy()
+        self._running_nodes: Set[Node] = set()
+        self._failed_nodes: Set[Node] = set()
+        self._succeeded_nodes: Set[Node] = set()
+
+        self._lifecycle_lock = threading.Lock()
+        self._status: Status = Status.WAITING
+
+        if self.name:
+            thread_name = f"Task graph {self.name} executor"
+        else:
+            thread_name = f"{self!r} executor"
+        self._event_loop_thread = threading.Thread(
+            name=thread_name,
+            target=self._run,
+            daemon=True,
+        )
+        self._done_event = threading.Event()
+        self._exception: Optional[BaseException] = None
+
+    @property
+    def status(self) -> Status:
+        with self._lifecycle_lock:
+            return self._status
+
+    def execute(self, **inputs: Any) -> None:
+        raise NotImplementedError()
+
+    def cancel(self) -> bool:
+        with self._lifecycle_lock:
+            if self._status in (Status.SUCCEEDED, Status.FAILED):
+                return False
+            self._status = Status.CANCELLED
+        for node in self._active_deps.topo_sorted:
+            node.cancel()
+        return True
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        self._done_event.wait(timeout)
+
+    def _make_node(
+        self,
+        uid: uuid.UUID,
+        name: Optional[str],
+        node_json: Dict[str, Any],
+    ) -> "Node":
+        raise NotImplementedError()
+
+    def _run(self):
+        """The main event loop of this Executor."""
+        raise NotImplementedError()
+
+
+class _ParamFormat(enum.Enum):
+    """The format used to encode the result of a parent node for a child."""
+
+    STORED_PARAMS = enum.auto()
+    """The node result is encoded in ``CallArgStoredParams`` format.
+
+    Rather than including the actual value in the UDF's parameter list sent to
+    the server, this will (when possible) provide the result ID to be
+    substituted in server-side. If the node is purely local (e.g., an input),
+    this will encode the value itself.
+    """
+    VALUES = enum.auto()
+    """The node result is encoded directly, in ``CallArg`` format.
+
+    This will include the actual result of the node in the parameter list,
+    without the need for any server-side processing.
+    """
+
+
+class Node(executor.Node[LocalExecutor, _T], metaclass=abc.ABCMeta):
+    """Base class for Nodes to be executed locally.
+
+    All public-facing methods MUST be thread-safe.
+    """
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._event = threading.Event()
+        self._status: Status = Status.WAITING
+        self._exception: Optional[Exception] = None
+
+    # External API
+
+    def result(self, timeout: Optional[float] = None) -> _T:
+        self._event.wait(timeout)
+        # Because it's guaranteed that `exception` will *never be written to*
+        # after the `_event` is set, we don't need to hold a lock here.
+        if self._exception:
+            raise self._exception
+        return self._result_impl()
+
+    def exception(self, timeout: Optional[float] = None) -> Optional[Exception]:
+        self._event.wait(timeout)
+        if self._status is Status.CANCELLED:
+            raise futures.CancelledError()
+        return self._exception
+
+    def cancel(self) -> bool:
+        cancelled = self._set_status_if_can_start(Status.CANCELLED)
+        if cancelled:
+            # If we were successful at cancelling this Node, we effectively
+            # "own" the result fields on this thread. We can set them safely
+            # ourselves before firing the Event.
+            self._exception = futures.CancelledError()
+            self._event.set()
+            self._do_callbacks()
+        return cancelled
+
+    # Internals
+
+    def _status_impl(self) -> Status:
+        return self._status
+
+    def _exec(self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
+        """The boilerplate for the ``_exec`` implementation for local Nodes.
+
+        This handles all the lifecycle management for Node execution. It should
+        only ever be called by the Executor. Subclasses should instead implement
+        ``_exec_impl``, which contains the type-specific behavior.
+        """
+        if not self._set_status_if_can_start(Status.RUNNING):
+            return
+
+        try:
+            self._exec_impl(parents, input_value)
+        except Exception as ex:
+            with self._lifecycle_lock:
+                self._status = Status.FAILED
+                self._exception = ex
+            raise
+        else:
+            with self._lifecycle_lock:
+                self._status = Status.SUCCEEDED
+        finally:
+            self._event.set()
+            self._do_callbacks()
+
+    @abc.abstractmethod
+    def _exec_impl(self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
+        """The type-specific behavior of executing a Node."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _result_impl(self) -> _T:
+        """Returns the result of this node's execution, if applicable.
+
+        This will only ever be called after ``_event`` is set and the state is
+        ``SUCCEEDED``. It should only ever be called inside ``result()``.
+        """
+        raise NotImplementedError()
+
+    def _assert_succeeded(self) -> None:
+        if self._status is not Status.SUCCEEDED:
+            raise AssertionError("_encoded_result is only valid for successful nodes")
+
+    def _set_ready(self) -> None:
+        self._set_status_if_can_start(Status.READY)
+
+    def _set_status_if_can_start(self, status: Status) -> bool:
+        """If this node is allowed to start, updates its status.
+
+        Updates the status of this node, but only if it's unstarted (and is able
+        to be started). Used to implement both :meth:`cancel` and the equivalent
+        of ``Future.set_running_or_notify_cancel``.
+        """
+        with self._lifecycle_lock:
+            if self._status in (Status.WAITING, Status.READY):
+                self._status = status
+                return True
+            return False
+
+    @abc.abstractmethod
+    def _encode_for_param(self, mode: _ParamFormat) -> Any:
+        """Encodes the result of this node for use in a JSON parameter list.
+
+        This is used to pass the output of this Node into the parameters of a
+        following Node.
+        """
+        raise NotImplementedError()

--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -215,6 +215,11 @@ class Node(Generic[_ET, _T]):
         """A fallback name for this node if unnamed."""
         return type(self).__name__
 
+    @abc.abstractmethod
+    def wait(self, timeout: Optional[float] = None) -> None:
+        """Waits for the given amount of time for this Node to complete."""
+        raise NotImplementedError()
+
     # Public interface of `futures.Future`.
 
     @abc.abstractmethod

--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -1,0 +1,311 @@
+"""Generic interfaces for task graph executors."""
+
+import abc
+import enum
+import logging
+import threading
+import uuid
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
+
+from tiledb.cloud.taskgraphs import builder
+from tiledb.cloud.taskgraphs import depgraph
+
+_log = logging.getLogger(__name__)
+
+
+class Status(enum.Enum):
+    """The current status of a Node (or a graph)."""
+
+    WAITING = enum.auto()
+    """A Node is waiting for input values."""
+    READY = enum.auto()
+    """All the inputs of a Node have resolved and it can run."""
+    RUNNING = enum.auto()
+    """The Node is currently running."""
+    SUCCEEDED = enum.auto()
+    """The Node completed successfully."""
+    FAILED = enum.auto()
+    """The Node failed to complete."""
+    CANCELLED = enum.auto()
+    """The Node was cancelled before it could complete."""
+
+
+GraphStructure = Union[Dict[str, Any], builder.TaskGraphBuilder]
+"""The structure of a task graph, as the JSON serialization or a Builder."""
+_N = TypeVar("_N", bound="Node")
+"""The specific type of Node that an executor uses."""
+
+
+class Executor(Generic[_N], metaclass=abc.ABCMeta):
+    """An interface allowing for execution and management of a task graph.
+
+    This is the basic interface fulfilled by any task graph executor. While some
+    implementations may provide more control, these operations, to the extent
+    that they are supported, are universal across task graph implementations.
+    """
+
+    def __init__(self, graph: GraphStructure):
+        if isinstance(graph, builder.TaskGraphBuilder):
+            graph_json = graph._tdb_to_json()
+        else:
+            graph_json = graph
+        self._graph_json = graph_json
+        self._deps = depgraph.DepGraph[_N]()
+        self._by_id: Dict[uuid.UUID, _N] = {}
+        self._by_name: Dict[str, _N] = {}
+
+        json_nodes = graph_json["nodes"]
+        for node_json in json_nodes:
+            self._add_node(node_json)
+
+    # Public API.
+
+    def node(self, nid: Union[str, uuid.UUID, builder.Node]) -> _N:
+        """Gets the node identified either by name, ID, or builder node.
+
+        When passed:
+        - a ``str``: The node with the given name.
+        - a :class:`uuid.UUID`: The node with the given ID.
+        - a :class:`builder.Node`: The execution node corresponding to the given
+          node from the :class:`builder.Builder`.
+        """
+        if isinstance(nid, str):
+            return self._by_name[nid]
+        if isinstance(nid, builder.Node):
+            nid = nid.id
+        if not isinstance(nid, uuid.UUID):
+            raise TypeError(
+                f"Nodes must be accessed by name, ID, or builder node, not {type(nid)}."
+            )
+        return self._by_id[nid]
+
+    @abc.abstractmethod
+    def execute(self, **inputs: Any) -> None:
+        """Starts execution of this graph with the given input values."""
+        del inputs
+        raise NotImplementedError()
+
+    def cancel(self) -> bool:
+        """If possible, cancels further execution of this graph.
+
+        Like ``futures.Future.cancel``, this returns ``True`` if the graph could
+        be cancelled, and ``False`` if not.
+        """
+        return False
+
+    @property
+    @abc.abstractmethod
+    def status(self) -> Status:
+        """The status of the entire graph."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def wait(self, timeout: Optional[float] = None) -> None:
+        """Waits for the execution of this task graph to complete."""
+        raise NotImplementedError()
+
+    # Internals.
+
+    def _add_node(self, node_json: Dict[str, Any]) -> None:
+        """Internal function to add a Node object to common data structures.
+
+        Subclasses should not need to override this, since this has no
+        Executor implementation–specific behavior.
+        """
+        uid = uuid.UUID(node_json["client_node_id"])
+        name = node_json.get("name")
+        node = self._make_node(uid, name, node_json)
+        dep_strs = node_json.get("depends_on", ())
+        dep_ids = (uuid.UUID(hex=dep_id) for dep_id in dep_strs)
+        deps = [self._by_id[dep] for dep in dep_ids]
+        self._deps.add_new_node(node, deps)
+        self._by_id[node.id] = node
+        if node.name is not None:
+            if self._by_name.setdefault(node.name, node) is not node:
+                raise KeyError(f"Duplicate node with name {node.name!r}")
+            self._by_name[node.name] = node
+
+    @abc.abstractmethod
+    def _make_node(
+        self,
+        uid: uuid.UUID,
+        name: Optional[str],
+        node_json: Dict[str, Any],
+    ) -> _N:
+        """Internal abstract function to turn a Node's JSON into a Node object.
+
+        An implementation should provide this to turn the JSON descriptions of
+        a Node into the concrete ``Node`` object that the executor uses to
+        handle actually running the graph.
+        """
+        raise NotImplementedError()
+
+
+_ET = TypeVar("_ET", bound=Executor)
+"""The type of the executor of a node."""
+_T = TypeVar("_T")
+"""The type of the value that a Node yields."""
+
+
+class Node(Generic[_ET, _T]):
+    """An abstract type specifying the operations on a Node of a task graph.
+
+    Executor implementations will return instances of implementations of these
+    Nodes when executing a task graph. If a caller uses only the methods here
+    when manipulating task graph nodes, the actions they take will work (to the
+    extent that they are supported) no matter the specifics of the executor
+    itself (client-side, server-side, etc.).
+
+    The external-facing API matches that of ``futures.Future``, with some added
+    niceties (like ``status``), and without the internal methods that are only
+    "meant for use in unit tests and Executor implementations":
+    ``set_running_or_notify_cancel``, ``set_result``, and ``set_exception``.
+
+    The generic types on this (which are really only of concern to Executor
+    implementors) represent the ``Executor`` type and the type the ``Node``
+    yields::
+
+        Node[MyExecutor, int]
+        # A Node subtype that is executed by a MyExecutor
+        # and whose .result() is an int.
+    """
+
+    # TODO: Retry functionality. When we do add retry functionality, assumptions
+    # around a node "finishing" exactly once will be broken.
+
+    def __init__(self, uid: uuid.UUID, owner: _ET, name: Optional[str]):
+        self.id = uid
+        """The client-generated UUID of this node."""
+        self.owner = owner
+        """The executor which this node belongs to."""
+        self.name = name
+        """The name of the node, if present."""
+
+        self._lifecycle_lock = threading.Lock()
+        """A lock to protect lifecycle events and callback list management."""
+        self._callbacks: List[Callable[[Node[_ET, _T]], None]] = []
+        """Callbacks that will be called when the Node completes."""
+
+    # Node-specific APIs.
+
+    @property
+    def status(self) -> Status:
+        """The current lifecycle state of this Node."""
+        with self._lifecycle_lock:
+            return self._status_impl()
+
+    @abc.abstractmethod
+    def _status_impl(self) -> Status:
+        """Abstract method for implementation of the status property.
+
+        ``_lifecycle_lock`` must be held by the caller.
+        """
+        raise NotImplementedError()
+
+    @property
+    def display_name(self) -> str:
+        """The name for this node that should show up in UIs."""
+        if self.name is not None:
+            return self.name
+        uid_str = str(self.id)[-12:]
+        return f"{self.fallback_name} ({uid_str})"
+
+    @property
+    def fallback_name(self) -> str:
+        """A fallback name for this node if unnamed."""
+        return type(self).__name__
+
+    # Public interface of `futures.Future`.
+
+    @abc.abstractmethod
+    def result(self, timeout: Optional[float] = None) -> _T:
+        """The value resulting from executing this node.
+
+        Returns the result if present, or raises an exception if execution
+        raised an exception.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def exception(self, timeout: Optional[float] = None) -> Optional[Exception]:
+        """If this node failed, the exception that was raised.
+
+        If the Node succeeded, returns None. If the Node was cancelled, a
+        ``futures.CancelledError`` will be *raised* rather than returned.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def cancel(self) -> bool:
+        """If possible, cancels execution of this node.
+
+        Returns True if cancellation succeeded, False if we could not cancel.
+        """
+        raise NotImplementedError()
+
+    def cancelled(self) -> bool:
+        """Returns True if the Node was cancelled."""
+        return self.status is Status.CANCELLED
+
+    def running(self) -> bool:
+        """Returns True if the Node is currently executing."""
+        return self.status is Status.RUNNING
+
+    def done(self) -> bool:
+        """Returns True if this Node has completed or been cancelled."""
+        with self._lifecycle_lock:
+            return self._done()
+
+    def add_done_callback(self, fn: Callable[["Node[_ET, _T]"], None]) -> None:
+        """Adds a callback that will be called when this Node completes.
+
+        While the current behavior is similar to the way ``add_done_callback``
+        on a regular ``Future`` works, we don't guarantee that it will remain
+        the same (e.g. will it be called immediately, on what thread).
+        Particularly, when retry functionality is later added to Nodes, this
+        behavior is likely to change.
+        """
+        with self._lifecycle_lock:
+            if not self._done():
+                self._callbacks.append(fn)
+                return
+
+        try:
+            fn(self)
+        except Exception:
+            _log.exception("%r callback %r failed", self, fn)
+
+    # Internals to handle Future methods.
+
+    def _done(self) -> bool:
+        """Internal implementation of ``done``.
+
+        The caller must already hold ``_lifecycle_lock``.
+
+        This needs to be separated from the ``done`` method so that
+        ``add_done_callback`` works correctly and can add a callback atomically,
+        without a race condition if a client adds a callback at the same time
+        as the Node completes.
+        """
+        return self._status_impl() in (
+            Status.CANCELLED,
+            Status.SUCCEEDED,
+            Status.FAILED,
+        )
+
+    def _do_callbacks(self) -> None:
+        """Actually performs the callbacks when a Node completes.
+
+        This should be called by the Node implementation exactly once,
+        with ``_lifecycle_lock`` *not* held.
+        """
+        assert self.done(), "_do_callbacks called when Node is not done"
+
+        # We don't need to hold _lifecycle_lock to iterate through _callbacks
+        # because add_done_callbacks guarantees that if the node is done,
+        # no more callbacks will be added to the list.
+        for fn in self._callbacks:
+            try:
+                fn(self)
+            except Exception:
+                _log.exception("%r callback %r failed", self, fn)


### PR DESCRIPTION
This is the beginning of the actual Executor implementation. The overall change is very large, but it's broken up into several parts to hopefully be easier to follow:

- Defining the basic interface of an executor.
- Filling in the very skeleton of that interface.
- Implementing a stored-parameter replacer.
- Creating the first Node implementation, the UDF node.

This is basically the bare-minimum task graph implementation. It's not complete, since it doesn't handle SQL, arrays, or inputs, but (as shown by the tests) can build viable graphs. Other node types will follow in subsequent changes, but I wanted to get this out before it got even larger.

[sc-14031]