### PR TITLE
Fix test_taskgraphs for Python 3.6.

### DIFF
--- a/tests/taskgraphs/test_taskgraphs.py
+++ b/tests/taskgraphs/test_taskgraphs.py
@@ -17,10 +17,7 @@ class TaskGraphsTest(unittest.TestCase):
 
         as_date = grf.udf(datetime.date, tg.args(year, month, day))
 
-        def to_instants(
-            day: datetime.date,
-            zone_name: str,
-        ) -> Tuple[datetime.datetime, datetime.datetime]:
+        def to_instants(day: datetime.date, zone_name: str):
             import datetime
 
             from dateutil import tz


### PR DESCRIPTION
Python 3.6 can't handle parameterized type hints. They were only there
for my own convenience in testing, so they're gone now.