### PR TITLE
Prepare main executor for retry support.

### DIFF
--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -177,15 +177,6 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
         """The location where this node will be executed."""
         return rest_api.TaskGraphLogRunLocation.SERVER
 
-    def task_id(self, timeout: Optional[float] = None) -> Optional[uuid.UUID]:
-        """The task ID that was returned from the server, if applicable.
-
-        If this was executed on the server side, this should return the UUID of
-        the actual execution of this task. If it was purely client-side, or the
-        server did not return a UUID, this should return None.
-        """
-        return None
-
 
 def wait_for(evt: threading.Event, timeout: Optional[float]) -> None:
     if not evt.wait(timeout):

--- a/tiledb/cloud/taskgraphs/client_executor/array_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/array_node.py
@@ -50,6 +50,9 @@ class ArrayNode(_base.Node[_base.ET, _T]):
             buffers=buffers,
         )
 
+    def task_id(self, timeout: Optional[float] = None) -> Optional[uuid.UUID]:
+        return None
+
     def _result_impl(self):
         raise TypeError("ArrayNode is a virtual node and does not have results.")
 

--- a/tiledb/cloud/taskgraphs/client_executor/input_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/input_node.py
@@ -43,6 +43,9 @@ class InputNode(_base.Node[_base.ET, _T]):
         if self._value_encoded is _base.NOTHING:
             raise KeyError(f"Input {self.name!r} must be provided")
 
+    def task_id(self, timeout: Optional[float] = None) -> Optional[uuid.UUID]:
+        return None
+
     def _result_impl(self):
         return self._value
 

--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -156,7 +156,7 @@ _T = TypeVar("_T")
 _Self = TypeVar("_Self", bound="Node")
 
 
-class Node(Generic[_ET, _T]):
+class Node(Generic[_ET, _T], metaclass=abc.ABCMeta):
     """An abstract type specifying the operations on a Node of a task graph.
 
     Executor implementations will return instances of implementations of these
@@ -288,6 +288,16 @@ class Node(Generic[_ET, _T]):
             fn(self)
         except Exception:
             _log.exception("%r callback %r failed", self, fn)
+
+    @abc.abstractmethod
+    def task_id(self, timeout: Optional[float] = None) -> Optional[uuid.UUID]:
+        """The task ID that was returned from the server, if applicable.
+
+        If this was executed on the server side, this should return the UUID of
+        the actual execution of this task. If it was purely client-side, or the
+        server did not return a UUID, this should return None.
+        """
+        raise NotImplementedError()
 
     # Internals to handle Future methods.
 


### PR DESCRIPTION
These changes update the executor interface and implementation to support firing "done" events multiple times. This is needed since, when a user retries, the graph will complete multiple times. It works by replacing the done Event (which, while it can be reset to be used multiple times, cannot in this implementation be synchronized) with a condition variable that looks at the graph's Status.