### PR TITLE
Record executions to task graph logs.

### DIFF
--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -104,6 +104,14 @@ class Executor(Generic[_N], metaclass=abc.ABCMeta):
         """Waits for the execution of this task graph to complete."""
         raise NotImplementedError()
 
+    @property
+    @abc.abstractmethod
+    def server_graph_uuid(self) -> Optional[uuid.UUID]:
+        """The UUID of this execution's log as returned by the server.
+
+        If log submission failed (or the graph was not yet submitted), None.
+        """
+
     # Internals.
 
     def _add_node(self, node_json: Dict[str, Any]) -> None:


### PR DESCRIPTION
Adds the code to submit graph executions to the logs. "Virtual" nodes
are not currently reported in any manner.

---

While I don't have Python tests for this, I can confirm by looking at the task graph logs on TileDB Cloud that everything is being reported correctly.