### PR TITLE
Allow nodes of modern task graphs to be executed locally.

### DIFF
--- a/tests/taskgraphs/delayed/test_delayed_funcs.py
+++ b/tests/taskgraphs/delayed/test_delayed_funcs.py
@@ -1,4 +1,6 @@
 import operator
+import os.path
+import tempfile
 import time
 import unittest
 
@@ -78,6 +80,20 @@ class FunctionsTest(unittest.TestCase):
         self.assertEqual(node_4.result(), 8)
         self.assertEqual(node_5.result(), 8)
         self.assertEqual(node_6.result(), 24)
+
+    def test_local(self):
+        def touch(file):
+            open(file, "w").close()
+            return file
+
+        d_touch = delayed.udf(touch, local=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fn = os.path.join(tmpdir, "testfile")
+
+            node = d_touch(fn)
+            self.assertEqual(fn, node.compute(5))
+            self.assertTrue(os.path.exists(fn))
 
     def test_register(self):
         d_repr = delayed.udf(repr)

--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -130,6 +130,7 @@ class TestBuilder(unittest.TestCase):
                 "{it!r} has a length of {ln}".format,
                 types.args(it=start, ln=length),
                 name="result",
+                local=True,
             )
             expected = {
                 "name": "my cool task graph",
@@ -188,6 +189,7 @@ class TestBuilder(unittest.TestCase):
                             "environment": {
                                 "language": "python",
                                 "language_version": utils.PYTHON_VERSION,
+                                "run_client_side": True,
                             },
                             "executable_code": "gASVQwAAAAAAAACMCGJ1aWx0aW5zlIwHZ2V0YXR0cpSTlIwbe2l0IXJ9IGhhcyBhIGxlbmd0aCBvZiB7bG59lIwGZm9ybWF0lIaUUpQu",
                             "result_format": "python_pickle",
@@ -249,6 +251,7 @@ class TestBuilder(unittest.TestCase):
                     sql_node,
                 ),
                 name="output",
+                local=True,
             )
 
             grf.udf(
@@ -442,6 +445,7 @@ class TestBuilder(unittest.TestCase):
                         "environment": {
                             "language": "python",
                             "language_version": utils.PYTHON_VERSION,
+                            "run_client_side": True,
                         },
                         "executable_code": "gASVTgAAAAAAAACMCGJ1aWx0aW5zlIwHZ2V0YXR0cpSTlIwmYXJyYXkgeyFyfSBnYXZlIHJlc3VsdCB7fTsgc3FsIGdhdmUge32UjAZmb3JtYXSUhpRSlC4=",
                         "result_format": "python_pickle",

--- a/tests/taskgraphs/test_registration.py
+++ b/tests/taskgraphs/test_registration.py
@@ -29,12 +29,20 @@ class RegistrationTest(unittest.TestCase):
                 raw_ranges=[[1, 2], [3, 4]],
                 layout="c",
             )
