### PR TITLE
Wire up DelayedGraph executor and create initial delayed UDFs.

### DIFF
--- a/tests/taskgraphs/delayed/test_build.py
+++ b/tests/taskgraphs/delayed/test_build.py
@@ -13,6 +13,9 @@ class DummyNode(_graph.Node):
         new_owner._add(new, parents=mgr.unexecuted_nodes)
         return new
 
+    def _to_builder_node_impl(self, _):
+        raise NotImplementedError()
+
 
 class TestBuild(unittest.TestCase):
     def test_merge(self):

--- a/tests/taskgraphs/delayed/test_delayed_funcs.py
+++ b/tests/taskgraphs/delayed/test_delayed_funcs.py
@@ -1,0 +1,132 @@
+import operator
+import unittest
+
+import numpy as np
+
+from tiledb.cloud import client
+from tiledb.cloud import testonly
+from tiledb.cloud._common import futures
+from tiledb.cloud.taskgraphs import delayed
+from tiledb.cloud.taskgraphs import executor
+
+
+class FunctionsTest(unittest.TestCase):
+    def test_basic_functions(self):
+        passthrough = delayed.udf(lambda *x: x)
+
+        nothing = passthrough.set(name="nothing")()
+        a = passthrough.set(name="a")("a", nothing)
+        b = passthrough.set(name="b")(nothing, "b")
+        c = passthrough.set(name="c")(a, b)
+        d = delayed.udf(repr, name="d")(c)
+
+        self.assertEqual("(('a', ()), ((), 'b'))", d.compute(30))
+
+    def test_two_delayeds(self):
+        d_repr = delayed.udf(repr)
+
+        repr_call = d_repr(1)
+        self.assertEqual("1", repr_call.compute(10))
+
+        repr_repr_call = d_repr(repr_call)
+        self.assertEqual("'1'", repr_repr_call.compute(10))
+
+    def test_simple(self):
+        node_1 = delayed.udf(np.median, name="node_1")([1, 2, 3])
+        node_2 = delayed.udf(lambda x: x * 2, name="node_2")(node_1)
+        node_3 = delayed.udf(lambda x: x * 2, name="node_3")(node_2)
+
+        node_3.compute(timeout=30)
+
+        self.assertEqual(2, node_1.result())
+        self.assertEqual(4, node_2.result())
+        self.assertEqual(8, node_3.result())
+
+    def test_kwargs(self):
+        def string_multi(multiplier, st=None):
+            return int(multiplier) * st
+
+        node_1 = delayed.udf(np.median, name="node_1")([1, 2, 3])
+        node_2 = delayed.udf(lambda x: x * 2, name="node_2")(node_1)
+        node_3 = delayed.udf(string_multi, name="node_3")(node_2, st="a")
+
+        node_3.compute(timeout=30)
+
+        self.assertEqual(2, node_1.result())
+        self.assertEqual(4, node_2.result())
+        self.assertEqual("aaaa", node_3.result())
+
+    def test_multi_dependencies(self):
+        node_1 = delayed.udf(np.median, name="multi_node_1")([1, 2, 3])
+        d_double = delayed.udf(lambda x: x * 2)
+        node_2 = d_double.set(name="multi_node_2")(node_1)
+        node_3 = d_double.set(name="multi_node_3")(node_2)
+        node_4 = d_double.set(name="multi_node_4")(node_2)
+        node_5 = d_double.set(name="multi_node_5")(node_2)
+
+        node_6 = delayed.udf(lambda *x: np.sum(x), name="multi_node_6")(
+            node_3, node_4, node_5
+        )
+        node_6.compute(30)
+
+        self.assertEqual(node_1.result(), 2)
+        self.assertEqual(node_2.result(), 4)
+        self.assertEqual(node_3.result(), 8)
+        self.assertEqual(node_4.result(), 8)
+        self.assertEqual(node_5.result(), 8)
+        self.assertEqual(node_6.result(), 24)
+
+
+class FailureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._me = client.default_user().username
+
+    def test_failure(self):
+        node = delayed.udf(lambda x: x * 2)(np.median)
+        with self.assertRaisesRegex(Exception, "unsupported operand"):
+            node.compute(timeout=30)
+
+        self.assertIsNotNone(node._owner._execution)
+
+    def test_dependency_fail_early(self):
+        node = delayed.udf(lambda x: x * 2)(np.median)
+        node_2 = delayed.udf(lambda x: x * 2)(10)
+        node_2.depends_on(node)
+
+        with self.assertRaises(futures.CancelledError):
+            node_2.compute(30)
+        self.assertEqual(executor.Status.FAILED, node.status)
+        self.assertEqual(executor.Status.PARENT_FAILED, node_2.status)
+
+    def test_failure_retry(self):
+        fail_name = testonly.random_name("delayed_retry")
+
+        fail = delayed.udf(f"{self._me}/{fail_name}")()
+        last = delayed.udf("got {!r}".format)(fail)
+
+        with self.assertRaises(executor.ParentFailedError):
+            last.compute(30)
+
+        self.assertIs(executor.Status.FAILED, fail.status)
+        self.assertIs(executor.Status.PARENT_FAILED, last.status)
+
+        with testonly.register_udf(lambda: 100, fail_name):
+            fail.retry()
+            self.assertEqual(100, fail.result(10))
+            self.assertEqual("got 100", last.result(10))
+
+    def test_retry_all(self):
+        fail_name = testonly.random_name("delayed_retry_all")
+
+        left = delayed.udf(f"{self._me}/{fail_name}")()
+        right = delayed.udf(f"{self._me}/{fail_name}")()
+
+        merge = delayed.udf(operator.add)(left, right)
+
+        with self.assertRaises(executor.ParentFailedError):
+            merge.compute(30)
+
+        with testonly.register_udf(lambda: "str", fail_name):
+            merge.retry_all()
+            self.assertEqual("strstr", merge.result(30))

