### PR TITLE
Use the default version scheme from setuptools_scm.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,4 @@
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.setuptools_scm]
-version_scheme = "guess-next-dev"
-local_scheme = "dirty-tag"
 write_to = "tiledb/cloud/version.py"


### PR DESCRIPTION
The (new?) default setuptools_scm version scheme includes the short revision hash in the version string. This is helpful for when you want to install a development version, because it will install `x.y.z.devN+somerev` rather than just `x.y.z.devN`, which would be the same if you have two separate branches that are both N revs away from the latest tag.