### PR TITLE
Don't try to derive the default groups credential client-side.

### DIFF
--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -12,7 +12,7 @@ TRIES = 5
 class GroupsTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.namespace, storage_path, _ = groups._default_ns_path_cred()
+        self.namespace, storage_path = groups._default_ns_path()
         self.test_path = storage_path + "/" + testonly.random_name("groups_test")
 
     def test_create_deregister(self):


### PR DESCRIPTION
If the server is not given a storage credential name, it will select the correct credential. We do not have to do this on the client side.