-            grf.udf(
+            repr_node = grf.udf(
                 repr,
                 types.args(arr_node),
                 name="ooga",
                 result_format="booga",
                 image_name="monkey",
+            )
+            grf.udf(
+                len,
+                types.args(repr_node),
+                name="hee",
+                result_format="haw",
+                image_name="cowboy",
+                local=True,
             )
             updated = grf._tdb_to_json()
             registration.update(grf)

--- a/tiledb/cloud/taskgraphs/builder.py
+++ b/tiledb/cloud/taskgraphs/builder.py
@@ -508,9 +508,8 @@ class _UDFNode(Node[_T]):
         See :meth:`TaskGraphBuilder.udf` for details.
         """
         utils.check_funcable(func=func)
-        if isinstance(func, str):
-            if local:
-                raise ValueError("Registered UDFs may only be executed server-side.")
+        if isinstance(func, str) and local:
+            raise ValueError("Registered UDFs may only be executed server-side.")
         jsoner = _ParameterEscaper()
         self.args = jsoner.arguments_to_json(args)
         if local and any(isinstance(node, _ArrayNode) for node in jsoner.seen_nodes):

--- a/tiledb/cloud/taskgraphs/client_executor/_replacers.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_replacers.py
@@ -1,11 +1,12 @@
 """Classes that descend into things and do replacements."""
 
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from tiledb.cloud._common import ordered
 from tiledb.cloud._common import visitor
 from tiledb.cloud.taskgraphs import _codec
+from tiledb.cloud.taskgraphs import types
 from tiledb.cloud.taskgraphs.client_executor import _base
 
 
@@ -33,6 +34,8 @@ class NodeOutputValueReplacer(_codec.Unescaper):
 
 
 class UDFParamReplacer(visitor.ReplacingVisitor):
+    """Converts ``RegisteredArg`` values to ``CallArg``[``StoredParams``]."""
+
     # This isn't an Unescaper since we don't want to unescape non-JSON values,
     # we only want to replace parent nodes with their data.
 
@@ -81,3 +84,71 @@ class UDFParamReplacer(visitor.ReplacingVisitor):
         # If it was neither an escape sequence or a node output,
         # do not dig further into the value.
         return visitor.Replacement(arg)
+
+
+def visit_args(
+    vtor: visitor.ReplacingVisitor, args: types.Arguments
+) -> types.Arguments:
+    return types.Arguments(
+        (vtor.visit(a) for a in args.args),
+        {k: vtor.visit(v) for k, v in args.kwargs.items()},
+    )
+
+
+UDFArgument = Dict[str, Any]
+"""Marker for a structured dict for an argument, with ``name`` and ``value``."""
+
+
+def parse_json_args(json_args: List[UDFArgument]) -> types.Arguments:
+    """Parses a list of ``UDFArgument``s into an ``Arguments`` instance.
+
+    This takes the ``UDFArgument`` sequence and turns it into its ``args`` and
+    ``kwargs`` values, without performing any parsing of the actual values
+    inside each of the arguments (that is, it turns the JSON list into a
+    list of args and a dict of kwargs, but does not perform further processing).
+    """
+    # Usually we don't include internal type-checks, but this function is also
+    # used on the server-side UDF executor, where we do want to ensure that
+    # we don't get the wrong type of data.
+    arg_type = type(json_args)
+    if arg_type is not list:
+        raise ValueError(
+            f"Arguments must be a list of TGUDFArgument dicts, not {arg_type}"
+        )
+    args: List[Any] = []
+    kwargs: Dict[str, Any] = {}
+    for pos, entry in enumerate(json_args):
+        e_type = type(entry)
+        if e_type is not dict:
+            raise ValueError(
+                "Each argument entry must be a TGUDFArgument dict."
+                f" Position {pos} was of type {e_type}."
+            )
+        name = entry.get("name")
+        # Go likes to eat `null` and turn it into a missing field, so we have to
+        # assume that a missing `value` field means None.
+        value = entry.get("value")
+        if name is None:
+            if kwargs:
+                # If 'name' is not present but kwargs already has been set,
+                # that means a positional argument appears after a named arg.
+                # This is not allowed.
+                raise ValueError(
+                    "All positional args must appear before all named args."
+                    f" Positional arg at index {pos} appears after named args"
+                    f" {tuple(kwargs)}."
+                )
+            args.append(value)
+        else:
+            if name in kwargs:
+                prev = len(args)
+                for kw in kwargs:
+                    if name == kw:
+                        break
+                    prev += 1
+                raise ValueError(
+                    f"Keyword arg {name!r} (at index {pos})"
+                    f" has already been used (at index {prev})."
+                )
+            kwargs[name] = value
+    return types.Arguments(args, kwargs)

--- a/tiledb/cloud/taskgraphs/client_executor/udf_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/udf_node.py
@@ -79,8 +79,8 @@ class UDFNode(_base.Node[_base.ET, _T]):
             self._exec_local(parents)
             # TODO: Add a way that users can specify that they want to retry
             # a local UDF remotely.
-            return
-        self._exec_remote(parents)
+        else:
+            self._exec_remote(parents)
 
     def _exec_local(self, parents: Dict[uuid.UUID, _base.Node]) -> None:
         lang = self._environment.get("language")

--- a/tiledb/cloud/taskgraphs/client_executor/udf_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/udf_node.py
@@ -1,6 +1,11 @@
+import base64
+import datetime
+import multiprocessing
 import uuid
 from typing import AbstractSet, Any, Dict, List, Optional, Sequence, TypeVar
 
+import attrs
+import cloudpickle
 import urllib3
 
 from tiledb.cloud import rest_api
@@ -8,11 +13,18 @@ from tiledb.cloud._common import json_safe
 from tiledb.cloud._common import ordered
 from tiledb.cloud._results import results
 from tiledb.cloud.taskgraphs import _codec
+from tiledb.cloud.taskgraphs import types
 from tiledb.cloud.taskgraphs.client_executor import _base
 from tiledb.cloud.taskgraphs.client_executor import _replacers
 from tiledb.cloud.taskgraphs.client_executor import array_node
 
 _T = TypeVar("_T")
+
+_DEFAULT_LOCAL_TIMEOUT = datetime.timedelta(hours=1)
+"""The default maximum amout of time we allow a local UDF to run."""
+
+
+_MP_CTX = multiprocessing.get_context("spawn")
 
 
 class UDFNode(_base.Node[_base.ET, _T]):
@@ -27,10 +39,19 @@ class UDFNode(_base.Node[_base.ET, _T]):
     ):
         super().__init__(uid, owner, name)
         udf_data: Dict[str, Any] = json_data["udf_node"]
-        self._udf_data = udf_data
-        """The UDF details, in JSON dict format."""
+        self._environment: Dict[str, Any] = udf_data.get("environment", {})
+        """Information about the environment where this UDF will run."""
+        self._executable_code: Optional[str] = udf_data.get("executable_code")
+        """The base64 pickle of the code to be executed, if present."""
         self._registered_udf_name: Optional[str] = udf_data.get("registered_udf_name")
-        """The UDF name, used to give this node a fallback name."""
+        """The name of the registered UDF to execute, if present."""
+        self._arguments: List[_replacers.UDFArgument] = udf_data.get("arguments", [])
+        """The RegisteredArg-formatted args that will be passed to this UDF."""
+        self._source_text: Optional[str] = udf_data.get("source_text")
+        """The source text of the function, for reference only."""
+        self._result_format: str = udf_data.get("result_format") or "python_pickle"
+        """The format results should be returned in."""
+
         self._task_id: Optional[uuid.UUID] = None
         """The server-side task ID for this node's execution."""
         self._result: Optional[_codec.BinaryResult] = None
@@ -46,20 +67,85 @@ class UDFNode(_base.Node[_base.ET, _T]):
         self.wait(timeout)
         return self._task_id
 
+    def _is_local(self) -> bool:
+        return bool(self._environment.get("run_client_side"))
+
     def _exec_impl(
         self, parents: Dict[uuid.UUID, _base.Node], input_value: Any
     ) -> None:
         assert input_value is _base.NOTHING
 
+        if self._is_local():
+            self._exec_local(parents)
+            # TODO: Add a way that users can specify that they want to retry
+            # a local UDF remotely.
+            return
+        self._exec_remote(parents)
+
+    def _exec_local(self, parents: Dict[uuid.UUID, _base.Node]) -> None:
+        lang = self._environment.get("language")
+        if lang != "python":
+            # Since we're Python, we can only execute more Python.
+            raise RemoteOnlyError(f"Can't execute {lang!r} UDF locally.")
+        if not self._executable_code:
+            raise RemoteOnlyError(
+                f"Can't execute registered UDF {self._registered_udf_name!r} locally."
+            )
+
+        # An Arguments whose entries are RegisteredArgs.
+        registered_args_args = _replacers.parse_json_args(self._arguments)
+        upr = _replacers.UDFParamReplacer(parents, _base.ParamFormat.VALUES)
+        # An Arguments whose entries are CallArgs. These are not fully decoded
+        # to native values since we need to pass them to our worker process
+        # while still CloudPickle-encoded (since regular Pickle may not handle
+        # them correctly).
+        call_args_args = _replacers.visit_args(upr, registered_args_args)
+
+        # Use an 'or' rather than `.get("timeout", default)` since we want to
+        # use the default timeout if it is set to zero.
+        udf_timeout: Optional[int] = self._environment.get("timeout")
+        actual_timeout = udf_timeout or _DEFAULT_LOCAL_TIMEOUT.total_seconds()
+
+        # TODO: Have the executor own a process pool and execute on that.
+        q = _MP_CTX.SimpleQueue()
+        p = _MP_CTX.Process(
+            name=f"{self.display_name} worker process",
+            target=_run_udf,
+            args=(self._executable_code, call_args_args, q),
+        )
+        p.start()
+        try:
+            p.join(actual_timeout)
+            p.terminate()  # No-op if the process already completed.
+            if p.exitcode != 0:
+                # The built-in TimeoutError is NOT a futures.TimeoutError
+                # and represents a different outcome.
+                raise TimeoutError(
+                    f"{self.display_name} terminated with code {p.exitcode}"
+                )
+        finally:
+            p.join(1)
+            # Python 3.6 doesn't have process.Close; sub in a no-op if needed.
+            getattr(p, "close", lambda: None)()
+        result: _RunResult = q.get()
+        if result.internal_exception:
+            roe = RemoteOnlyError(result.internal_exception)
+            raise roe from result.internal_exception
+        if result.user_exception:
+            raise result.user_exception
+        assert result.result
+        self._result = result.result
+        # TODO: Report local execution success to the server.
+
+    def _exec_remote(self, parents: Dict[uuid.UUID, _base.Node]) -> None:
         # Parse the arguments.
-        raw_args: List[Any] = self._udf_data["arguments"] or []
         stored_param_ids: AbstractSet[uuid.UUID]
         arrays: Sequence[Dict[str, Any]]
         if parents:
             replacer = _replacers.UDFParamReplacer(
                 parents, _base.ParamFormat.STORED_PARAMS
             )
-            replaced_args = replacer.visit(raw_args)
+            replaced_args = replacer.visit(self._arguments)
             stored_param_ids = ordered.FrozenSet(
                 filter(None, (n.task_id() for n in replacer.seen_nodes))
             )
@@ -70,49 +156,40 @@ class UDFNode(_base.Node[_base.ET, _T]):
             )
         else:
             # If there are no parents, then we only have the existing args.
