### PR TITLE
Use `client_node_id` for array node parameter ID.

### DIFF
--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -281,7 +281,6 @@ class TestBuilder(unittest.TestCase):
                 },
                 {
                     "array_node": {
-                        "parameter_id": "0badc0de-dead-beef-cafe-000000000001",
                         "ranges": {"ranges": [[1, 1, 2, 4], []]},
                         "uri": {
                             "__tdbudf__": "node_output",

--- a/tiledb/cloud/taskgraphs/builder.py
+++ b/tiledb/cloud/taskgraphs/builder.py
@@ -352,7 +352,6 @@ class _ArrayNode(Node[types.ArrayMultiIndex]):
     def to_registration_json(self, existing_names: Set[str]) -> Dict[str, Any]:
         ret = super().to_registration_json(existing_names)
         node_data = dict(
-            parameter_id=str(self.id),
             uri=self.uri,
             ranges={"ranges": self.raw_ranges},
         )

--- a/tiledb/cloud/taskgraphs/client_executor/array_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/array_node.py
@@ -24,8 +24,6 @@ class ArrayNode(_base.Node[_base.ET, _T]):
     ):
         super().__init__(uid, owner, name)
         self._array_data = json_data["array_node"]
-        array_data = json_data["array_node"]
-        self._parameter_id = array_data["parameter_id"]
         self._details: Optional[Dict[str, Any]] = None
 
     def _exec_impl(
@@ -46,7 +44,7 @@ class ArrayNode(_base.Node[_base.ET, _T]):
         # TODO: remove this.
         ranges["ranges"] = ranges.get("ranges") or []
         self._details = dict(
-            parameter_id=self._parameter_id,
+            parameter_id=str(self.id),
             uri=uri,
             ranges=ranges,
             buffers=buffers,


### PR DESCRIPTION
For `ArrayNode`s, the UUID that we use for the parameter ID has always
been the `id` of the node itself. There’s no reason to duplicate this
information in the array node data itself.