### PR TITLE
Add retries into legacy task graph API.

### DIFF
--- a/tiledb/cloud/_common/futures.py
+++ b/tiledb/cloud/_common/futures.py
@@ -1,0 +1,94 @@
+"""Classes and helpers for dealing with concurrency and futures.
+
+This is intended to be a drop-in replacement for the ``concurrent.futures``
+module (to the extent that we use it).
+"""
+
+import abc
+import sys
+import threading
+import warnings
+from concurrent import futures
+from typing import Callable, Generic, Iterable, Optional, TypeVar
+
+_T = TypeVar("_T")
+
+# Re-exports from the built-in futures module.
+Future = futures.Future
+CancelledError = futures.CancelledError
+TimeoutError = futures.TimeoutError
+Executor = futures.Executor
+ProcessPoolExecutor = futures.ProcessPoolExecutor
+ThreadPoolExecutor = futures.ThreadPoolExecutor
+
+if sys.version_info < (3, 8):
+
+    class InvalidStateError(futures._base.Error):
+        """The operation is not allowed in this state."""
+
+else:
+    InvalidStateError = futures.InvalidStateError
+
+
+# New stuff.
+
+
+class FutureLike(Generic[_T], metaclass=abc.ABCMeta):
+    """The public-facing API of Futures.
+
+    Ideally this would be a Protocol, but those aren't in Python before 3.8.
+
+    Implementations of this class may have different behaviors than standard
+    Futures if they support additional operations (like retrying), but when
+    a client does not use those operations, it should behave just like a
+    standard :class:`futures.Future`.
+    """
+
+    @abc.abstractmethod
+    def cancel(self) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def cancelled(self) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def running(self) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def done(self) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def exception(self, timeout: Optional[float] = None) -> Optional[BaseException]:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def result(self, timeout: Optional[float] = None) -> _T:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_done_callback(self, fn: Callable[["FutureLike[_T]"], None]) -> None:
+        raise NotImplementedError()
+
+
+FutureLike.register(Future)
+
+
+def wait_for(
+    w: threading.Condition, pred: Callable[[], bool], timeout: Optional[float]
+) -> None:
+    """Waits for a condition variable or raises an error on timeout."""
+    if not w.wait_for(pred, timeout):
+        raise TimeoutError(f"timed out after {timeout} sec")
+
+
+def execute_callbacks(thing: _T, callbacks: Iterable[Callable[[_T], None]]) -> None:
+    """Runs callback functions and swallows errors."""
+
+    for cb in callbacks:
+        try:
+            cb(thing)
+        except Exception as exc:
+            warnings.warn(UserWarning(f"{exc} in callback {cb}({thing!r})"))

--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -112,24 +112,6 @@ class RemoteResult(Result[_T], Generic[_T]):
     _decoded: Any = attrs.field(default=_SENTINEL)
 
 
-class UnwrapperProxy(Generic[_T]):
-    """Implements the public API of a Future but unwraps what it's given."""
-
-    def __init__(self, wrapped: "futures.Future[Result[_T]]"):
-        self._wrapped = wrapped
-        self.cancel = self._wrapped.cancel
-        self.cancelled = self._wrapped.cancelled
-        self.running = self._wrapped.running
-        self.done = self._wrapped.done
-        self.exception = self._wrapped.exception
-
-    def result(self, timeout: Optional[float] = None) -> _T:
-        return self._wrapped.result(timeout).get()
-
-    def add_done_callback(self, fn: Callable[["futures.Future[_T]"], None]) -> None:
-        self._wrapped.add_done_callback(lambda _: fn(self))  # type: ignore[arg-type]
-
-
 class AsyncResult(Generic[_T]):
     """Asynchronous wrapper for compatibility with the old array.TaskResult."""
 

--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -3,7 +3,6 @@
 import abc
 import threading
 import uuid
-from concurrent import futures
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 import attrs
@@ -12,6 +11,7 @@ import urllib3
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud._common import futures
 from tiledb.cloud._results import decoders
 from tiledb.cloud._results import stored_params
 

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -7,7 +7,6 @@ import threading
 import time
 import uuid
 import warnings
