### PR TITLE
Make building API into a generic function that we just pass.

### DIFF
--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -6,6 +6,7 @@ import urllib3
 import tiledb.cloud
 from tiledb.cloud import client
 from tiledb.cloud import config
+from tiledb.cloud import rest_api
 from tiledb.cloud import testonly
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import udf
@@ -97,7 +98,9 @@ class GenericUDFTest(unittest.TestCase):
                 config.user
             )
 
-            response: urllib3.HTTPResponse = client.client.udf_api.submit_generic_udf(
+            response: urllib3.HTTPResponse = client.build(
+                rest_api.UdfApi
+            ).submit_generic_udf(
                 udf=udf_req,
                 namespace=namespace,
                 _preload_content=False,

--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -165,7 +165,7 @@ def _maybe_uuid(id_str: Optional[str]) -> Optional[uuid.UUID]:
 
 
 def fetch_remote(task_id: uuid.UUID, decoder: decoders.AbstractDecoder[_T]) -> _T:
-    api_instance = client.client.tasks_api
+    api_instance = client.build(rest_api.TasksApi)
     try:
         resp: urllib3.HTTPResponse = api_instance.task_id_result_get(
             str(task_id),

--- a/tiledb/cloud/array.py
+++ b/tiledb/cloud/array.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Iterable, Optional, Sequence, Union
 import numpy
 
 from tiledb.cloud import client
+from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud._common import json_safe
@@ -68,7 +69,7 @@ def info(uri, async_req=False):
     :return: metadata object
     """
     (namespace, array_name) = split_uri(uri)
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.get_array_metadata(
@@ -81,7 +82,7 @@ def info(uri, async_req=False):
 def list_shared_with(uri, async_req=False):
     """Return array sharing policies"""
     (namespace, array_name) = split_uri(uri)
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.get_array_sharing_policies(
@@ -112,7 +113,7 @@ def share_array(uri, namespace, permissions, async_req=False):
             raise Exception("Only read or write permissions are accepted")
 
     (array_namespace, array_name) = split_uri(uri)
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.share_array(
@@ -156,7 +157,7 @@ def update_info(
     :param str file_properties: set file properties on array
     :param async_req: return future instead of results for async support
     """
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
     (namespace, current_array_name) = split_uri(uri)
 
     try:
@@ -185,7 +186,7 @@ def update_file_properties(uri, file_type=None, file_properties=None, async_req=
     :return:
     """
 
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
     (namespace, current_array_name) = split_uri(uri)
 
     try:
@@ -217,7 +218,7 @@ def register_array(
     :param str access_credentials_name: optional name of access credentials to use, if left blank default for namespace will be used
     :param async_req: return future instead of results for async support
     """
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     namespace = namespace or client.default_user().username
 
@@ -247,7 +248,7 @@ def deregister_array(uri, async_req=False):
     """
     (namespace, array_name) = split_uri(uri)
 
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.deregister_array(
@@ -268,7 +269,7 @@ def delete_array(uri, *, async_req=False):
     """
     (namespace, array_name) = split_uri(uri)
 
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.delete_array(
@@ -290,7 +291,7 @@ def array_activity(uri, async_req=False):
     """
     (namespace, array_name) = split_uri(uri)
 
-    api_instance = client.client.array_api
+    api_instance = client.build(rest_api.ArrayApi)
 
     try:
         return api_instance.array_activity_log(
@@ -438,7 +439,7 @@ def apply_base(
     if result_format_version:
         warnings.warn(DeprecationWarning("result_format_version is unused."))
 
-    api_instance = client.client.udf_api
+    api_instance = client.build(rest_api.UdfApi)
 
     if name:
         warnings.warn(
@@ -611,7 +612,7 @@ def exec_multi_array_udf_base(
     if result_format_version:
         warnings.warn(DeprecationWarning("result_format_version is unused."))
 
-    api_instance = client.client.udf_api
+    api_instance = client.build(rest_api.UdfApi)
 
     namespace = namespace or client.default_charged_namespace()
 

--- a/tiledb/cloud/client.py
+++ b/tiledb/cloud/client.py
@@ -116,7 +116,7 @@ def login(
     if (token is None or token == "") and not no_session:
         config.setup_configuration(**kwargs)
         client.set_threads(threads)
-        user_api = client.user_api
+        user_api = build(rest_api.UserApi)
         session = user_api.get_session(remember_me=True)
         token = session.token
 
@@ -178,7 +178,7 @@ def list_public_arrays(
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
-    api_instance = client.array_api
+    api_instance = build(rest_api.ArrayApi)
     permissions = _maybe_unwrap(permissions)
 
     try:
@@ -238,7 +238,7 @@ def list_shared_arrays(
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
-    api_instance = client.array_api
+    api_instance = build(rest_api.ArrayApi)
     permissions = _maybe_unwrap(permissions)
 
     try:
@@ -298,7 +298,7 @@ def list_arrays(
     :return: list of all array metadata you have access to that meet the filter applied
     """
 
-    api_instance = client.array_api
+    api_instance = build(rest_api.ArrayApi)
     permissions = _maybe_unwrap(permissions)
 
     try:
@@ -338,7 +338,7 @@ def user_profile(async_req=False):
     :return: your user profile
     """
 
-    api_instance = client.user_api
+    api_instance = build(rest_api.UserApi)
 
     try:
         return api_instance.get_user(async_req=async_req)
@@ -353,7 +353,7 @@ def organizations(async_req=False):
     :return: list of all organizations user is part of
     """
 
-    api_instance = client.organization_api
+    api_instance = build(rest_api.OrganizationApi)
 
     try:
         return api_instance.get_all_organizations(async_req=async_req)
@@ -369,7 +369,7 @@ def organization(organization, async_req=False):
     :return: details about organization
     """
 
-    api_instance = client.organization_api
+    api_instance = build(rest_api.OrganizationApi)
 
     try:
         return api_instance.get_organization(
@@ -471,34 +471,11 @@ class Client:
         self._pool_lock = threading.Lock()
         self._set_threads(pool_threads)
         self._retry_mode(retry_mode)
-        self._init_clients()
+        self._client = self._rebuild_client()
 
-    def _init_clients(self):
-        """
-        Initialize api clients
-        """
-        # If users increase the size of the thread pool, increase the size
-        # of the connection pool to match. (The internal members of
-        # ThreadPoolExecutor are not exposed in the .pyi files, so we silence
-        # mypy's warning here.)
-        pool_size = self._thread_pool._max_workers  # type: ignore[attr-defined]
-        config.config.connection_pool_maxsize = pool_size
-        client = rest_api.ApiClient(config.config)
-        client.rest_client.pool_manager = _PoolManagerWrapper(
-            client.rest_client.pool_manager
-        )
-
-        self.array_api = rest_api.ArrayApi(client)
-        self.file_api = rest_api.FilesApi(client)
-        self.notebook_api = rest_api.NotebookApi(client)
-        self.organization_api = rest_api.OrganizationApi(client)
-        self.sql_api = rest_api.SqlApi(client)
-        self.task_graph_logs_api = rest_api.TaskGraphLogsApi(client)
-        self.registered_task_graphs_api = rest_api.RegisteredTaskGraphsApi(client)
-        self.tasks_api = rest_api.TasksApi(client)
-        self.udf_api = rest_api.UdfApi(client)
-        self.user_api = rest_api.UserApi(client)
-        self.groups_api = rest_api.GroupsApi(client)
+    def build(self, builder: Callable[[rest_api.ApiClient], _T]) -> _T:
+        """Builds an API client with the given config."""
+        return builder(self._client)
 
     def set_disable_retries(self):
         self.retry_mode(RetryMode.DISABLED)
@@ -512,16 +489,32 @@ class Client:
     def retry_mode(self, mode: RetryOrStr = RetryMode.DEFAULT) -> None:
         """Sets how we should retry requests and updates API instances."""
         self._retry_mode(mode)
-        self._init_clients()
+        self._client = self._rebuild_client()
+
+    def set_threads(self, threads: Optional[int] = None) -> None:
+        """Updates the number of threads in the async thread pool."""
+        self._set_threads(threads)
+        self._client = self._rebuild_client()
 
     def _retry_mode(self, mode: RetryOrStr) -> None:
         mode = RetryMode.maybe_from(mode)
         config.config.retries = _RETRY_CONFIGS[mode]
 
-    def set_threads(self, threads: Optional[int] = None) -> None:
-        """Updates the number of threads in the async thread pool."""
-        self._set_threads(threads)
-        self._init_clients()
+    def _rebuild_client(self):
+        """
+        Initialize api clients
+        """
+        # If users increase the size of the thread pool, increase the size
+        # of the connection pool to match. (The internal members of
+        # ThreadPoolExecutor are not exposed in the .pyi files, so we silence
+        # mypy's warning here.)
+        pool_size = self._thread_pool._max_workers  # type: ignore[attr-defined]
+        config.config.connection_pool_maxsize = pool_size
+        client = rest_api.ApiClient(config.config)
+        client.rest_client.pool_manager = _PoolManagerWrapper(
+            client.rest_client.pool_manager
+        )
+        return client
 
     def _set_threads(self, threads) -> None:
         with self._pool_lock:
@@ -543,6 +536,8 @@ class Client:
 
 
 client = Client()
+
+build = client.build
 
 
 def _maybe_unwrap(param: Union[None, str, Sequence[str]]) -> Optional[str]:

--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -585,7 +585,9 @@ class DAG:
             if not self._tried_setup:
                 log_structure = self._build_log_structure()
                 try:
-                    result = client.client.task_graph_logs_api.create_task_graph_log(
+                    result = client.build(
+                        rest_api.TaskGraphLogsApi
+                    ).create_task_graph_log(
                         namespace=self.namespace,
                         log=log_structure,
                     )
@@ -662,7 +664,7 @@ class DAG:
         except KeyError as ke:
             raise AssertionError(f"Task graph ended in invalid state {status}") from ke
         do_update = utils.ephemeral_thread(
-            client.client.task_graph_logs_api.update_task_graph_log
+            client.build(rest_api.TaskGraphLogsApi).update_task_graph_log
         )
         do_update(
             id=str(self.server_graph_uuid),
@@ -900,7 +902,7 @@ class DAG:
             # the structure of the graph.
             if to_report:
                 do_report = utils.ephemeral_thread(
-                    client.client.task_graph_logs_api.report_client_node
+                    client.build(rest_api.TaskGraphLogsApi).report_client_node
                 )
                 do_report(
                     id=str(self.server_graph_uuid),
@@ -918,7 +920,7 @@ class DAG:
                 except KeyError as ke:
                     raise AssertionError(f"Invalid end state {status}") from ke
                 do_update = utils.ephemeral_thread(
-                    client.client.task_graph_logs_api.update_task_graph_log
+                    client.build(rest_api.TaskGraphLogsApi).update_task_graph_log
                 )
                 do_update(
                     id=str(self.server_graph_uuid),
@@ -1291,7 +1293,7 @@ def list_logs(
     :param page: The page number to use, starting from 1.
     :param per_page: The number of items per page.
     """
-    return client.client.task_graph_logs_api.list_task_graph_logs(
+    return client.build(rest_api.TaskGraphLogsApi).list_task_graph_logs(
         namespace=namespace,
         created_by=created_by,
         search=search,
@@ -1329,7 +1331,7 @@ def server_logs(
 
     namespace = namespace or client.default_charged_namespace()
 
-    return client.client.task_graph_logs_api.get_task_graph_log(
+    return client.build(rest_api.TaskGraphLogsApi).get_task_graph_log(
         namespace=namespace,
         id=str(the_id),
     )

--- a/tiledb/cloud/file.py
+++ b/tiledb/cloud/file.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple, Union
 import tiledb
 from tiledb.cloud import array
 from tiledb.cloud import client
+from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud.rest_api import ApiException as GenApiException
 from tiledb.cloud.rest_api import models
@@ -27,7 +28,7 @@ def create_file(
     :return: FileCreated details, including file_uuid and output_uri
     """
     try:
-        api_instance = client.client.file_api
+        api_instance = client.build(rest_api.FilesApi)
 
         file_create = models.FileCreate(
             input_uri=input_uri,
@@ -100,7 +101,7 @@ def export_file(
     try:
         (namespace, name) = array.split_uri(uri)
 
-        api_instance = client.client.file_api
+        api_instance = client.build(rest_api.FilesApi)
 
         if output_uri.startswith("file://") or "://" not in output_uri:
             return export_file_local(

--- a/tiledb/cloud/notebook.py
+++ b/tiledb/cloud/notebook.py
@@ -16,7 +16,6 @@ from tiledb.cloud import client
 from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud.rest_api import ApiException as GenApiException
-from tiledb.cloud.rest_api import rest
 
 RESERVED_NAMESPACES = frozenset(["cloud", "owned", "public", "shared"])
 CHARACTER_ENCODING = "utf-8"
@@ -44,7 +43,7 @@ def rename_notebook(
       use. If left blank. default for namespace will be used.
     :param bool async_req: return future instead of results for async support.
     """
-    api_instance = client.client.notebook_api
+    api_instance = client.build(rest_api.NotebookApi)
     (namespace, current_notebook_name) = array.split_uri(tiledb_uri)
 
     try:

--- a/tiledb/cloud/sql.py
+++ b/tiledb/cloud/sql.py
@@ -73,7 +73,7 @@ def exec_base(
 
     namespace = namespace or client.default_charged_namespace()
 
-    api_instance = client.client.sql_api
+    api_instance = client.build(rest_api.SqlApi)
 
     if init_commands is not None and not isinstance(init_commands, list):
         raise Exception("init_commands must be a list of query strings")
@@ -101,7 +101,7 @@ def exec_base(
 
         # If the user wishes to set a specific array name for the newly registered output array let's update the details
         if output_array_name is not None:
-            array_api = client.client.array_api
+            array_api = client.build(rest_api.ArrayApi)
             array_api.update_array_metadata(
                 namespace=namespace,
                 output_uri=output_uri,

--- a/tiledb/cloud/taskgraphs/client_executor/impl.py
+++ b/tiledb/cloud/taskgraphs/client_executor/impl.py
@@ -179,7 +179,9 @@ class LocalExecutor(_base.IClientExecutor):
             self._status = Status.RUNNING
 
         try:
-            result = self._client.task_graph_logs_api.create_task_graph_log(
+            result = self._client.build(
+                rest_api.TaskGraphLogsApi
+            ).create_task_graph_log(
                 namespace=self.namespace,
                 log=self._build_log_structure(),
             )
@@ -475,7 +477,7 @@ class LocalExecutor(_base.IClientExecutor):
             warnings.warn(UserWarning(f"Task graph ended in invalid state {st!r}"))
 
         do_update = utils.ephemeral_thread(
-            client.client.task_graph_logs_api.update_task_graph_log,
+            client.build(rest_api.TaskGraphLogsApi).update_task_graph_log,
             name=self._prefix + "-reporter",
         )
         do_update(

--- a/tiledb/cloud/taskgraphs/client_executor/sql_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/sql_node.py
@@ -55,7 +55,7 @@ class SQLNode(_base.Node[_base.ET, _T]):
         )
 
         try:
-            resp = self.owner._client.sql_api.run_sql(
+            resp = self.owner._client.build(rest_api.SqlApi).run_sql(
                 namespace=namespace,
                 sql=rest_api.SQLParameters(
                     name=self.display_name,
@@ -77,7 +77,7 @@ class SQLNode(_base.Node[_base.ET, _T]):
         if download_results or not self._task_id:
             self._result = _codec.BinaryResult.from_response(resp)
         else:
-            self._result = _codec.LazyResult(self._task_id)
+            self._result = _codec.LazyResult(self.owner._client, self._task_id)
 
     def _result_impl(self):
         return self._result.decode()

--- a/tiledb/cloud/taskgraphs/client_executor/udf_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/udf_node.py
@@ -203,7 +203,7 @@ class UDFNode(_base.Node[_base.ET, _T]):
             raise ValueError("Neither executable code nor UDF name set")
 
         # Actually make the call.
-        api = self.owner._client.udf_api
+        api = self.owner._client.build(rest_api.UdfApi)
         try:
             resp: urllib3.HTTPResponse = api.submit_multi_array_udf(
                 namespace=self._environment.get("namespace") or self.owner.namespace,
@@ -242,7 +242,7 @@ class UDFNode(_base.Node[_base.ET, _T]):
         if download_results or not self._task_id:
             self._result = _codec.BinaryResult.from_response(resp)
         else:
-            self._result = _codec.LazyResult(self._task_id)
+            self._result = _codec.LazyResult(self.owner._client, self._task_id)
 
     def _result_impl(self):
         return self._result.decode()

--- a/tiledb/cloud/taskgraphs/registration.py
+++ b/tiledb/cloud/taskgraphs/registration.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple
 import urllib3
 
 from tiledb.cloud import client
+from tiledb.cloud import rest_api
 from tiledb.cloud._common import json_safe
 from tiledb.cloud.taskgraphs import builder
 
@@ -22,7 +23,7 @@ def register(
         namespace (i.e. ``my-graph``, not ``me/my-graph``).
     :param namespace: The namespace, if not your own, to register the graph in.
     """
-    api_client = client.client.registered_task_graphs_api
+    api_client = client.build(rest_api.RegisteredTaskGraphsApi)
     namespace = namespace or client.default_user().username
     name = name or graph.name
 
@@ -48,7 +49,7 @@ def load(
         current user's namespace.
     """
     name, namespace = _canonicalize(name_or_nsname, namespace)
-    api_client = client.client.registered_task_graphs_api
+    api_client = client.build(rest_api.RegisteredTaskGraphsApi)
 
     result: urllib3.HTTPResponse = api_client.get_registered_task_graph(
         namespace=namespace,
@@ -73,7 +74,7 @@ def update(
     :param namespace: The namespace, if not your own, where the graph will
         be updated.
     """
-    api_client = client.client.registered_task_graphs_api
+    api_client = client.build(rest_api.RegisteredTaskGraphsApi)
     namespace = namespace or client.default_user().username
     name = old_name or graph.name
     api_client.update_registered_task_graph(
@@ -96,7 +97,7 @@ def delete(name_or_nsname: str, *, namespace: Optional[str] = None) -> None:
         current user's namespace.
     """
     name, namespace = _canonicalize(name_or_nsname, namespace)
-    api_client = client.client.registered_task_graphs_api
+    api_client = client.build(rest_api.RegisteredTaskGraphsApi)
     api_client.delete_registered_task_graph(namespace, name)
 
 

--- a/tiledb/cloud/tasks.py
+++ b/tiledb/cloud/tasks.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from tiledb.cloud import array
 from tiledb.cloud import client
+from tiledb.cloud import rest_api
 from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
@@ -26,7 +27,7 @@ def task(id, async_req=False):
     if id is None:
         raise Exception("id parameter can not be empty")
 
-    api_instance = client.client.tasks_api
+    api_instance = client.build(rest_api.TasksApi)
 
     try:
         return api_instance.task_id_get(id=id, async_req=async_req)
@@ -57,7 +58,7 @@ def tasks(
     :param async_req: return future instead of results for async support
     :return:
     """
-    api_instance = client.client.tasks_api
+    api_instance = client.build(rest_api.TasksApi)
 
     if end is not None:
         if not isinstance(end, datetime.datetime):

--- a/tiledb/cloud/udf.py
+++ b/tiledb/cloud/udf.py
@@ -7,6 +7,7 @@ import cloudpickle
 
 from tiledb.cloud import array
 from tiledb.cloud import client
+from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud._results import decoders
@@ -76,7 +77,7 @@ def exec_base(
     if result_format_version:
         warnings.warn(DeprecationWarning("result_format_version is unused."))
 
-    api_instance = client.client.udf_api
+    api_instance = client.build(rest_api.UdfApi)
 
     namespace = namespace or client.default_charged_namespace()
 
@@ -182,7 +183,7 @@ def register_udf(
     """
 
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         namespace = namespace or client.default_user().username
 
@@ -332,7 +333,7 @@ def update_udf(
     """
 
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         namespace = namespace or client.default_user().username
 
@@ -439,7 +440,7 @@ def info(namespace=None, name=None, async_req=False):
     :return: registered udf details
     """
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         if not (
             namespace is not None
@@ -480,7 +481,7 @@ def share(name=None, namespace=None, async_req=False):
         udf_namespace = client.default_user().username
 
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         return api_instance.share_udf_info(
             udf_namespace,
@@ -513,7 +514,7 @@ def unshare(name=None, namespace=None, async_req=False):
         udf_namespace = client.default_user().username
 
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         return api_instance.share_udf_info(
             udf_namespace,
@@ -539,7 +540,7 @@ def delete(name, namespace, async_req=False):
     :return: deleted udf details
     """
     try:
-        api_instance = client.client.udf_api
+        api_instance = client.build(rest_api.UdfApi)
 
         return api_instance.delete_udf_info(
             namespace,


### PR DESCRIPTION
This replaces all the `client.whatever_api` members with a single function that builds the appropriate API object and provides it with a configuration. These objects are cheap, since the only state they have is that config itself.

---

part of [sc-22834]