### PR TITLE
Generate nice node names by default.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,40 @@ class SourceLinesTest(unittest.TestCase):
         self.assertIsNone(utils.getsourcelines(dir))
 
 
+class FuncableTest(unittest.TestCase):
+    def test_good(self):
+        class ImCallable:
+            def __call__(self):
+                pass
+
+        items = (
+            "registered/udf",
+            len,
+            lambda: None,
+            self.test_good,
+            utils.check_funcable,
+            str.format,
+            "".format,
+            object,
+            FuncableTest,
+            ImCallable(),
+        )
+        for item in items:
+            with self.subTest(item):
+                utils.check_funcable(item=item)
+
+    def test_bad(self):
+        items = (
+            5,
+            object(),
+            os.path,
+        )
+        for item in items:
+            with self.subTest(item):
+                with self.assertRaises(TypeError):
+                    utils.check_funcable(item=item)
+
+
 class PickleTest(unittest.TestCase):
     def test_roundtrip(self):
         cases = (


### PR DESCRIPTION
This updates the task graph builder to generate names for graph nodes
when they are not provided by the caller. When building the graph for
execution or registration, the generated names are used for node names,
but only when they don't collide with a user-defined name.

---

Most of the change is tests so this shouldn’t be as scary as it looks.

[sc-18567]