-from concurrent import futures
 from typing import (
     Any,
     Callable,
@@ -32,6 +31,7 @@ from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error as tce
 from tiledb.cloud import udf
 from tiledb.cloud import utils
+from tiledb.cloud._common import futures
 from tiledb.cloud._common import visitor
 from tiledb.cloud._results import results
 from tiledb.cloud._results import stored_params

--- a/tiledb/cloud/dag/status.py
+++ b/tiledb/cloud/dag/status.py
@@ -7,6 +7,7 @@ class Status(enum.Enum):
     COMPLETED = 3
     FAILED = 4
     CANCELLED = 5
+    PARENT_FAILED = 6
 
     def __str__(self):
         return self.name.replace("_", " ").title()

--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -4,11 +4,11 @@ import abc
 import enum
 import threading
 import uuid
-from concurrent import futures
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar
 
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
+from tiledb.cloud._common import futures
 from tiledb.cloud.taskgraphs import executor
 
 Status = executor.Status
@@ -102,7 +102,7 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
             self.owner._enqueue_done_node(self)
             cbs = self._callbacks()
         if cancelled:
-            executor.do_callbacks(self, cbs)
+            futures.execute_callbacks(self, cbs)
         return cancelled
 
     def wait(self, timeout: Optional[float] = None) -> None:
@@ -171,7 +171,7 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
                 self.owner._enqueue_done_node(self)
                 cbs = self._callbacks()
         finally:
-            executor.do_callbacks(self, cbs)
+            futures.execute_callbacks(self, cbs)
 
     #
     # Lifecycle-management internals.
@@ -229,7 +229,7 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
             self.owner._enqueue_done_node(self)
             cbs = self._callbacks()
 
-        executor.do_callbacks(self, cbs)
+        futures.execute_callbacks(self, cbs)
 
     def _parent_failed_error(self) -> executor.ParentFailedError:
         """Returns the PFE that should be associated with this Node.

--- a/tiledb/cloud/taskgraphs/client_executor/impl.py
+++ b/tiledb/cloud/taskgraphs/client_executor/impl.py
@@ -8,11 +8,11 @@ import threading
 import traceback
 import uuid
 import warnings
-from concurrent import futures
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
+from tiledb.cloud._common import futures
 from tiledb.cloud._common import ordered
 from tiledb.cloud.taskgraphs import executor
 from tiledb.cloud.taskgraphs.client_executor import _base
@@ -21,16 +21,7 @@ from tiledb.cloud.taskgraphs.client_executor import input_node
 from tiledb.cloud.taskgraphs.client_executor import sql_node
 from tiledb.cloud.taskgraphs.client_executor import udf_node
 
-# Define InvalidStateError if it hasn't been defined yet.
-if hasattr(futures, "InvalidStateError"):
-    InvalidStateError = futures.InvalidStateError  # type: ignore[attr-defined]
-
-else:
-
-    class InvalidStateError(futures._base.Error):  # type: ignore[attr-defined,no-redef]
-        """The operation is not allowed in this state."""
-
-
+InvalidStateError = futures.InvalidStateError
 Status = _base.Status
 _T = TypeVar("_T")
 Node = _base.Node["LocalExecutor", _T]


### PR DESCRIPTION
This change adds the ability to retry failed tasks to the legacy task
graphs/delayed API. Doing this required effectively rewriting most of
the way execution is handled. There's not much that can be done to
disentangle these changes.

Externally-visible changes are:

- Adds `retry()` method to Node and `retry_all()` to DAG.

- Nodes and DAGs can now "finish" multiple times and may be reset when
  they are retried.

- Adds a PARENT FAILED state, to ensure that we can differentiate
  between nodes that fail themselves or are cancelled and nodes that
  are unable to run because one of their parents failed.  For consumers
  using the Future-style API, this is treated like cancellation.

- There may be minor changes in the ordering of events when callbacks
  are called. Clients should not be adversely affected by these,
  since Nodes and DAGs now provide improved correctness.

DAG class changes:

- Add synchronization and lock things with a condition variable.
  This both preserves internal invariants and allows us to efficiently
  signal state changes (using wait/notify rather than polling).
  This was originally chosen to be less intrusive to the implementation
  than rewriting the entire thing with an event loop. Whether this
  ended up being true is debatable.

- Adds new "node executor" separate from the "task executor". This
  ensures that we can run the node lifecycle code (starting, parameter
  management, etc.) separately from the server-side calls. This resolves
  an issue where using processes instead of threads was no longer
  working (as it is impossible to serialize a lock to another process).

Node class changes:

- Handles lifecycle management in-house rather than delegating to an
  internal Future. We use the lifecycle condition as a lock to ensure
  access is properly synchronized and invariants are held.

- Implements the entire public API of Future in the Node itself,
  so that we don't need to proxy results to a proper futures.Future
  only for the purposes of returning to the user.  This is also
  necessary so that we can handle the "resettable future" semantics
  that retry functionality requires.

The trickiest parts of the control flow come from the way locking works.

- All callbacks always must be called when the object's condition lock
  is *not* held. Otherwise, the callback may try to re-enter the lock
  which is already held on the same thread. This is not allowed because
  we use traditional locks (not reentrant locks) so we're always
  guaranteed that at the time we take a lock, our invariants hold,
  and likewise that we have restored all applicable invariants when we
  release the lock.

- We can't `.cancel()` nodes while the DAG holds its own lock. This is
  an implementation-specific detail of the way both Python's stdlib
  Futures work and our reimplementation within Node does:

  When a lifecycle action like `.cancel()` is called, it immediately
  calls its own callback functions on the same thread. One of the
  actions is to notify the DAG that the node failed, which happens
  synchronously. This takes the DAG's lock, which is already held.

  This is also why setting PARENT FAILED happens in the `_dag_exec`
  function, which executes later on the node runner thread.