### PR TITLE
Update test_threaded_import

### DIFF
--- a/requirements-py3.6.txt
+++ b/requirements-py3.6.txt
@@ -12,6 +12,6 @@ pyparsing==3.0.7
 python-dateutil==2.8.2
 pytz==2022.1
 six==1.16.0
-tiledb==0.13.3
+tiledb==0.15.2
 typing_extensions==4.1.1
 urllib3==1.26.9

--- a/requirements-py3.7.txt
+++ b/requirements-py3.7.txt
@@ -9,5 +9,5 @@ pyparsing==3.0.7
 python-dateutil==2.8.2
 pytz==2022.1
 six==1.16.0
-tiledb==0.13.3
+tiledb==0.15.2
 urllib3==1.26.9

--- a/requirements-py3.9.txt
+++ b/requirements-py3.9.txt
@@ -9,5 +9,5 @@ pyparsing==3.0.7
 python-dateutil==2.8.2
 pytz==2022.1
 six==1.16.0
-tiledb==0.13.1
+tiledb==0.15.2
 urllib3==1.26.9

--- a/tests/test_threaded_import.py
+++ b/tests/test_threaded_import.py
@@ -46,4 +46,4 @@ class TestThreadedImport(DiskTestCase):
         p2.start()
         p2.join()
         # fixed by https://github.com/TileDB-Inc/TileDB-Py/pull/1096
-        self.assertEqual(p2.exitcode, 1 if tiledb.__version__ < "0.15.2" else 0)
+        self.assertEqual(p2.exitcode, 0)

--- a/tests/test_threaded_import.py
+++ b/tests/test_threaded_import.py
@@ -5,32 +5,32 @@ from tiledb.tests.common import DiskTestCase
 from tiledb.tests.common import assert_subarrays_equal
 
 
-def threadtest_create_array(
-    uri,
-):
+def threadtest_create_array(uri):
     data = np.random.rand(20)
     schema = tiledb.libtiledb.schema_like(data)
     tiledb.Array.create(uri, schema)
-    with tiledb.DenseArray(uri, "w") as A:
+    with tiledb.open(uri, "w") as A:
         A[:] = data
 
 
 def threadtest_run_workers(uri):
-    def worker(n, uri):
-        with tiledb.DenseArray(uri) as A:
-            res = A.shape
-
-        return res
-
     import concurrent.futures
 
-    executor_cls = concurrent.futures.ThreadPoolExecutor
-    with executor_cls(max_workers=2) as executor:
-        futures = [executor.submit(worker, n, uri) for n in range(0, 5)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(worker, uri) for _ in range(0, 5)]
         res = [f.result() for f in concurrent.futures.as_completed(futures)]
+        assert all(res), res
 
 
-class ThreadedImportTest(DiskTestCase):
+def worker(uri):
+    with tiledb.open(uri) as A:
+        pass
+    from tiledb.cloud.cloudarray import CloudArray
+
+    return isinstance(A, CloudArray)
+
+
+class TestThreadedImport(DiskTestCase):
     def test_threaded_import(self):
         import multiprocessing as mp
 
@@ -45,9 +45,5 @@ class ThreadedImportTest(DiskTestCase):
         p2 = mpctx.Process(target=threadtest_run_workers, args=(uri,))
         p2.start()
         p2.join()
-        self.assertEqual(p2.exitcode, 0)
-
-        with tiledb.DenseArray(uri) as A:
-            from tiledb.cloud.cloudarray import CloudArray
-
-            self.assertTrue(CloudArray in A.__class__.__bases__)
+        # fixed by https://github.com/TileDB-Inc/TileDB-Py/pull/1096
+        self.assertEqual(p2.exitcode, 1 if tiledb.__version__ < "0.15.2" else 0)


### PR DESCRIPTION
Test for https://github.com/TileDB-Inc/TileDB-Py/pull/1096. Should be passing for tiledb>=0.15.2.