### PR TITLE
Sa/sc 17990/sql resource classes

### DIFF
--- a/tiledb/cloud/rest_api/docs/SQLParameters.md
+++ b/tiledb/cloud/rest_api/docs/SQLParameters.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **output_uri** | **str** | Output array uri | [optional] 
 **store_results** | **bool** | store results for later retrieval | [optional] 
 **dont_download_results** | **bool** | Set to true to avoid downloading the results of this UDF. Useful for intermediate nodes in a task graph where you will not be using the results of your function. Defaults to false (\&quot;yes download results\&quot;). | [optional] 
+**resource_class** | **str** | The resource class to use for the SQL execution. Resource classes define resource limits for memory and CPUs. If this is empty, then the SQL will execute in the standard resource class of the TileDB Cloud provider.  | [optional] 
 **result_format** | [**ResultFormat**](ResultFormat.md) |  | [optional] 
 **init_commands** | **list[str]** | Queries or commands to run before main query | [optional] 
 **parameters** | **list[object]** | SQL query parameters | [optional] 

--- a/tiledb/cloud/rest_api/models/sql_parameters.py
+++ b/tiledb/cloud/rest_api/models/sql_parameters.py
@@ -38,6 +38,7 @@ class SQLParameters(object):
         "output_uri": "str",
         "store_results": "bool",
         "dont_download_results": "bool",
+        "resource_class": "str",
         "result_format": "ResultFormat",
         "init_commands": "list[str]",
         "parameters": "list[object]",
@@ -51,6 +52,7 @@ class SQLParameters(object):
         "output_uri": "output_uri",
         "store_results": "store_results",
         "dont_download_results": "dont_download_results",
+        "resource_class": "resource_class",
         "result_format": "result_format",
         "init_commands": "init_commands",
         "parameters": "parameters",
@@ -65,6 +67,7 @@ class SQLParameters(object):
         output_uri=None,
         store_results=None,
         dont_download_results=None,
+        resource_class=None,
         result_format=None,
         init_commands=None,
         parameters=None,
@@ -82,6 +85,7 @@ class SQLParameters(object):
         self._output_uri = None
         self._store_results = None
         self._dont_download_results = None
+        self._resource_class = None
         self._result_format = None
         self._init_commands = None
         self._parameters = None
@@ -99,6 +103,8 @@ class SQLParameters(object):
             self.store_results = store_results
         if dont_download_results is not None:
             self.dont_download_results = dont_download_results
+        if resource_class is not None:
+            self.resource_class = resource_class
         if result_format is not None:
             self.result_format = result_format
         if init_commands is not None:
@@ -224,6 +230,29 @@ class SQLParameters(object):
         """
 
         self._dont_download_results = dont_download_results
+
+    @property
+    def resource_class(self):
+        """Gets the resource_class of this SQLParameters.  # noqa: E501
+
+        The resource class to use for the SQL execution. Resource classes define resource limits for memory and CPUs. If this is empty, then the SQL will execute in the standard resource class of the TileDB Cloud provider.   # noqa: E501
+
+        :return: The resource_class of this SQLParameters.  # noqa: E501
+        :rtype: str
+        """
+        return self._resource_class
+
+    @resource_class.setter
+    def resource_class(self, resource_class):
+        """Sets the resource_class of this SQLParameters.
+
+        The resource class to use for the SQL execution. Resource classes define resource limits for memory and CPUs. If this is empty, then the SQL will execute in the standard resource class of the TileDB Cloud provider.   # noqa: E501
+
+        :param resource_class: The resource_class of this SQLParameters.  # noqa: E501
+        :type: str
+        """
+
+        self._resource_class = resource_class
 
     @property
     def result_format(self):

--- a/tiledb/cloud/rest_api/test/test_sql_parameters.py
+++ b/tiledb/cloud/rest_api/test/test_sql_parameters.py
@@ -42,6 +42,7 @@ class TestSQLParameters(unittest.TestCase):
                 output_uri="s3://my_bucket/my_output_array",
                 store_results=True,
                 dont_download_results=True,
+                resource_class="standard",
                 result_format="python_pickle",
                 init_commands=["0"],
                 parameters=[None],

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -32,6 +32,7 @@ def exec_base(
     result_format: str = models.ResultFormat.ARROW,
     result_format_version=None,
     store_results: bool = False,
+    resource_class: Optional[str] = None,
     _download_results: bool = True,
     _server_graph_uuid: Optional[uuid.UUID] = None,
     _client_node_uuid: Optional[uuid.UUID] = None,
@@ -52,6 +53,8 @@ def exec_base(
     :param str result_format_version: Deprecated and ignored.
     :param store_results: True to temporarily store results on the server side
         for later retrieval (in addition to downloading them).
+    :param resource_class: The name of the resource class to use. Resource classes
+        define maximum limits for cpu and memory usage.
     :param _server_graph_uuid: If this function is being executed within a DAG,
         the server-generated ID of the graph's log. Otherwise, None.
     :param _client_node_uuid: If this function is being executed within a DAG,
@@ -115,6 +118,7 @@ def exec_base(
             parameters=parameters,
             result_format=result_format,
             store_results=store_results,
+            resource_class=resource_class,
             dont_download_results=not _download_results,
             task_graph_uuid=_server_graph_uuid and str(_server_graph_uuid),
             client_node_uuid=_client_node_uuid and str(_client_node_uuid),


### PR DESCRIPTION
Ref https://app.shortcut.com/tiledb-inc/story/17990/sql-image-should-be-supported-by-standard-and-large-resource-classes

Api https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/pull/344

This PR is analogous to the UDF one https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/270