### PR TITLE
Allow callers to retry failed or cancelled task graph nodes.

### DIFF
--- a/tests/taskgraphs/test_registration.py
+++ b/tests/taskgraphs/test_registration.py
@@ -4,6 +4,7 @@ import time
 import unittest
 
 from tiledb.cloud import rest_api
+from tiledb.cloud import testonly
 from tiledb.cloud.taskgraphs import builder
 from tiledb.cloud.taskgraphs import registration
 from tiledb.cloud.taskgraphs import types
@@ -13,7 +14,7 @@ class RegistrationTest(unittest.TestCase):
     maxDiff = None
 
     def test_register(self):
-        name = f"zzz_unittest_manual_{random_letters(10)}"
+        name = testonly.random_name("registered_graph")
         grf = builder.TaskGraphBuilder(name=name)
         original = grf._tdb_to_json()
 

--- a/tests/taskgraphs/test_retries.py
+++ b/tests/taskgraphs/test_retries.py
@@ -1,0 +1,88 @@
+import operator
+import unittest
+from concurrent import futures
+
+import tiledb.cloud.taskgraphs as tg
+from tiledb.cloud import client
+from tiledb.cloud import testonly
+from tiledb.cloud.taskgraphs import client_executor
+
+
+class RetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._me = client.default_user().username
+
+    def test_retry_one(self):
+        fail_name = testonly.random_name("retry_one")
+        grf = tg.Builder("retry_one")
+        fail = grf.udf(f"{self._me}/{fail_name}")
+        last = grf.udf(lambda prev: f"got {prev!r}", tg.args(fail))
+
+        exec = tg.execute(grf)
+        fail_node = exec.node(fail)
+        last_node = exec.node(last)
+        with self.assertRaises(Exception):
+            fail_node.result(10)
+        with self.assertRaises(tg.ParentFailedError) as cm:
+            last_node.result(1)
+        self.assertIs(last_node.status, tg.Status.PARENT_FAILED)
+        self.assertIs(cm.exception.node, fail_node)
+
+        with testonly.register_udf(lambda: 100, fail_name):
+            fail_node.retry()
+            self.assertEqual(100, fail_node.result(10))
+            self.assertEqual("got 100", last_node.result(10))
+        exec.wait(1)
+
+    def test_retry_cascade(self):
+        grf = tg.Builder("retry_cancelled")
+        one = grf.udf(lambda: 1)
+        two = grf.udf(operator.add, tg.args(one, one))
+        three = grf.udf(operator.add, tg.args(one, two))
+        four = grf.udf(operator.add, tg.args(one, three))
+        seven = grf.udf(operator.add, tg.args(four, three))
+
+        exec = client_executor.LocalExecutor(grf)
+        one_node = exec.node(one)
+        two_node = exec.node(two)
+        seven_node = exec.node(seven)
+        two_node.cancel()
+        exec.execute()
+        self.assertEqual(1, one_node.result(10))
+        with self.assertRaises(futures.CancelledError):
+            two_node.result(1)
+        with self.assertRaises(tg.ParentFailedError):
+            seven_node.result(1)
+        exec.retry(two_node)
+        self.assertEqual(7, seven_node.result(20))
+        exec.wait(1)
+
+    def test_retry_all(self):
+        retry_all_b = testonly.random_name("retry_all_b")
+        grf = tg.Builder("retry_all")
+
+        def a_func():
+            return "a"
+
+        a = grf.udf(a_func, name="node a")
+        b = grf.udf(f"{self._me}/{retry_all_b}", name="node b")
+        c = grf.udf(lambda x: x, tg.args("c"), name="node c")
+
+        merge = grf.udf(" ".join, tg.args((a, b, c)), name="joiner")
+        final = grf.udf(repr, tg.args(merge), name="repr")
+
+        exec = client_executor.LocalExecutor(grf)
+        c_node = exec.node(c)
+        c_node.cancel()
+        final_node = exec.node(final)
+        final_node.cancel()
+
+        exec.execute()
+
+        with testonly.register_udf(lambda: "b", func_name=retry_all_b):
+            exec.retry_all()
+
+            exec.wait(30)
+
+        self.assertEqual("'a b c'", final_node.result(1))

