### PR TITLE
Always drain the HTTP connection when not preloading response.

### DIFF
--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -105,11 +105,14 @@ class GenericUDFTest(unittest.TestCase):
                 namespace=namespace,
                 _preload_content=False,
             )
-            self.assertEqual(200, response.status)
-            self.assertEqual(
-                rb'''"called with ('called with (1,) {}',) {'named': \"called with () {'param': 'two'}\", 'basic': 'three'}"''',  # noqa: E501
-                response.data,
-            )
+            try:
+                self.assertEqual(200, response.status)
+                self.assertEqual(
+                    rb'''"called with ('called with (1,) {}',) {'named': \"called with () {'param': 'two'}\", 'basic': 'three'}"''',  # noqa: E501
+                    response.data,
+                )
+            finally:
+                utils.release_connection(response)
 
     def test_timeout(self):
         def test():

--- a/tiledb/cloud/_results/results.py
+++ b/tiledb/cloud/_results/results.py
@@ -11,6 +11,7 @@ import urllib3
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
 from tiledb.cloud import tiledb_cloud_error as tce
+from tiledb.cloud import utils
 from tiledb.cloud._common import futures
 from tiledb.cloud._results import decoders
 from tiledb.cloud._results import stored_params
@@ -173,4 +174,7 @@ def fetch_remote(task_id: uuid.UUID, decoder: decoders.AbstractDecoder[_T]) -> _
         )
     except rest_api.ApiException as exc:
         raise tce.check_exc(exc) from None
-    return decoder.decode(resp.data)
+    try:
+        return decoder.decode(resp.data)
+    finally:
+        utils.release_connection(resp)

--- a/tiledb/cloud/taskgraphs/_codec.py
+++ b/tiledb/cloud/taskgraphs/_codec.py
@@ -12,6 +12,7 @@ import urllib3
 
 from tiledb.cloud import client as client_mod
 from tiledb.cloud import rest_api
+from tiledb.cloud import utils
 from tiledb.cloud._common import visitor
 from tiledb.cloud._results import decoders
 from tiledb.cloud.taskgraphs import types
@@ -229,7 +230,10 @@ class LazyResult(Result):
                     str(self._task_id),
                     _preload_content=False,
                 )
-                self._result = BinaryResult.from_response(resp)
+                try:
+                    self._result = BinaryResult.from_response(resp)
+                finally:
+                    utils.release_connection(resp)
             return self._result
 
 

--- a/tiledb/cloud/taskgraphs/client_executor/udf_node.py
+++ b/tiledb/cloud/taskgraphs/client_executor/udf_node.py
@@ -9,6 +9,7 @@ import cloudpickle
 import urllib3
 
 from tiledb.cloud import rest_api
+from tiledb.cloud import utils
 from tiledb.cloud._common import json_safe
 from tiledb.cloud._common import ordered
 from tiledb.cloud._results import results
@@ -238,11 +239,18 @@ class UDFNode(_base.Node[_base.ET, _T]):
     def _set_result(
         self, resp: urllib3.HTTPResponse, *, download_results: bool
     ) -> None:
-        self._task_id = results.extract_task_id(resp)
-        if download_results or not self._task_id:
-            self._result = _codec.BinaryResult.from_response(resp)
-        else:
-            self._result = _codec.LazyResult(self.owner._client, self._task_id)
+        """Handles all the internals of setting result information.
+
+        This includes draining and releasing the HTTP connection.
+        """
+        try:
+            self._task_id = results.extract_task_id(resp)
+            if download_results or not self._task_id:
+                self._result = _codec.BinaryResult.from_response(resp)
+            else:
+                self._result = _codec.LazyResult(self.owner._client, self._task_id)
+        finally:
+            utils.release_connection(resp)
 
     def _result_impl(self):
         return self._result.decode()

--- a/tiledb/cloud/taskgraphs/registration.py
+++ b/tiledb/cloud/taskgraphs/registration.py
@@ -5,6 +5,7 @@ import urllib3
 
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
+from tiledb.cloud import utils
 from tiledb.cloud._common import json_safe
 from tiledb.cloud.taskgraphs import builder
 
@@ -56,7 +57,10 @@ def load(
         name=name,
         _preload_content=False,
     )
-    return json.loads(result.data)
+    try:
+        return json.loads(result.data)
+    finally:
+        utils.release_connection(result)
 
 
 def update(


### PR DESCRIPTION
When `preload_content` is set to False on a urllib3 HTTP request, the connection is not automatically returned to the pool, and the contents of the response body are not read. This means that, if the code does not explicitly call `.read()`, control may be returned to the parent before the server has "finalized" the HTTP response, which in our case means the operation requested may not have fully completed.

For both of these reasons, we always need to manually return the connection to its pool, and `utils.release_connection` does that for us.

---

This appears to solve [sc-23078].