--- a/tiledb/cloud/taskgraphs/builder.py
+++ b/tiledb/cloud/taskgraphs/builder.py
@@ -31,7 +31,7 @@ ValOrNodeSeq = Union[
 ]
 """Either a Node that yields a sequence or a sequence that may contain nodes."""
 
-_NOTHING = object()
+_NOTHING: Any = object()
 """Sentinel object used when we need to distinguish "unset" from "None"."""
 
 
@@ -96,7 +96,7 @@ class TaskGraphBuilder:
     def input(
         self,
         name: str,
-        default_value: _T = _NOTHING,  # type:ignore[assignment]
+        default_value: _T = _NOTHING,
     ) -> "Node[_T]":
         """Creates a Node that can be used as an input to the graph.
 
@@ -128,6 +128,7 @@ class TaskGraphBuilder:
         :param image_name: If specified, will execute the UDF within
             the specified image rather than the default image for its language.
         """
+        # NOTE: When adding parameters here, also update delayed/_udf.py.
         return self._add_node(
             _UDFNode(
                 func,

--- a/tiledb/cloud/taskgraphs/delayed/__init__.py
+++ b/tiledb/cloud/taskgraphs/delayed/__init__.py
@@ -1,0 +1,21 @@
+"""``delayed``, a simplified interface for task graphs.
+
+This can be imported either as a namespace, or with ``import *``::
+
+    from ... import delayed
+    d_func = delayed.udf(some_func)(...)
+    d_sql = delayed.sql(...)
+
+or::
+
+    from ....delayed import *
+    d_func = Delayed(some_func)(...)
+    d_sql = DelayedSQL(...)
+"""
+
+from tiledb.cloud.taskgraphs.delayed import _udf
+
+udf = _udf.DelayedFunction.create
+Delayed = udf
+
+__all__ = ("Delayed",)

--- a/tiledb/cloud/taskgraphs/delayed/_graph.py
+++ b/tiledb/cloud/taskgraphs/delayed/_graph.py
@@ -1,26 +1,218 @@
-from typing import Iterable, Optional
+import abc
+from typing import Any, Callable, Iterable, List, Optional, TypeVar, Union
 
+from tiledb.cloud import taskgraphs
 from tiledb.cloud._common import futures
 from tiledb.cloud._common import ordered
 from tiledb.cloud._common import visitor
+from tiledb.cloud.taskgraphs import builder
 from tiledb.cloud.taskgraphs import depgraph
 from tiledb.cloud.taskgraphs import executor
+from tiledb.cloud.taskgraphs import types
+
+_T = TypeVar("_T")
+
+ValOrNode = Union[_T, "Node[_T]"]
+ValOrNodeSeq = Union[
+    ValOrNode[types.NativeSequence[_T]],
+    types.NativeSequence[ValOrNode[_T]],
+]
+
+_ExecNode = executor.Node[executor.Executor, _T]
+"""Shortcut for the type of an executed task graph node."""
 
 
-class Node:
+class Node(futures.FutureLike[_T], metaclass=abc.ABCMeta):
     """A single node in a Delayed graph."""
 
     def __init__(self, owner: "DelayedGraph"):
         self._owner = owner
+        """The graph that this Node belongs to.
+
+        This may change during the building process, but is fixed once execution
+        starts.
+        """
+        self._builder_node: Optional[builder.Node[_T]] = None
+        """The builder node that this represents when the graph is built/run.
+
+        This is used both in the process of building the graph using the
+        :class:`builder.TaskGraphBuilder` (as the node to build, and as the
+        input to downstream nodes) and during execution as a way to get the
+        :class:`executor.Node` which represents what is actually happening.
+
+        This is only set up when the graph is actually built for either
+        registration or startup.
+        """
+        self._pre_start_callbacks: List[Callable[[Node[_T]], Any]] = []
+        """``done_callback``s that were added before this Node was started."""
 
     def depends_on(self, other: "Node") -> None:
+        """Manually defines that this Node needs to run after the provided Node.
+
+        This is usually not needed; when a node is used as an input to another
+        Node, their dependency is automatically recorded, and it's recommended
+        that you represent dependencies by explicitly passing data from parent
+        to child. This method allows you to record a dependency not reflected
+        in the graph's data flow.
+        """
         self._owner._absorb(other._owner)
         self._owner._add_dep(parent=other, child=self)
 
+    # Methods around managing the lifecycle of a Node.
+
+    def start(self, *, name: Optional[str] = None) -> None:
+        """Starts the task graph associated with this Node.
+
+        When executed, all the nodes in a task graph are built and "finalized";
+        no changes to data or structure are possible. This method is idempotent;
+        calling ``start`` on a node of an already-started Delayed graph has no
+        effect.
+
+        While Delayed graph construction is not thread-safe, once this function
+        completes, all execution-related functionality (reading results,
+        cancelling, retrying, etc.) *is* thread-safe.
+
+        :param name: The name of this execution of the Delayed graph to display
+            in task graph logs.
+        """
+        self._owner._start(name=name)
+
+    def compute(
+        self, timeout: Optional[float] = None, *, name: Optional[str] = None
+    ) -> _T:
+        """Starts this graph and gets this node's results.
+
+        :param timeout: The *client-side* timeout for *waiting for results*.
+            This is only passed to the `Future`-like :meth:`result` method.
+            Setting it only constrains how long this code will wait for a result
+            to appear you make this call; it does not stop execution after that
+            time has elapsed.
+        :param name: The name of this execution of the Delayed graph to display
+            in task graph logs.
+        """
+        self.start(name=name)
+        return self.result(timeout)
+
+    # FutureLike methods.
+
+    def result(self, timeout: Optional[float] = None) -> _T:
+        """Gets the result of executing this node, just like a ``Future``.
+
+        The semantics of calling this are the same as those of a traditional
+        ``Future``: it will return the result if the node was successful, or
+        raise an exception if the node failed.
+
+        This method (along with most ``Future``-like methods) is only valid
+        after the Delayed graph this Node belongs to has been started.
+        """
+        return self._exec_node().result(timeout)
+
+    def add_done_callback(self, fn: Callable[["Node[_T]"], None]) -> None:
+        """Adds a callback that will be called once this Node completes.
+
+        While this method is ``Future``-like, it *may* be called before the
+        graph started. Like a done callback on a raw task graph, this may be
+        called multiple times if the Node is retried.
+
+        :param fn: The function to call. When called, it will be provided with
+            a reference to this Node.
+        """
+
+        def proxy(_):
+            del _
+            return fn(self)
+
+        if self._finalized:
+            self._exec_node().add_done_callback(proxy)
+        else:
+            self._pre_start_callbacks.append(proxy)
+
+    def cancel(self) -> bool:
+        """Attempts to cancel execution of this node.
+
+        This method (along with most ``Future``-like methods) is only valid
+        after the Delayed graph this Node belongs to has been started.
+        """
+        return self._exec_node().cancel()
+
+    def cancelled(self) -> bool:
+        """Returns True if this Node has been cancelled."""
+        try:
+            return self._exec_node().cancelled()
+        except futures.InvalidStateError:
+            return False
+
+    def running(self) -> bool:
+        """Returns True if this Node is currently running."""
+        try:
+            return self._exec_node().running()
+        except futures.InvalidStateError:
+            return False
+
+    def done(self) -> bool:
+        """Returns True if this Node's execution has completed."""
+        try:
+            return self._exec_node().done()
+        except futures.InvalidStateError:
+            return False
+
+    def exception(self, timeout: Optional[float] = None) -> Optional[BaseException]:
+        """Returns the execution raised by this Node's execution, if present.
+
+        If the Node completed successfully, returns None. If the node failed,
+        returns the exception. If the Node was cancelled, *raises* an exception.
+
+        This method (along with most ``Future``-like methods) is only valid
+        after the Delayed graph this Node belongs to has been started.
+        """
+        return self._exec_node().exception(timeout)
+
+    # Task graph bonus methods.
+
+    def retry(self) -> bool:
+        """Retries this Node of the graph, if necessary.
+
+        If this node has not run, or it ran successfully, this is a no-op.
+        This method (along with most ``Future``-like methods) is only valid
+        after the Delayed graph this Node belongs to has been started.
+        """
+        return self._exec_node().retry()
+
+    def retry_all(self):
+        """Retries all failed Nodes in the graph.
+
+        If this node has not run, or it ran successfully, this is a no-op.
+        This method (along with most ``Future``-like methods) is only valid
+        after the Delayed graph this Node belongs to has been started.
+        """
+        self._owner._get_execution().retry_all()
+
+    @property
+    def status(self) -> executor.Status:
+        """The status of this Node."""
+        try:
+            return self._exec_node().status
+        except futures.InvalidStateError:
+            return executor.Status.WAITING
+
     # Internals.
+
+    def _exec_node(self) -> _ExecNode[_T]:
+        """The execution node this node maps to."""
+        return self._owner._exec_node(self)
 
     def _finalized(self) -> bool:
         return bool(self._owner._execution)
+
+    def _to_builder_node(self, grf: builder.TaskGraphBuilder) -> builder.Node[_T]:
+        """Builds this node into the provided graph and returns the result."""
+        self._builder_node = self._to_builder_node_impl(grf)
+        return self._builder_node
+
+    @abc.abstractmethod
+    def _to_builder_node_impl(self, grf: builder.TaskGraphBuilder) -> builder.Node[_T]:
+        """The type-specific implementation that builds a builder Node."""
+        raise NotImplementedError()
 
 
 class DelayedGraph:
@@ -80,9 +272,45 @@ class DelayedGraph:
             )
         self._deps.add_new_node(n, parents)
 
+    def _get_execution(self) -> executor.Executor:
+        if not self._execution:
+            raise futures.InvalidStateError(
+                "Cannot manage lifecycle of an unstarted Delayed task graph."
+                " Before calling this method, ensure that you have called"
+                " some_node.start() or some_node.compute()."
+            )
+        return self._execution
+
+    def _exec_node(self, n: Node[_T]) -> _ExecNode[_T]:
+        """Gets the execution node associated with the given Delayed node."""
+        exec = self._get_execution()
+        bn = n._builder_node
+        assert bn, "node must be built if executing"
+        return exec.node(bn)
+
     def _add_dep(self, *, parent: Node, child: Node) -> None:
         """Records a dependency between parent and child node."""
         self._deps.add_edge(parent=parent, child=child)
+
+    def _start(self, name: Optional[str] = None) -> None:
+        """Starts execution of this graph (if not yet started)."""
+        if self._execution:
+            return
+        bld = builder.TaskGraphBuilder(name)
+        for node in self._deps:
+            builder_node = node._to_builder_node(bld)
+            # Include parent–child relationships that are not specified
+            # by the params.
+            for parent in self._deps.parents_of(node):
+                built_parent = parent._builder_node
+                bld.add_dep(parent=built_parent, child=builder_node)
+        self._execution = taskgraphs.execute(bld)
+        # Ensure that all the ``done_callback``s that were registered before
+        # starting the graph are executed.
+        for node in self._deps:
+            exec_node = self._exec_node(node)
+            for cb in node._pre_start_callbacks:
+                exec_node.add_done_callback(cb)
 
 
 class Merger(visitor.ReplacingVisitor):
@@ -133,4 +361,27 @@ class Merger(visitor.ReplacingVisitor):
             # but nodes on fresh graphs need to be united.
             if not arg._finalized():
                 self.unexecuted_nodes.add(arg)
+        return None
+
+
+class BuilderNodeReplacer(visitor.ReplacingVisitor):
+    """Replaces delayed Nodes with builder Nodes for building a task graph."""
+
+    def __init__(self, dg: DelayedGraph):
+        super().__init__()
+        self._dg = dg
+
+    def maybe_replace(self, arg) -> Optional[visitor.Replacement]:
+        if isinstance(arg, Node):
+            if arg._owner is self._dg:
+                # Normal case: We're assembling a node from our same graph
+                # into the ouput builder graph. Because `DelayedGraph.start`
+                # iterates over Nodes in dependency order, we are guaranteed
+                # that all our parent nodes have already been built.
+                assert arg._builder_node, "Input arg was not already built."
+                return visitor.Replacement(arg._builder_node)
+            # Abnormal case: We're reading data from a previously-executed
+            # Delayed graph. Rather than treating it as a node in our graph,
+            # we need to extract its value.
+            return visitor.Replacement(arg.result())
         return None

--- a/tiledb/cloud/taskgraphs/delayed/_udf.py
+++ b/tiledb/cloud/taskgraphs/delayed/_udf.py
@@ -1,0 +1,158 @@
+"""Classes that implement delayed UDFs."""
+
+from typing import Any, Dict, Generic, NoReturn, Optional, Tuple, TypeVar
+
+from tiledb.cloud import utils
+from tiledb.cloud.taskgraphs import builder
+from tiledb.cloud.taskgraphs import types
+from tiledb.cloud.taskgraphs.delayed import _graph
+
+_T = TypeVar("_T")
+
+_NOTHING: Any = object()
+"""Sentinel value to distinguish an unset parameter from None."""
+
+
+class DelayedFunction(Generic[_T]):
+    """The wrapper around a function that makes it delayed-callable."""
+
+    def __init__(self, fn: utils.Funcable[_T], kwargs: Dict[str, Any]):
+        """Initializes a new DelayedFunction.
+
+        Users should never have to call this directly.
+        """
+
+        self._fn = fn
+        self._node_args = kwargs
+
+    @classmethod
+    def create(
+        cls,
+        __fn: utils.Funcable[_T],
+        *,
+        result_format: Optional[str] = _NOTHING,
+        image_name: Optional[str] = _NOTHING,
+        name: Optional[str] = _NOTHING,
+    ) -> "DelayedFunction[_T]":
+        """Wraps the given function to later call it in a delayed task graph.
+
+        All parameters that you provide to this function configure properties
+        about the UDF node that will be executed. You then ``__call__`` the
+        returned :class:`DelayedFunction` with the parameters that will be
+        passed to your UDF at execution time. The return value of *that* call
+        is a :class:`DelayedCall` which is used to build a task graph::
+
+            # Creates a DelayedFunction:
+            delayed_fn = delayed.udf(my_fn, name="call_my_fn")
+            # Calling the DelayedFunction gives you a DelayedCall.
+            # The parameters here are as if you were calling `my_fn`.
+            node = delayed_fn(my_params, ...)
+
+        :param __fn: The function to call. This may be a Python callable or
+            the name of a registered UDF.
+        :param result_format: The format to return results in.
+        :param image_name: If specified, will execute the UDF within
+            the specified image rather than the default image for its language.
+        :param name: If specified, the name of this node within the graph.
+            If provided, this must be unique.
+        """
+        # NOTE: Parameters here are repeated from builder.TaskGraphBuilder.udf
+        # for good developer experience when reading documentation / using
+        # autocomplete.
+
+        # Create a kwargs dict with only the explicitly-set arguments,
+        # so that the default values of the named arguments to
+        # `TaskGraphBuilder.udf` are used if unset rather than having to keep
+        # them in sync.
+        raw_kwargs = dict(
+            result_format=result_format,
+            image_name=image_name,
+            name=name,
+        )
+        node_kwargs = {k: v for k, v in raw_kwargs.items() if v is not _NOTHING}
+        return cls(__fn, node_kwargs)
+
+    def set(self, **updates: Any) -> "DelayedFunction[_T]":
+        """Returns a new DelayedFunction with the given argument updates.
+
+        Arguments are the same as :meth:`create` (i.e. the `Delayed` function).
+        """
+        new_args = dict(self._node_args)
+        new_args.update(updates)
+        return DelayedFunction(self._fn, new_args)
+
+    def __call__(self, *args, **kwargs) -> "DelayedCall[_T]":
+        """Sets up the actual function call with your given parameters.
+
+        Parameters can be provided either as raw values or as the results of
+        previous delayed nodes (whether delayed UDFs, arrays, or SQL queries).
+        The previous nodes' output values will be substituted into the
+        actual parameter list when your UDF is called.
+        """
+        return DelayedCall._create(self, args, kwargs)
+
+    def __repr__(self) -> str:
+        return f"<delayed {utils.func_name(self._fn)}>"
+
+
+class DelayedCall(_graph.Node[_T]):
+    """A node in a delayed task graph that represents a UDF call.
+
+    Once executed, this node acts like a Future, and its results can be accessed
+    with the usual methods. A user should never have to directly instantiate
+    a DelayedCall; it is created by ``__call__``ing a :class:`DelayedFunction`.
+    """
+
+    def __init__(
+        self,
+        owner: _graph.DelayedGraph,
+        fn: DelayedFunction[_T],
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        *,
+        has_node_args: bool,
+    ):
+        """Initializes this DelayedCall.
+
+        Users should never call this directly.
+        """
+        super().__init__(owner)
+        self._fn = fn
+        self._args = args
+        self._kwargs = kwargs
+        self._has_node_args = has_node_args
+
+    @classmethod
+    def _create(
+        cls,
+        fn: DelayedFunction[_T],
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+    ) -> "DelayedCall[_T]":
+        """Factory function for a DelayedCall.
+
+        Users should never call this directly.
+        """
+        merger = _graph.Merger()
+        merger.visit((args, kwargs))
+        owner = merger.merge_visited()
+
+        dc = DelayedCall(owner, fn, args, kwargs, has_node_args=merger.has_nodes)
+        owner._add(dc, parents=merger.unexecuted_nodes)
+        return dc
+
+    def _to_builder_node_impl(self, grf: builder.TaskGraphBuilder) -> builder.Node[_T]:
+        if self._has_node_args:
+            bnr = _graph.BuilderNodeReplacer(self._owner)
+            args, kwargs = bnr.visit((self._args, self._kwargs))
+            arguments = types.Arguments(args, kwargs)
+        else:
+            arguments = types.Arguments(self._args, self._kwargs)
+        return grf.udf(self._fn._fn, arguments, **self._fn._node_args)
+
+    def __call__(self, *args, **kwargs) -> NoReturn:
+        del args, kwargs
+        raise TypeError("This is already a Delayed call; it cannot be called again")
+
+    def __repr__(self) -> str:
+        return f"<{self._fn}(...) {id(self):x}>"


### PR DESCRIPTION
These two changes together create the most complex and most important parts of Delayed execution. The two steps are technically somewhat independent, but without an executor, there’s not really much for a delayed UDF to do, and without a delayed UDF, there’s not much for an executor to execute. Hence, while they’re in two separate changes, I have introduced them here as one review.

This change is long, but a lot of it is docstrings, mostly targeting end-user developers who are trying to build things with delayed task graphs.