--- a/tiledb/cloud/_common/ordered.py
+++ b/tiledb/cloud/_common/ordered.py
@@ -53,7 +53,10 @@ class FrozenSet(AbstractSet[_T_co]):
 
 
 class Set(FrozenSet[_T], MutableSet[_T]):
-    """An :class:`_OrderedFrozenSet`, but this time it's mutable."""
+    """An :class:`_OrderedFrozenSet`, but this time it's mutable.
+
+    Not guaranteed to be thread-safe.
+    """
 
     def copy(self: _Self) -> _Self:
         """Returns a shallow copy of this set. Equivalent to ``set.copy()``."""
@@ -77,6 +80,21 @@ class Set(FrozenSet[_T], MutableSet[_T]):
 
     def clear(self) -> None:
         self._dict.clear()
+
+    def popleft(self) -> _T:
+        """Drops and returns the least recently-added item. New!"""
+        try:
+            start = next(iter(self))
+        except StopIteration:
+            raise KeyError("pop from an empty ordered set")
+        self._dict.pop(start)
+        return start
+
+    def update(self, *others: Iterable[_T]) -> None:
+        """Adds every element from the ``others`` iterables to this one."""
+        for oth in others:
+            for item in oth:
+                self.add(item)
 
     __hash__ = None  # type: ignore[assignment]
     """This is mutable, so it's not hashable."""

--- a/tiledb/cloud/taskgraphs/__init__.py
+++ b/tiledb/cloud/taskgraphs/__init__.py
@@ -27,6 +27,7 @@ from tiledb.cloud.taskgraphs import types
 
 Builder = builder.TaskGraphBuilder
 InvalidStateError = client_executor.InvalidStateError
+ParentFailedError = executor.ParentFailedError
 Status = executor.Status
 args = types.args
 ArrayMultiIndex = types.ArrayMultiIndex

--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -16,12 +16,16 @@ NOTHING = object()
 """Sentinel value to distinguish missing values from None."""
 
 
-class IClientExecutor(executor.Executor["Node"]):
+class IClientExecutor(executor.Executor["Node"], metaclass=abc.ABCMeta):
     """Executor sub-interface adding type information used by Nodes."""
 
     _client: client.Client
     _namespace: str
     _server_graph_uuid: Optional[uuid.UUID]
+
+    @abc.abstractmethod
+    def _enqueue_done_node(self, node: "Node") -> None:
+        raise NotImplementedError()
 
 
 ET = TypeVar("ET", bound=IClientExecutor)
@@ -47,6 +51,10 @@ class ParamFormat(enum.Enum):
     """
 
 
+_Self = TypeVar("_Self", bound="Node")
+"""Type for self-annotations where needed"""
+
+
 class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
     """Base class for Nodes to be executed locally.
 
@@ -55,7 +63,6 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self._event = threading.Event()
         self._status: Status = Status.WAITING
         self._result_exception: Optional[Exception] = None
         """An exception that was raised when executing the Node."""