-            replaced_args = raw_args
+            replaced_args = self._arguments
             stored_param_ids = frozenset()
             arrays = []
 
         # Set up the basics of the call.
+        # The default value of everything in MultiArrayUDF is None, so values
+        # that were already None are equivalent to leaving them unset.
         udf_call = rest_api.MultiArrayUDF(
+            _exec=self._executable_code,
+            udf_info_name=self._registered_udf_name,
             task_name=self.display_name,
             stored_param_uuids=json_safe.Value([str(uid) for uid in stored_param_ids]),
             arrays=json_safe.Value(arrays),
             arguments_json=json_safe.Value(replaced_args),
             store_results=True,
-            result_format=self._udf_data.get("result_format") or "python_pickle",
+            result_format=self._result_format,
             client_node_uuid=str(self.id),
             task_graph_uuid=str(self.owner._server_graph_uuid),
-            # This is for reference only.
-            exec_raw=self._udf_data.get("source_text"),
+            exec_raw=self._source_text,  # For reference only.
+            image_name=self._environment.get("image_name"),
+            language=self._environment.get("language"),
+            version=self._environment.get("language_version"),
+            timeout=self._environment.get("timeout"),
+            resource_class=self._environment.get("resource_class"),
         )
 
-        # Set up the environment. The default value of everything in the
-        # udf_call object is `None`, so setting it to None is equivalent to
-        # leaving it unset.
-        env: Dict[str, str] = self._udf_data.get("environment", {})
-        udf_call.image_name = env.get("image_name")
-        udf_call.language = env.get("language")
-        udf_call.version = env.get("language_version")
-        udf_call.timeout = env.get("timeout")
-        udf_call.resource_class = env.get("resource_class")
-
-        # Executable code.
-        exec_code = self._udf_data.get("executable_code")
-        if exec_code:
-            udf_call._exec = exec_code
-        else:
-            try:
-                udf_call.udf_info_name = self._udf_data["registered_udf_name"]
-            except KeyError as ke:
-                raise AssertionError("Neither executable code nor UDF name set") from ke
+        if not (self._executable_code or self._registered_udf_name):
+            raise ValueError("Neither executable code nor UDF name set")
 
         # Actually make the call.
         api = self.owner._client.udf_api
         try:
             resp: urllib3.HTTPResponse = api.submit_multi_array_udf(
-                namespace=env.get("namespace") or self.owner._namespace,
+                namespace=self._environment.get("namespace") or self.owner._namespace,
                 udf=udf_call,
                 _preload_content=False,
             )
