### PR TITLE
Use an empty attrs instance for nicer sentinels.

### DIFF
--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -43,7 +43,7 @@ class LocalResult(Result[_T], Generic[_T]):
         return lambda *args, **kwargs: cls(func(*args, **kwargs))
 
 
-_SENTINEL = object()
+_SENTINEL: Any = attrs.make_class("Sentinel", (), frozen=True, slots=True)()
 
 
 # Not frozen, but externally immutable, and callers should *treat* it like it's

--- a/tiledb/cloud/taskgraphs/builder.py
+++ b/tiledb/cloud/taskgraphs/builder.py
@@ -14,6 +14,8 @@ from typing import (
     Union,
 )
 
+import attrs
+
 from tiledb.cloud import utils
 from tiledb.cloud._common import ordered
 from tiledb.cloud._common import visitor
@@ -31,7 +33,7 @@ ValOrNodeSeq = Union[
 ]
 """Either a Node that yields a sequence or a sequence that may contain nodes."""
 
-_NOTHING: Any = object()
+_NOTHING: Any = attrs.make_class("Nothing", (), frozen=True, slots=True)()
 """Sentinel object used when we need to distinguish "unset" from "None"."""
 
 

--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -6,13 +6,15 @@ import threading
 import uuid
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar
 
+import attrs
+
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
 from tiledb.cloud._common import futures
 from tiledb.cloud.taskgraphs import executor
 
 Status = executor.Status
-NOTHING = object()
+NOTHING = attrs.make_class("Nothing", (), frozen=True, slots=True)()
 """Sentinel value to distinguish missing values from None."""
 
 

--- a/tiledb/cloud/taskgraphs/delayed/_udf.py
+++ b/tiledb/cloud/taskgraphs/delayed/_udf.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Generic, NoReturn, Optional, Tuple, TypeVar
 
+import attrs
+
 from tiledb.cloud import utils
 from tiledb.cloud.taskgraphs import builder
 from tiledb.cloud.taskgraphs import types
@@ -9,7 +11,7 @@ from tiledb.cloud.taskgraphs.delayed import _graph
 
 _T = TypeVar("_T")
 
-_NOTHING: Any = object()
+_NOTHING: Any = attrs.make_class("Nothing", (), frozen=True, slots=True)()
 """Sentinel value to distinguish an unset parameter from None."""
 
 


### PR DESCRIPTION
To get nicer outputs in ipython sessions and generated documentation,
we replace empty `object()`s with an equivalent instance of an ephemeral
attrs-generated class with a nicer `__repr__()`.

Before:

    In[2]: delayed.udf?

    Signature:
    delayed.udf(
        _DelayedFunction__fn: Union[str, Callable[..., ~_T]],
        *,
        result_format: Optional[str] = <object object at 0x7f126d615fe0>,
        image_name: Optional[str] = <object object at 0x7f126d615fe0>,
        name: Optional[str] = <object object at 0x7f126d615fe0>,
    ) -> 'DelayedFunction[_T]'

After:

    In[2]: delayed.udf?

    Signature:
    delayed.udf(
        _DelayedFunction__fn: Union[str, Callable[..., ~_T]],
        *,
        result_format: Optional[str] = Nothing(),
        image_name: Optional[str] = Nothing(),
        name: Optional[str] = Nothing(),
    ) -> 'DelayedFunction[_T]'