@@ -66,65 +73,45 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
         by methods like `.exception()` rather than returned.
         """
 
-    # External API
+    #
+    # External API.
+    #
 
     def result(self, timeout: Optional[float] = None) -> _T:
-        self.wait(timeout)
-        # Because it's guaranteed that `exception` will *never be written to*
-        # after the `_event` is set, we don't need to hold a lock here.
-        exc = self._lifecycle_exception or self._result_exception
-        if exc:
-            raise exc
-        return self._result_impl()
+        with self._lifecycle_condition:
+            self._lifecycle_condition.wait_for(self._done, timeout)
+            exc = self._lifecycle_exception or self._result_exception
+            if exc:
+                raise exc
+            return self._result_impl()
 
     def exception(self, timeout: Optional[float] = None) -> Optional[Exception]:
-        self.wait(timeout)
-        if self._lifecycle_exception:
-            raise self._lifecycle_exception
-        return self._result_exception
+        with self._lifecycle_condition:
+            self._lifecycle_condition.wait_for(self._done, timeout)
+            if self._lifecycle_exception:
+                raise self._lifecycle_exception
+            return self._result_exception
 
     def cancel(self) -> bool:
-        cancelled = self._set_status_if_can_start(Status.CANCELLED)
-        if cancelled:
-            # If we were successful at cancelling this Node, we effectively
-            # "own" the result fields on this thread. We can set them safely
-            # ourselves before firing the Event.
+        with self._lifecycle_condition:
+            cancelled = self._set_status_if_can_start(Status.CANCELLED)
+            if not cancelled:
+                return cancelled
             self._lifecycle_exception = futures.CancelledError()
-            self._event.set()
-            self._do_callbacks()
+            self._lifecycle_condition.notify_all()
+            self.owner._enqueue_done_node(self)
+            cbs = self._callbacks()
+        if cancelled:
+            executor.do_callbacks(self, cbs)
         return cancelled
 
     def wait(self, timeout: Optional[float] = None) -> None:
-        wait_for(self._event, timeout)
+        with self._lifecycle_condition:
+            self._lifecycle_condition.wait_for(self._done, timeout)
 
-    # Internals
-
-    def _status_impl(self) -> Status:
-        return self._status
-
-    def _exec(self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
-        """The boilerplate for the ``_exec`` implementation for local Nodes.
-
-        This handles all the lifecycle management for Node execution. It should
-        only ever be called by the Executor. Subclasses should instead implement
-        ``_exec_impl``, which contains the type-specific behavior.
-        """
-        if not self._set_status_if_can_start(Status.RUNNING):
-            return
-
-        try:
-            self._exec_impl(parents, input_value)
-        except Exception as ex:
-            with self._lifecycle_lock:
-                self._status = Status.FAILED
-                self._result_exception = ex
-            raise
-        else:
-            with self._lifecycle_lock:
-                self._status = Status.SUCCEEDED
-        finally:
-            self._event.set()
-            self._do_callbacks()
+    #
+    # Abstract methods to be implemented by subclasses to do the work of a Node.
+    #
 
     @abc.abstractmethod
     def _exec_impl(self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
@@ -140,12 +127,63 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def _encode_for_param(self, mode: ParamFormat) -> Any:
+        """Encodes the result of this node for use in a JSON parameter list.
+
+        This is used to pass the output of this Node into the parameters of a
+        following Node.
+        """
+        raise NotImplementedError()
+
+    #
+    # Execution internals
+    #
+
+    def _status_impl(self) -> Status:
+        return self._status
+
+    def _exec(self: _Self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
+        """The boilerplate for the ``_exec`` implementation for local Nodes.
+
+        This handles all the lifecycle management for Node execution. It should
+        only ever be called by the Executor. Subclasses should instead implement
+        ``_exec_impl``, which contains the type-specific behavior.
+        """
+        with self._lifecycle_condition:
+            # Make sure we're still in a runnable state (weren't just cancelled)
+            if not self._set_status_if_can_start(Status.RUNNING):
+                return
+
+        try:
+            self._exec_impl(parents, input_value)
+        except Exception as ex:
+            with self._lifecycle_condition:
+                self._set_status_notify(Status.FAILED)
+                self._result_exception = ex
+                self.owner._enqueue_done_node(self)
+                cbs = self._callbacks()
+            raise
+        else:
+            with self._lifecycle_condition:
+                self._set_status_notify(Status.SUCCEEDED)
+                self._result_exception = None
+                self.owner._enqueue_done_node(self)
+                cbs = self._callbacks()
+        finally:
+            executor.do_callbacks(self, cbs)
+
+    #
+    # Lifecycle-management internals.
+    #
+
     def _assert_succeeded(self) -> None:
         if self._status is not Status.SUCCEEDED:
             raise AssertionError("_encoded_result is only valid for successful nodes")
 
     def _set_ready(self) -> None:
-        self._set_status_if_can_start(Status.READY)
+        with self._lifecycle_condition:
+            self._set_status_if_can_start(Status.READY)
 
     def _set_status_if_can_start(self, status: Status) -> bool:
         """If this node is allowed to start, updates its status.