@@ -130,7 +207,7 @@ class UDFNode(_base.Node[_base.ET, _T]):
         values_replacer = _replacers.UDFParamReplacer(parents, _base.ParamFormat.VALUES)
 
         udf_call.stored_param_uuids = []
-        udf_call.arguments_json = values_replacer.visit(raw_args)
+        udf_call.arguments_json = values_replacer.visit(self._arguments)
         try:
             resp = api.submit_generic_udf(
                 namespace=self.owner._namespace,
@@ -156,3 +233,44 @@ class UDFNode(_base.Node[_base.ET, _T]):
                 }
         assert self._result
         return self._result._tdb_to_json()
+
+    def _run_location(self) -> str:
+        if self._is_local():
+            return rest_api.TaskGraphLogRunLocation.CLIENT
+        return rest_api.TaskGraphLogRunLocation.SERVER
+
+
+def _run_udf(
+    exec_data: str, encoded_args: types.Arguments, ret: multiprocessing.SimpleQueue
+) -> None:
+    unesc = _replacers.NodeOutputValueReplacer({})
+    try:
+        udf_pkl = base64.b64decode(exec_data)
+        udf = cloudpickle.loads(udf_pkl)
+        real_args = _replacers.visit_args(unesc, encoded_args)
+    except Exception as e:
+        ret.put(_RunResult(internal_exception=e))
+        return
+
+    try:
+        result = real_args.apply(udf)
+    except Exception as e:
+        ret.put(_RunResult(user_exception=e))
+        return
+    try:
+        bin_result = _codec.BinaryResult.of(result)
+    except Exception as e:
+        ret.put(_RunResult(internal_exception=e))
+    else:
+        ret.put(_RunResult(result=bin_result))
+
+
+@attrs.define(frozen=True, slots=True)
+class _RunResult:
+    result: Optional[_codec.BinaryResult] = None
+    internal_exception: Optional[Exception] = None
+    user_exception: Optional[Exception] = None
+
+
+class RemoteOnlyError(RuntimeError):
+    """Raised when a UDF can only be executed server-side."""

