### PR TITLE
Add the Array Node, which enables Array UDFs.

### DIFF
--- a/tests/taskgraphs/delayed/test_delayed_complex.py
+++ b/tests/taskgraphs/delayed/test_delayed_complex.py
@@ -7,6 +7,7 @@ import tiledb.cloud
 from tiledb.cloud import testonly
 from tiledb.cloud.taskgraphs.delayed import Delayed
 from tiledb.cloud.taskgraphs.delayed import DelayedArray
+from tiledb.cloud.taskgraphs.delayed import DelayedArrayUDF
 
 SPARSE = "tiledb://TileDB-Inc/quickstart_sparse"
 DENSE = "tiledb://TileDB-Inc/quickstart_dense"
@@ -17,11 +18,14 @@ class ArraysTest(unittest.TestCase):
         with tiledb.open(SPARSE, ctx=tiledb.cloud.Ctx()) as arr:
             orig = arr[:]
 
-        node = Delayed(lambda x: np.sum(x["a"]), name="node")(
-            DelayedArray(SPARSE, raw_ranges=((), ())),
-        )
+        node = DelayedArrayUDF(
+            SPARSE,
+            lambda x, y: np.sum(x["a"]) + y,
+            raw_ranges=((), ()),
+            name="node",
+        )(5)
 
-        self.assertEqual(node.compute(30), np.sum(orig["a"]))
+        self.assertEqual(node.compute(30), np.sum(orig["a"]) + 5)
 
     def test_multi_sum(self):
         # TileDB array indices are [start:end) based, but ranges passed to

--- a/tests/taskgraphs/delayed/test_delayed_complex.py
+++ b/tests/taskgraphs/delayed/test_delayed_complex.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy as np
+
+import tiledb
+import tiledb.cloud
+from tiledb.cloud import testonly
+from tiledb.cloud.taskgraphs.delayed import Delayed
+from tiledb.cloud.taskgraphs.delayed import DelayedArray
+
+SPARSE = "tiledb://TileDB-Inc/quickstart_sparse"
+DENSE = "tiledb://TileDB-Inc/quickstart_dense"
+
+
+class ArraysTest(unittest.TestCase):
+    def test_sum(self):
+        with tiledb.open(SPARSE, ctx=tiledb.cloud.Ctx()) as arr:
+            orig = arr[:]
+
+        node = Delayed(lambda x: np.sum(x["a"]), name="node")(
+            DelayedArray(SPARSE, raw_ranges=((), ())),
+        )
+
+        self.assertEqual(node.compute(30), np.sum(orig["a"]))
+
+    def test_multi_sum(self):
+        # TileDB array indices are [start:end) based, but ranges passed to
+        # DelayedArray are [start, end].
+        with tiledb.open(SPARSE, ctx=tiledb.cloud.Ctx()) as arr_sp:
+            orig_sp = arr_sp[1:4, 1:4]
+        with tiledb.open(DENSE, ctx=tiledb.cloud.Ctx()) as arr_de:
+            orig_de = arr_de[1:4, 1:4]
+
+        d_uri = Delayed("tiledb://TileDB-Inc/quickstart_{}".format)
+
+        def sum_it(left, right):
+            import numpy as np
+
+            return np.sum(left["a"]) + np.sum(right["a"])
+
+        one_to_three = Delayed(lambda *args: args)(1, 3)
+        two_of_them = Delayed(lambda x: (x, x))
+
+        # Also test passing upstream nodes as range parameters, along with
+        # providing a mix of nodes and raw data.
+        d_sum = Delayed(sum_it)(
+            DelayedArray(d_uri("sparse"), raw_ranges=((1, 3), one_to_three)),
+            DelayedArray(d_uri("dense"), raw_ranges=two_of_them(one_to_three)),
+        )
+
+        expected = np.sum(orig_sp["a"]) + np.sum(orig_de["a"])
+
+        self.assertEqual(expected, d_sum.compute(30))
+
+    def test_sum_by_name(self):
+        with tiledb.open(SPARSE, ctx=tiledb.cloud.Ctx()) as arr:
+            orig = arr[:]
+
+        def sum_a(x):
+            import numpy as np
+
+            return np.sum(x["a"])
+
+        with testonly.register_udf(sum_a) as sum_a_name:
+            node = Delayed(sum_a_name)(DelayedArray(SPARSE, raw_ranges=((), ())))
+
+            self.assertEqual(np.sum(orig["a"]), node.compute(30))

