### PR TITLE
adding connector for the Python DB 2.0 API

### DIFF
--- a/src/tiledb/cloud/sql/README.md
+++ b/src/tiledb/cloud/sql/README.md
@@ -1,0 +1,22 @@
+# DB API 2.0 Connector
+
+This package features the TileDB-Cloud-PythonDB connector, which aligns with the Python DB API 2.0 specification. It offers a convenient way for Python developers to connect to TileDB-Cloud and perform all necessary operations. 
+This can also be seen as an alternative to a JDBC or ODBC driver.
+
+## Usage
+
+```python
+from tiledb.cloud.sql.tiledb_connection import TileDBConnection
+
+connection = TileDBConnection()
+cursor = connection.cursor()
+cursor.execute("SELECT * from `tiledb://TileDB-Inc/quickstart_dense`")
+
+row = cursor.fetchone()
+while row:
+    print(row)
+    row = cursor.fetchone()
+
+print(cursor.description())
+
+```

--- a/src/tiledb/cloud/sql/__init__.py
+++ b/src/tiledb/cloud/sql/__init__.py
@@ -3,12 +3,30 @@ from typing import Optional
 from tiledb.cloud.sql._execution import exec
 from tiledb.cloud.sql._execution import exec_and_fetch
 from tiledb.cloud.sql._execution import exec_async
+from tiledb.cloud.sql.db_api_exceptions import *
+from tiledb.cloud.sql.tiledb_connection import TileDBConnection
 
 last_sql_task_id: Optional[str] = None
+
+# Required by the Python DB API
+apilevel = "2.0"
+threadsafety = 2
+paramstyle = "qmark"
+connect = TileDBConnection
 
 __all__ = (
     "exec",
     "exec_and_fetch",
     "exec_async",
     "last_sql_task_id",
+    "TileDBConnection",
+    "InterfaceError",
+    "DatabaseError",
+    "ProgrammingError",
+    "DataError",
+    "OperationalError",
+    "IntegrityError",
+    "InternalError",
+    "NotSupportedError",
+    "connect",
 )

--- a/src/tiledb/cloud/sql/db_api_exceptions.py
+++ b/src/tiledb/cloud/sql/db_api_exceptions.py
@@ -1,0 +1,38 @@
+class Error(Exception):
+    """Base class for exceptions in the DB API 2.0 implementation."""
+
+
+class InterfaceError(Error):
+    """Raised when the database encountered a programming error."""
+
+
+class DatabaseError(Error):
+    """Raised when the database encountered a programming error."""
+
+
+class Warning(Exception):
+    """Exception for important warnings."""
+
+
+class ProgrammingError(Error):
+    """Raised when the database encountered a programming error."""
+
+
+class DataError(Error):
+    """Raised when the database encountered data-related errors."""
+
+
+class OperationalError(Error):
+    """Raised when the database encountered operational errors."""
+
+
+class IntegrityError(Error):
+    """Raised when the database encountered an integrity constraint error."""
+
+
+class InternalError(Error):
+    """Raised when the database encountered an internal error."""
+
+
+class NotSupportedError(Error):
+    """Raised when the database encountered a feature not supported error."""

--- a/src/tiledb/cloud/sql/tiledb_connection.py
+++ b/src/tiledb/cloud/sql/tiledb_connection.py
@@ -1,0 +1,21 @@
+from tiledb.cloud.sql.db_api_exceptions import NotSupportedError
+from tiledb.cloud.sql.tiledb_cursor import Cursor
+
+
+class TileDBConnection:
+    def cursor(self):
+        return Cursor()
+
+    def commit(self):
+        # Commit must work, even if it doesn't do anything
+        # No rollback method due to no transaction support
+        pass
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        pass

--- a/src/tiledb/cloud/sql/tiledb_cursor.py
+++ b/src/tiledb/cloud/sql/tiledb_cursor.py
@@ -1,0 +1,118 @@
+import pyarrow as pa
+
+from tiledb.cloud.sql._execution import exec
+from tiledb.cloud.sql.db_api_exceptions import DataError
+from tiledb.cloud.sql.db_api_exceptions import ProgrammingError
+
+
+def _get_db_type(dtype):
+    if pa.types.is_timestamp(dtype):
+        return "DATETIME"
+    elif pa.types.is_boolean(dtype):
+        return "BOOLEAN"
+    elif pa.types.is_string(dtype):
+        return "STRING"
+    elif pa.types.is_integer(dtype) or pa.types.is_floating(dtype):
+        return "NUMBER"
+    return "UNKNOWN"
+
+
+class Cursor:
+    def __init__(self):
+        self._results = None
+        self._row_index = 0
+        self.arraysize = 1
+        self._description_cache = None
+
+    def executemany(self, query, seq_of_parameters):
+        for params in seq_of_parameters:
+            self.execute(query, params)
+
+    def execute(self, query, params=()):
+        try:
+            self._description_cache = None
+            self._results = exec(query=query, parameters=params, raw_results=True)
+        except Exception as e:
+            self._results = None
+            raise DataError(f"Error executing query: {e}") from e
+
+    def fetchmany(self, size=-1):
+        if not self._results:
+            raise DataError("Failed to fetch results")
+
+        if size == -1:
+            size = self.arraysize
+
+        if size + self._row_index > len(self._results):
+            # give all that is remaining
+            size = len(self._results) - self._row_index
+
+        if size == 0:
+            # There are no more records
+            return []
+
+        rows = self._results[self._row_index : self._row_index + size]
+        self._row_index += size
+        return rows.to_pylist()
+
+    def setinputsizes(self, sizes):
+        return None
+
+    def setoutputsize(self, size, column):
+        return None
+
+    @property
+    def rowcount(self):
+        return -1 if self._results is None else len(self._results)
+
+    def fetchone(self):
+        result = self.fetchmany(1)
+        if len(result) == 0:
+            return None
+        return result[0]
+
+    @property
+    def description(self):
+        if self._description_cache is not None:
+            return self._description_cache
+
+        if not self._results:
+            return None
+
+        description = [
+            (field.name, _get_db_type(field.type), None, None, None, None, None)
+            for field in self._results.schema
+        ]
+        self._description_cache = description
+        return description
+
+    def fetchall(self):
+        if self._row_index > 0:
+            return self.fetchmany(len(self._results) - self._row_index)
+        if self._results is None:
+            raise DataError("The query results are null")
+        return self._results.to_pylist()
+
+    def close(self):
+        pass
+
+    def reset(self):
+        self._row_index = 0
+        self.arraysize = 1
+
+    def scroll(self, value, mode="relative"):
+        if mode == "relative":
+            new_index = self._row_index + value
+        elif mode == "absolute":
+            new_index = value
+        else:
+            raise ProgrammingError(
+                f"Invalid mode '{mode}'. Please choose between 'relative' and 'absolute'."
+            )
+
+        if not 0 <= new_index < len(self._results) - 1:
+            raise IndexError(
+                f"Row index {new_index} is out of bounds (0 to {len(self._results) - 1})."
+            )
+
+        self._row_index = new_index

--- a/tests/db_connector/test_connector.py
+++ b/tests/db_connector/test_connector.py
@@ -1,0 +1,76 @@
+import os
+import unittest
+
+from tiledb.cloud.sql.tiledb_connection import TileDBConnection
+
+
+class TileDBConnectionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Using setUpClass to run query only once for this class
+        con = TileDBConnection()
+        cls.cur = con.cursor()
+        cls.cur.execute(
+            "SELECT * from `tiledb://TileDB-Inc/quickstart_dense` WHERE `rows` > ?",
+            (0,),
+        )
+        cls.correct_data = [
+            {"rows": 1, "cols": 1, "a": 1},
+            {"rows": 1, "cols": 2, "a": 2},
+            {"rows": 1, "cols": 3, "a": 3},
+            {"rows": 1, "cols": 4, "a": 4},
+            {"rows": 2, "cols": 1, "a": 5},
+            {"rows": 2, "cols": 2, "a": 6},
+            {"rows": 2, "cols": 3, "a": 7},
+            {"rows": 2, "cols": 4, "a": 8},
+            {"rows": 3, "cols": 1, "a": 9},
+            {"rows": 3, "cols": 2, "a": 10},
+            {"rows": 3, "cols": 3, "a": 11},
+            {"rows": 3, "cols": 4, "a": 12},
+            {"rows": 4, "cols": 1, "a": 13},
+            {"rows": 4, "cols": 2, "a": 14},
+            {"rows": 4, "cols": 3, "a": 15},
+            {"rows": 4, "cols": 4, "a": 16},
+        ]
+
+    def test_row_count(self):
+        # reset the cursor
+        self.cur.scroll(0, "absolute")
+        self.assertEqual(16, self.cur.rowcount)
+
+    def test_fetchall(self):
+        # reset the cursor
+        self.cur.scroll(0, "absolute")
+        results = self.cur.fetchall()
+        self.assertEqual(results, self.correct_data)
+
+    def test_fetchmany(self):
+        self.cur.scroll(0, "absolute")
+        results = self.cur.fetchmany(5)
+        self.assertEqual(results, self.correct_data[:5])
+        results = self.cur.fetchmany(2)
+        self.assertEqual(results, self.correct_data[5:7])
+
+    def test_fetchone(self):
+        self.cur.scroll(1, "absolute")
+        results = self.cur.fetchone()
+        self.assertEqual(results, self.correct_data[1])
+
+    def test_fetchmix(self):
+        self.cur.scroll(0, "absolute")
+        results = self.cur.fetchmany(5)
+        self.assertEqual(results, self.correct_data[:5])
+        results = self.cur.fetchone()
+        self.assertEqual(results, self.correct_data[5])
+        results = self.cur.fetchall()
+        self.assertEqual(results, self.correct_data[6:])
+
+    def test_description(self):
+        correct_description = [
+            ("rows", "NUMBER", None, None, None, None, None),
+            ("cols", "NUMBER", None, None, None, None, None),
+            ("a", "NUMBER", None, None, None, None, None),
+        ]
+        self.cur.scroll(0, "absolute")
+        desc = self.cur.description
+        self.assertEqual(desc, correct_description)


### PR DESCRIPTION
This PR introduces a connector in accordance with the Python DB API 2.0 standards. 

In my initial implementation I created a separate repository https://github.com/TileDB-Inc/TileDB-Cloud-PythonDB, but @ihnorton suggested that we should include the connector here instead. 

All the code is included in this PR but I am not sure how to package it correctly. Any suggestions are welcome @thetorpedodog