### PR TITLE
Don't use multiprocessing when running nodes locally.

### DIFF
--- a/tests/taskgraphs/test_client_executor.py
+++ b/tests/taskgraphs/test_client_executor.py
@@ -142,14 +142,6 @@ class ClientExecutorTestLocal(unittest.TestCase):
             os.remove(p_two)
             self.assertEqual("one two", exec.node(out).result(5))
 
-    def test_timeout(self):
-        grf = builder.TaskGraphBuilder()
-        timer = grf.udf(time.sleep, types.args(10), timeout=2, local=True)
-        exec = client_executor.LocalExecutor(grf)
-        exec.execute()
-        with self.assertRaises(TimeoutError):
-            exec.node(timer).result(5)
-
 
 class ClientExecutorTestArrays(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Despite the potential advantages of running local nodes in multiple threads from 008cf67248b28aa15a810827e6b610e4b2959ef2 when it was added, there are difficult-to-diagnose issues with multiprocessing where it seems like certain processes are never starting. For this reason, we're dropping back to just executing everything on the same thread.