### PR TITLE
Create unified taskgraphs namespace.

### DIFF
--- a/tests/taskgraphs/test_taskgraphs.py
+++ b/tests/taskgraphs/test_taskgraphs.py
@@ -39,10 +39,13 @@ class TaskGraphsTest(unittest.TestCase):
 
         def to_utc(times):
             import datetime
+
             return [t.astimezone(datetime.timezone.utc) for t in times]
 
         utc_start_end = grf.udf(to_utc, tg.args(start_end), name="normalize")
-        length = grf.udf(lambda se: se[1] - se[0], tg.args(utc_start_end), name="length")
+        length = grf.udf(
+            lambda se: se[1] - se[0], tg.args(utc_start_end), name="length"
+        )
 
         def format_info(start_end, zone, length):
             start, end = start_end

--- a/tests/taskgraphs/test_taskgraphs.py
+++ b/tests/taskgraphs/test_taskgraphs.py
@@ -1,0 +1,65 @@
+"""Test for the unified ``tiledb.cloud.taskgraphs`` namespace."""
+
+import datetime
+import unittest
+from typing import Tuple
+
+import tiledb.cloud.taskgraphs as tg
+
+
+class TaskGraphsTest(unittest.TestCase):
+    def test_basic(self):
+        grf = tg.Builder()
+        year = grf.input("year")
+        month = grf.input("month")
+        day = grf.input("day")
+        zone = grf.input("timezone", "Europe/Athens")
+
+        as_date = grf.udf(datetime.date, tg.args(year, month, day))
+
+        def to_instants(
+            day: datetime.date,
+            zone_name: str,
+        ) -> Tuple[datetime.datetime, datetime.datetime]:
+            import datetime
+
+            from dateutil import tz
+
+            tomorrow = day + datetime.timedelta(days=1)
+            zone = tz.gettz(zone_name)
+
+            midnight = datetime.time(tzinfo=zone)
+
+            start_instant = datetime.datetime.combine(day, midnight)
+            end_instant = datetime.datetime.combine(tomorrow, midnight)
+
+            return start_instant, end_instant
+
+        start_end = grf.udf(to_instants, tg.args(as_date, zone))
+
+        def to_utc(times):
+            import datetime
+            return [t.astimezone(datetime.timezone.utc) for t in times]
+
+        utc_start_end = grf.udf(to_utc, tg.args(start_end), name="normalize")
+        length = grf.udf(lambda se: se[1] - se[0], tg.args(utc_start_end), name="length")
+
+        def format_info(start_end, zone, length):
+            start, end = start_end
+            return f"{start:%Y-%m-%d} to {end:%Y-%m-%d} in {zone} is {length}"
+
+        grf.udf(
+            format_info,
+            tg.args(start_end, zone, length),
+            result_format="json",
+            name="output",
+        )
+
+        exec = tg.execute(grf, year=2022, month=3, day=27)
+        exec.wait(30)
+        self.assertEqual(exec.status, tg.Status.SUCCEEDED)
+        self.assertEqual(datetime.timedelta(hours=23), exec.node(length).result())
+        self.assertEqual(
+            "2022-03-27 to 2022-03-28 in Europe/Athens is 23:00:00",
+            exec.node("output").result(),
+        )

--- a/tiledb/cloud/taskgraphs/__init__.py
+++ b/tiledb/cloud/taskgraphs/__init__.py
@@ -1,4 +1,71 @@
-"""This module contains currently-unused code for a task graph API refresh.
+"""Version 2 of the task graph API, allowing registration and sharing.
 
-It is not yet suitable for public consumption.
+This namespace groups together all the classes, functions, and other resources
+that a typical user will need when using task graphs. In most cases, you should
+not need to import anything from the sub-modules directly.
+
+By convention it is imported as ``tg``::
+
+    import tiledb.cloud.taskgraphs as tg
+
+These APIs are close to final, though still subject to minor changes. Consider
+this a late-stage beta. We will endeavor to maintain compatibility but cannot
+guarantee it 100%.
 """
+
+from typing import Any, Union
+
+from tiledb.cloud.taskgraphs import builder
+from tiledb.cloud.taskgraphs import client_executor
+from tiledb.cloud.taskgraphs import executor
+from tiledb.cloud.taskgraphs import registration
+from tiledb.cloud.taskgraphs import types
+
+#
+# Re-exports.
+#
+
+Builder = builder.TaskGraphBuilder
+InvalidStateError = client_executor.InvalidStateError
+Status = executor.Status
+args = types.args
+
+register = registration.register
+update = registration.update
+load = registration.load
+delete = registration.delete
+
+#
+# Helpers.
+#
+
+GraphOrRegistered = Union[executor.GraphStructure, str]
+"""Either a graph structure, or the name of a registered task graph."""
+
+
+def execute(
+    __graph: GraphOrRegistered,
+    **graph_inputs: Any,
+) -> executor.Executor:
+    """Executes this graph with default settings and the provided input values.
+
+    This is an all-in-one convenience function which will set up the default
+    executor (currently :class:`client_executor.LocalExecutor`), start execution
+    with the given input values (provided in ``kwargs``), and return the
+    :class:`executor.Executor` object that it built for inspection, use, and
+    result retrieval.
+
+    The graph can be specified as any of:
+
+    - A task graph builder.
+    - The output of a task graph builder.
+    - The name of a registered task graph, in the form "namespace/name".
+
+    For more advanced control, you should construct your own Executor and set
+    the desired options manually.
+    """
+
+    grf = load(__graph) if isinstance(__graph, str) else __graph
+    exec = client_executor.LocalExecutor(grf)
+    exec.execute(**graph_inputs)
+    return exec


### PR DESCRIPTION
Creates a unified namespace where users can import everything they'll need for task graphs in one place, and adds some initial tests to make sure it all works together. Further integration testing will come in follow-up changes.