@@ -153,19 +191,34 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
         Updates the status of this node, but only if it's unstarted (and is able
         to be started). Used to implement both :meth:`cancel` and the equivalent
         of ``Future.set_running_or_notify_cancel``.
-        """
-        with self._lifecycle_lock:
-            if self._status in (Status.WAITING, Status.READY):
-                self._status = status
-                return True
-            return False
 
-    def _set_parent_failed(self, pfe: executor.ParentFailedError) -> None:
-        failed = self._set_status_if_can_start(Status.PARENT_FAILED)
-        if failed:
+        ``_lifecycle_condition`` must be held.
+        """
+        if self._status in (Status.WAITING, Status.READY):
+            self._set_status_notify(status)
+            return True
+        return False
+
+    def _set_status_notify(self, status: Status) -> None:
+        """Sets the Node's status and notifies waiters.
+
+        ``_lifecycle_condition`` must be held.
+        """
+        if self._status is status:
+            return
+        self._status = status
+        self._lifecycle_condition.notify_all()
+
+    def _set_parent_failed(self: _Self, pfe: executor.ParentFailedError) -> None:
+        with self._lifecycle_condition:
+            could_set = self._set_status_if_can_start(Status.PARENT_FAILED)
+            if not could_set:
+                return
             self._lifecycle_exception = pfe
-            self._event.set()
-            self._do_callbacks()
+            self.owner._enqueue_done_node(self)
+            cbs = self._callbacks()
+
+        executor.do_callbacks(self, cbs)
 
     def _parent_failed_error(self) -> executor.ParentFailedError:
         """Returns the PFE that should be associated with this Node.
@@ -184,16 +237,18 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
         if st is Status.PARENT_FAILED:
             assert isinstance(self._lifecycle_exception, executor.ParentFailedError)
             return self._lifecycle_exception
-        raise AssertionError(f"Accessing _parent_failed_error with status {st}")
+        raise AssertionError(f"Accessing {self}._parent_failed_error() with status {st}")
 
-    @abc.abstractmethod
-    def _encode_for_param(self, mode: ParamFormat) -> Any:
-        """Encodes the result of this node for use in a JSON parameter list.
-
-        This is used to pass the output of this Node into the parameters of a
-        following Node.
-        """
-        raise NotImplementedError()
+    def _prepare_to_retry(self) -> None:
+        with self._lifecycle_condition:
+            assert self._status in (
+                Status.FAILED,
+                Status.CANCELLED,
+                Status.PARENT_FAILED,
+            )
+            self._set_status_notify(Status.WAITING)
+            self._lifecycle_exception = None
+            self._result_exception = None
 
     def _to_log_metadata(
         self,

--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -1,11 +1,11 @@
 """Generic interfaces for task graph executors."""
 
 import abc
-from concurrent import futures
 import enum
 import logging
 import threading
 import uuid
+from concurrent import futures
 from typing import (
     Any,
     Callable,
@@ -119,6 +119,18 @@ class Executor(Generic[_N], metaclass=abc.ABCMeta):
         be cancelled, and ``False`` if not.
         """
         return False
+
+    def retry(self, node: _N) -> bool:
+        """Attempts to retry a node.
+
+        Returns True if the node was retried, false if not.
+        """
+        del node  # Default implementation does nothing.
+        return False
+
+    def retry_all(self) -> None:
+        """Retries all retry-able nodes."""
+        pass  # By default, do nothing
 
     @property
     @abc.abstractmethod
@@ -333,6 +345,10 @@ class Node(Generic[_ET, _T], metaclass=abc.ABCMeta):
         server did not return a UUID, this should return None.
         """
         raise NotImplementedError()
+
+    def retry(self) -> bool:
+        """Attempts to submit this node for retry, if possible."""
+        return self.owner.retry(self)
 
     # Internals to handle Future methods.
 


### PR DESCRIPTION
This adds retry logic to the new task graph API. The `Executor` itself
is responsible for handling all retries, with a convenience method on
each `Node` to perform a retry if necessary.

Retries are handled on the same event loop as all other graph lifecycle
management operations, and are accomplished by resetting the state of
the to-be-retried node, re-walking the graph, and re-enqueuing all nodes
that should be run as needed.