### PR TITLE
Update documentation and workflows to use `main`.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "codeql-analysis"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     # Time randomly-selected by the autogenerator to spread load.
     - cron: '29 17 * * 3'

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "*" ]
   push:
-    branches: [ master ]
+    branches: [ main ]
   release:
     types: [ published ]
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # TileDB-Cloud-Py
 
-[![Azure Pipelines](https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/TileDB-Inc.TileDB-Cloud-Py?branchName=master)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=13&branchName=master)
-
 This repository contains the Python client for the TileDB Cloud Service.
 
 ## Quick Links


### PR DESCRIPTION
The default branch is now `main`, so things should be updated to reflect that.