--- a/tiledb/cloud/taskgraphs/delayed/__init__.py
+++ b/tiledb/cloud/taskgraphs/delayed/__init__.py
@@ -13,9 +13,15 @@ or::
     d_sql = DelayedSQL(...)
 """
 
+from tiledb.cloud.taskgraphs.delayed import _nodes
 from tiledb.cloud.taskgraphs.delayed import _udf
 
 udf = _udf.DelayedFunction.create
 Delayed = udf
+array = _nodes.Array.create
+DelayedArray = array
 
-__all__ = ("Delayed",)
+__all__ = (
+    "Delayed",
+    "DelayedArray",
+)

--- a/tiledb/cloud/taskgraphs/delayed/__init__.py
+++ b/tiledb/cloud/taskgraphs/delayed/__init__.py
@@ -20,8 +20,10 @@ udf = _udf.DelayedFunction.create
 Delayed = udf
 array = _nodes.Array.create
 DelayedArray = array
+DelayedArrayUDF = _udf.array_udf
 
 __all__ = (
     "Delayed",
     "DelayedArray",
+    "DelayedArrayUDF",
 )

--- a/tiledb/cloud/taskgraphs/delayed/_graph.py
+++ b/tiledb/cloud/taskgraphs/delayed/_graph.py
@@ -1,6 +1,6 @@
 import abc
 import warnings
-from typing import Any, Callable, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar, Union
 
 from tiledb.cloud import taskgraphs
 from tiledb.cloud._common import futures
@@ -442,3 +442,30 @@ class BuilderNodeReplacer(visitor.ReplacingVisitor):
             # we need to extract its value.
             return visitor.Replacement(arg.result())
         return None
+
+
+NOTHING: Any = object()
+"""Sentinel value to distinguish an unset parameter from None."""
+
+
+def filter_kwargs(**kwargs: _T) -> Dict[str, _T]:
+    """Returns a dict of the kwargs, but without any NOTHINGs.
+
+    This is useful to provided argument information in a function signature
+    without having to copy over all the defaults::
+
+        def func(*, source="from", sink="to"):
+            ...
+
+        def wrapped_func(*, source=NOTHING, sink=NOTHING):
+            return lambda: func(**filter_kwargs(
+                source=source,
+                sink=sink,
+            ))
+    """
+    return filter_dict(kwargs)
+
+
+def filter_dict(arg_dict: Dict[str, _T]) -> Dict[str, _T]:
+    """:func:`filter_kwargs`, but it takes its inputs as a dict."""
+    return {k: v for k, v in arg_dict.items() if v is not NOTHING}

--- a/tiledb/cloud/taskgraphs/delayed/_nodes.py
+++ b/tiledb/cloud/taskgraphs/delayed/_nodes.py
@@ -1,0 +1,114 @@
+"""Simpler nodes for Delayed task graphs.
+
+Unlike the UDF node, these nodes are "static" once created.
+"""
+
+from typing import Any, Dict, Optional
+
+from tiledb.cloud.taskgraphs import builder
+from tiledb.cloud.taskgraphs import types
+from tiledb.cloud.taskgraphs.delayed import _graph
+
+
+class Array(_graph.Node[types.ArrayMultiIndex]):
+    """Used as an input parameter to a UDF node."""
+
+    def __init__(
+        self,
+        owner: _graph.DelayedGraph,
+        uri: _graph.ValOrNode[str],
+        nodeable_kwargs: Dict[str, Any],
+        *,
+        name: Optional[str],
+        has_node_args: bool,
+    ):
+        """Initializer. Users should never call this directly."""
+        super().__init__(owner)
+        self._uri = uri
+        """The URI to visit (may be a node)"""
+        self._nodeable_kwargs = nodeable_kwargs
+        """The kwargs to pass to ``array_node`` (which may be nodes)"""
+        self._name = name
+        """A name (also to pass to ``array_node``, but cannot be a node)"""
+        self._has_node_args = has_node_args
+        """True if we found any Nodes in node_kwargs."""
+
+    @classmethod
+    def create(
+        cls,
+        uri: _graph.ValOrNode[str],
+        *,
+        raw_ranges: Optional[_graph.ValOrNodeSeq] = _graph.NOTHING,
+        buffers: Optional[_graph.ValOrNodeSeq[str]] = _graph.NOTHING,
+        name: Optional[str] = _graph.NOTHING,
+    ) -> "Array":
+        """Creates an array parameter that can be used as an input to a UDF.
+
+        This allows you to specify an array to be used as an input to a UDF
+        executed on TileDB Cloud. Arrays can be provided as a parameter to UDFs
+        and appear just like any other parameter to the UDF::
+
+            result = Delayed(my_function, name="process array data")(
+                first_param,
+                DelayedArray("tiledb://some/array", raw_ranges=[[10, 20], [30, 50]]),
+                more,
+                params,
+            )
+
+        Most inputs can be provided as either direct values, or as upstream
+        nodes, so you can dynamically specify, for instance, which array
+        to read from::
+
+            which_array = Delayed(pick_array)(param)
+            result = Delayed(my_function, name="process array data")(
+                source=DelayedArray(which_array, raw_ranges=[[1, 7, 99, 650]),
+            )
+
+        Further details about the parameters can be found on
+        :meth:`builder.TaskGraphBuilder.array_read`.
+
+        :param uri: The ``tiledb://`` URI of the array to be queried.
+        :param raw_ranges: The ranges to read. Each dimension is provided as
+            a list of `[lo1, hi1, lo2, hi2, ...]` (both inclusive) pairs.
+            To read values 3–5 and 20–29 on the only dimension, you would
+            provide `[[3, 5, 20, 29]]` as the value.
+        :param buffers: The names of the dimensions and attributes to read from.
+        :param name: An optional name for reference in the task graph.
+            If provided, this must be unique within the graph.
+        """
+        merger = _graph.Merger()
+        merger.visit(uri)
+        merger.visit(raw_ranges)
+        merger.visit(buffers)
+        owner = merger.merge_visited()
+        node = cls(
+            owner,
+            uri,
+            dict(
+                raw_ranges=raw_ranges,
+                buffers=buffers,
+            ),
+            name=name,
+            has_node_args=merger.has_nodes,
+        )
+        owner._add(node, parents=merger.unexecuted_nodes)
+        return node
+
+    def _to_builder_node_impl(
+        self,
+        grf: builder.TaskGraphBuilder,
+    ) -> builder.Node[types.ArrayMultiIndex]:
+        if self._has_node_args:
+            bnr = _graph.BuilderNodeReplacer(self._owner)
+            uri = bnr.visit(self._uri)
+            kwargs = _graph.filter_kwargs(
+                **bnr.visit(self._nodeable_kwargs),
+                name=self._name,
+            )
+        else:
+            uri = self._uri
+            kwargs = _graph.filter_kwargs(
+                **self._nodeable_kwargs,
+                name=self._name,
+            )
+        return grf.array_read(uri, **kwargs)


### PR DESCRIPTION
This adds and tests the Array node, so that users can actually start
doing interesting TileDB-specific things with their UDFs by passing in
their TileDB arrays as values.

This also streamlines the process of default-handling with `NOTHING`,
by making a central place to strip `NOTHING`s out of kwarg dictionaries.