### PR TITLE
Add "don't download results" functionality to new task graphs API

### DIFF
--- a/tests/taskgraphs/test_builder.py
+++ b/tests/taskgraphs/test_builder.py
@@ -231,6 +231,7 @@ class TestBuilder(unittest.TestCase):
             format_it = grf.udf(
                 "sum of {name!r} is {sum!r}".format,
                 types.args(name=array_uri, sum=intify),
+                download_results=False,
             )
 
             # Execute an SQL query with parameterized input.
@@ -239,6 +240,8 @@ class TestBuilder(unittest.TestCase):
                 "select 2 * ? as doubleit",
                 parameters=[sql_input],
                 result_format="json",
+                namespace="beans",
+                download_results=True,
             )
             # Artificially constrain `format_it` to run after `sql_node`.
             grf.add_dep(parent=sql_node, child=format_it)
@@ -302,7 +305,9 @@ class TestBuilder(unittest.TestCase):
                     "depends_on": ["0badc0de-dead-beef-cafe-000000000006"],
                     "name": "SQL query",
                     "sql_node": {
+                        "download_results": True,
                         "init_commands": (),
+                        "namespace": "beans",
                         "parameters": [
                             {
                                 "__tdbudf__": "node_output",
@@ -405,6 +410,7 @@ class TestBuilder(unittest.TestCase):
                                 },
                             },
                         ],
+                        "download_results": False,
                         "environment": {
                             "language": "python",
                             "language_version": utils.PYTHON_VERSION,

--- a/tiledb/cloud/taskgraphs/client_executor/_base.py
+++ b/tiledb/cloud/taskgraphs/client_executor/_base.py
@@ -124,7 +124,13 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
     #
 
     @abc.abstractmethod
-    def _exec_impl(self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
+    def _exec_impl(
+        self,
+        *,
+        parents: Dict[uuid.UUID, "Node"],
+        input_value: Any,
+        default_download_results: bool,
+    ) -> None:
         """The type-specific behavior of executing a Node."""
         raise NotImplementedError()
 
@@ -153,7 +159,13 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
     def _status_impl(self) -> Status:
         return self._status
 
-    def _exec(self: _Self, parents: Dict[uuid.UUID, "Node"], input_value: Any) -> None:
+    def _exec(
+        self,
+        *,
+        parents: Dict[uuid.UUID, "Node"],
+        input_value: Any,
+        default_download_results: bool,
+    ) -> None:
         """The boilerplate for the ``_exec`` implementation for local Nodes.
 
         This handles all the lifecycle management for Node execution. It should
@@ -166,7 +178,11 @@ class Node(executor.Node[ET, _T], metaclass=abc.ABCMeta):
                 return
 
         try:
-            self._exec_impl(parents, input_value)
+            self._exec_impl(
+                parents=parents,
+                input_value=input_value,
+                default_download_results=default_download_results,
+            )
         except Exception as ex:
             with self._lifecycle_condition:
                 self._set_status_notify(Status.FAILED)

--- a/tiledb/cloud/taskgraphs/client_executor/array_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/array_node.py
@@ -30,7 +30,9 @@ class ArrayNode(_base.Node[_base.ET, _T]):
         self,
         parents: Dict[uuid.UUID, _base.Node],
         input_value: Any,
+        default_download_results: bool,
     ) -> None:
+        del default_download_results  # Unused.
         assert input_value is _base.NOTHING
         uri = self._array_data["uri"]
         ranges = self._array_data.get("ranges")

--- a/tiledb/cloud/taskgraphs/client_executor/input_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/input_node.py
@@ -27,11 +27,12 @@ class InputNode(_base.Node[_base.ET, _T]):
 
     def _exec_impl(
         self,
+        *,
         parents: Dict[uuid.UUID, _base.Node],
         input_value: Any,
-        server_graph_uuid: Optional[uuid.UUID] = None,
+        default_download_results: bool,
     ) -> None:
-        del server_graph_uuid  # Unused.
+        del default_download_results  # Unused.
         assert not parents, "InputNode cannot depend on anything"
         if input_value is _base.NOTHING:
             self._value_encoded = self._default_value_encoded


### PR DESCRIPTION
This adds the "don't download results" functionality that was omitted from the initial release of the task graphs API. It works just the same: By default only terminal nodes (or nodes which have local dependents) are downloaded, but the user can override it.