### PR TITLE
Add visualization of task graphs.

### DIFF
--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -27,6 +27,10 @@ class IClientExecutor(executor.Executor["Node"], metaclass=abc.ABCMeta):
     def _enqueue_done_node(self, node: "Node") -> None:
         raise NotImplementedError()
 
+    @abc.abstractclassmethod
+    def _notify_node_status_change(self) -> None:
+        raise NotImplementedError()
+
 
 ET = TypeVar("ET", bound=IClientExecutor)
 _T = TypeVar("_T")
@@ -208,6 +212,7 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
             return
         self._status = status
         self._lifecycle_condition.notify_all()
+        self.owner._notify_node_status_change()
 
     def _set_parent_failed(
         self,

--- a/tiledb/cloud/taskgraphs/delayed/_graph.py
+++ b/tiledb/cloud/taskgraphs/delayed/_graph.py
@@ -206,6 +206,10 @@ class Node(futures.FutureLike[_T], metaclass=abc.ABCMeta):
         """
         self._owner._register(name, namespace=namespace)
 
+    def visualize(self) -> Any:
+        """Returns a visualization of the graph for a Jupyter notebook."""
+        return self._owner._get_execution().visualize()
+
     # Internals.
 
     def _exec_node(self) -> _ExecNode[_T]:

--- a/tiledb/cloud/taskgraphs/executor.py
+++ b/tiledb/cloud/taskgraphs/executor.py
@@ -36,11 +36,15 @@ class Status(enum.Enum):
     cancellation.
     """
 
+    def friendly_name(self) -> str:
+        return self.name.replace("_", " ").lower()
+
 
 GraphStructure = Union[Dict[str, Any], builder.TaskGraphBuilder]
 """The structure of a task graph, as the JSON serialization or a Builder."""
 _N = TypeVar("_N", bound="Node")
 """The specific type of Node that an executor uses."""
+_ExSelf = TypeVar("_ExSelf", bound="Executor")
 
 
 class ParentFailedError(futures.CancelledError, Generic[_N]):
@@ -73,6 +77,9 @@ class Executor(Generic[_N], metaclass=abc.ABCMeta):
         json_nodes = graph_json["nodes"]
         for node_json in json_nodes:
             self._add_node(node_json)
+
+        self._update_callbacks_lock = threading.Lock()
+        self._update_callbacks: List[Callable[[_ExSelf], None]] = []
 
     #
     # Public API.
@@ -196,6 +203,24 @@ class Executor(Generic[_N], metaclass=abc.ABCMeta):
         If log submission failed (or the graph was not yet submitted), None.
         """
 
+    # Visualization.
+
+    def visualize(self) -> Any:
+        """Returns a visualization of this graph for a Jupyter notebook."""
+        from tiledb.cloud.taskgraphs import visualization
+
+        return visualization.visualize(self)
+
+    def add_update_callback(self: _ExSelf, callback: Callable[[_ExSelf], None]) -> None:
+        """Adds a callback that will be called when a node's state changes.
+
+        Callbacks are delivered on a best-effort basis and may be asynchronous
+        or batched depending upon the implementation. There is no guarantee
+        as to what thread the callback may come in on.
+        """
+        with self._update_callbacks_lock:
+            self._update_callbacks.append(callback)
+
     # Internals.
 
     def _nodes_with_status(self, *statuses: Status) -> Tuple[_N, ...]:
@@ -240,7 +265,7 @@ _ET = TypeVar("_ET", bound=Executor)
 """The type of the executor of a node."""
 _T = TypeVar("_T")
 """The type of the value that a Node yields."""
-_Self = TypeVar("_Self", bound="Node")
+_NSelf = TypeVar("_NSelf", bound="Node")
 
 
 class Node(futures.FutureLike[_T], Generic[_ET, _T], metaclass=abc.ABCMeta):
@@ -269,7 +294,7 @@ class Node(futures.FutureLike[_T], Generic[_ET, _T], metaclass=abc.ABCMeta):
     # TODO: Retry functionality. When we do add retry functionality, assumptions
     # around a node "finishing" exactly once will be broken.
 
-    def __init__(self: _Self, uid: uuid.UUID, owner: _ET, name: Optional[str]):
+    def __init__(self: _NSelf, uid: uuid.UUID, owner: _ET, name: Optional[str]):
         self.id = uid
         """The client-generated UUID of this node."""
         self.owner = owner
@@ -279,7 +304,7 @@ class Node(futures.FutureLike[_T], Generic[_ET, _T], metaclass=abc.ABCMeta):
 
         self._lifecycle_condition = threading.Condition(threading.Lock())
         """A lock to protect lifecycle events and callback list management."""
-        self._cb_list: List[Callable[[_Self], None]] = []
+        self._cb_list: List[Callable[[_NSelf], None]] = []
         """Callbacks that will be called when the Node completes."""
 
     # Node-specific APIs.
@@ -357,7 +382,7 @@ class Node(futures.FutureLike[_T], Generic[_ET, _T], metaclass=abc.ABCMeta):
         with self._lifecycle_condition:
             return self._done()
 
-    def add_done_callback(self: _Self, fn: Callable[[_Self], None]) -> None:
+    def add_done_callback(self: _NSelf, fn: Callable[[_NSelf], None]) -> None:
         """Adds a callback that will be called when this Node completes.
 
         While the current behavior is similar to the way ``add_done_callback``
@@ -377,7 +402,7 @@ class Node(futures.FutureLike[_T], Generic[_ET, _T], metaclass=abc.ABCMeta):
         except Exception:
             _log.exception("%r callback %r failed", self, fn)
 
-    def _callbacks(self: _Self) -> Tuple[Callable[[_Self], None], ...]:
+    def _callbacks(self: _NSelf) -> Tuple[Callable[[_NSelf], None], ...]:
         """Returns an immutable copy of the callback list.
 
         Must be called with ``_lifecycle_condition`` held.

--- a/tiledb/cloud/taskgraphs/visualization.py
+++ b/tiledb/cloud/taskgraphs/visualization.py
@@ -1,0 +1,85 @@
+"""Tools for visualizing TileDB Cloud task graphs."""
+
+# This module should never be eagerly imported by TileDB Cloud code; it relies
+# on packages we do not depend on by default. It should only be imported by
+# user code or lazily imported when the user calls a task graph object method.
+
+
+import json
+from typing import Any, Dict, Tuple
+
+import networkx
+from networkx.drawing import nx_pydot
+
+from tiledb.cloud.taskgraphs import executor
+
+
+class TileDBVisualizer:
+    def __init__(
+        self,
+        graph: executor.Executor,
+        positions: Dict[str, Tuple[float, float]],
+    ):
+        from tiledb.plot import widget
+
+        self._graph = graph
+        self._nodes = tuple(str(n.id) for n in self._graph._deps)
+        self._edges = tuple(
+            (str(e.parent.id), str(e.child.id)) for e in self._graph._deps.edges()
+        )
+        self._positions = positions
+
+        self.widget = widget.Visualize(data=self._to_json())
+
+    @classmethod
+    def create(cls, graph: executor.Executor) -> "TileDBVisualizer":
+        positions = _position_nodes(graph)
+        viz = cls(graph, positions)
+        viz._start_updates()
+        return viz
+
+    def _start_updates(self) -> None:
+        self._graph.add_update_callback(self._do_update)
+
+    def _do_update(self, grf: executor.Executor) -> None:
+        assert self._graph is grf, "Somehow got passed the wrong graph???"
+        self.widget.setData(self._to_json())
+
+    def _node_details(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            str(n.id): dict(
+                name=n.name,
+                status=n.status.friendly_name(),
+            )
+            for n in self._graph._deps
+        }
+
+    def _to_json(self) -> str:
+        return json.dumps(
+            dict(
+                nodes=self._nodes,
+                edges=self._edges,
+                positions=self._positions,
+                node_details=self._node_details(),
+            )
+        )
+
+
+def visualize(graph: executor.Executor) -> Any:
+    ver = TileDBVisualizer.create(graph)
+    return ver.widget
+
+
+def _position_nodes(graph: executor.Executor) -> Dict[str, Tuple[float, float]]:
+    net = _to_networkx(graph)
+    return nx_pydot.pydot_layout(net, prog="dot")
+
+
+def _to_networkx(graph: executor.Executor) -> networkx.DiGraph:
+    nxgraph = networkx.DiGraph()
+    nxgraph.add_nodes_from(str(n.id) for n in graph.nodes_by_name().values())
+    nxgraph.add_edges_from(
+        (str(e.parent.id), str(e.child.id)) for e in graph._deps.edges()
+    )
+
+    return nxgraph


### PR DESCRIPTION
This adds the TileDB Jupyter notebook visualization of task graphs.
A user can access it by calling `exec.visualize()` on some executor,
or `d_node.visualize()` on some Delayed node.