### PR TITLE
Improve visualization graph layout by making nodes round.

### DIFF
--- a/tiledb/cloud/taskgraphs/visualization.py
+++ b/tiledb/cloud/taskgraphs/visualization.py
@@ -77,7 +77,12 @@ def _position_nodes(graph: executor.Executor) -> Dict[str, Tuple[float, float]]:
 
 def _to_networkx(graph: executor.Executor) -> networkx.DiGraph:
     nxgraph = networkx.DiGraph()
-    nxgraph.add_nodes_from(str(n.id) for n in graph.nodes_by_name().values())
+    nxgraph.add_nodes_from(
+        (str(n.id) for n in graph.nodes_by_name().values()),
+        label="",
+        height=0.5,
+        width=0.5,
+    )
     nxgraph.add_edges_from(
         (str(e.parent.id), str(e.child.id)) for e in graph._deps.edges()
     )


### PR DESCRIPTION
The visualizer shells out to GraphViz to actually generate the layout for the graph that appears in the Jupyter notebook. By default, it uses the ID of the node (which is a UUID) as the label of the node, which means that every node is a big wide oval. This makes for weirdness when layout is done, because the big wide ovals do not look like the circles that are actually used when rendering the graph.

This change explicitly clears the label and sets the height and width of the graphviz nodes so that they are circles and should lay out much more nicely.