### PR TITLE
Propagate exceptions to child nodes with ParentFailedError.

### DIFF
--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -12,6 +12,7 @@ from tiledb.cloud.compute import DelayedArrayUDF
 from tiledb.cloud.compute import DelayedSQL
 from tiledb.cloud.compute import Status
 from tiledb.cloud.compute.delayed import DelayedMultiArrayUDF
+from tiledb.cloud.dag import dag
 
 
 class DelayedClassTest(unittest.TestCase):
@@ -106,8 +107,9 @@ class DelayedFailureTest(unittest.TestCase):
         # Add timeout so we don't wait forever in CI
         node2.set_timeout(30)
 
-        with self.assertRaises(futures.CancelledError):
+        with self.assertRaisesRegex(dag.ParentFailedError, r"operand type\(s\)") as cm:
             node2.compute()
+        self.assertEqual(node, cm.exception.node)
         with self.assertRaises(TypeError):
             node2.dag.wait(1)
 


### PR DESCRIPTION
Rather than just providing "parent failed", instead we provide the node and exception itself.

What this looks like in practice:
![A stack trace with node <tiledb.cloud.compute.delayed.DelayedArrayUDF object at 0x7f6677fd5350> failed: Error message: received an error from the container: the UDF process exited (exit code 1) in it](https://user-images.githubusercontent.com/6622003/184962944-afa80c7e-c371-4fe4-9642-9c6fdbdda4b9.png)