--- a/tiledb/cloud/taskgraphs/delayed/_udf.py
+++ b/tiledb/cloud/taskgraphs/delayed/_udf.py
@@ -34,6 +34,7 @@ class DelayedFunction(Generic[_T]):
         __fn: utils.Funcable[_T],
         *,
         result_format: Optional[str] = _NOTHING,
+        local: bool = _NOTHING,
         image_name: Optional[str] = _NOTHING,
         timeout: Union[datetime.timedelta, int, None] = _NOTHING,
         resource_class: Optional[str] = _NOTHING,
@@ -56,6 +57,8 @@ class DelayedFunction(Generic[_T]):
         :param __fn: The function to call. This may be a Python callable or
             the name of a registered UDF.
         :param result_format: The format to return results in.
+        :param local: If set to True, will execute the function on the local
+            machine rather than in TileDB Cloud.
         :param image_name: If specified, will execute the UDF within
             the specified image rather than the default image for its language.
         :param timeout: If specified, the length of time after which the UDF
@@ -79,6 +82,7 @@ class DelayedFunction(Generic[_T]):
         # them in sync.
         raw_kwargs = dict(
             result_format=result_format,
+            local=local,
             image_name=image_name,
             timeout=timeout,
             resource_class=resource_class,

--- a/tiledb/cloud/taskgraphs/types.py
+++ b/tiledb/cloud/taskgraphs/types.py
@@ -2,7 +2,7 @@
 
 import enum
 import itertools
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import attrs
 import numpy as np
@@ -84,7 +84,7 @@ class Arguments:
     :meth:``of``.
     """
 
-    args: tuple = ()
+    args: Tuple[Any, ...] = attrs.field(converter=tuple, default=())
     kwargs: Dict[str, Any] = attrs.Factory(dict)
 
     @classmethod
@@ -99,6 +99,9 @@ class Arguments:
 
         """
         return cls(args, kwargs)
+
+    def apply(self, to: Callable[..., _T]) -> _T:
+        return to(*self.args, **self.kwargs)
 
     def __repr__(self):
         """A representation of this which looks like a function call."""


### PR DESCRIPTION
This is a first implementation of local execution for task graphs.
I've assumed that local nodes may be compute-intensive, so they always
run under a new process rather than a thread on the current one.
We assume UDF components are more or less independent and as such should
not rely on communicating within the same thread, so thread-based
local execution is a niche use case.

This depends upon this change being submitted and deployed server-side;
registration of UDFs to be executed on the client side will not work and
the registration-related tests will not pass until then.

https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/pull/355

Open questions:

- Is always running these in separate processes a good idea?
  It does lead to a simpler API.

- Do we want to automatically fall back to running server-side
  if we can't run client-side, or should we require that be explicitly
  requested somehow?

Improvements to come to this changeset:

- Better testing of local execution.
- Other cleanup.

Improvements planned for follow-ons:

- Use a process pool, stored in the Executor, rather than creating
  a new process for each UDF call.
- Separate the count of UDFs that are allowed to be run in parallel
  on the server side from those on the client side (i.e. even if you're
  already running your maximum of 5 UDFs on the server, client-side
  execution has a separate quota pool).