### PR TITLE
Add the ability to name a Delayed task graph and improve failure.

### DIFF
--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -105,8 +105,10 @@ class DelayedFailureTest(unittest.TestCase):
         # Add timeout so we don't wait forever in CI
         node2.set_timeout(30)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(futures.CancelledError):
             node2.compute()
+        with self.assertRaises(TypeError):
+            node2.dag.wait(1)
 
         self.assertEqual(node.status, Status.FAILED)
         self.assertEqual(


### PR DESCRIPTION
- Per a request from on high, adds a `name` parameter to Delayed's
  `.compute` method allowing you to name the task graph it constructs.
- Improves failure behavior: calling `.compute` on a Delayed node will
  fail only if the node itself (or one of its parents) fails, not if
  any unrelated node fails.