### PR TITLE
Move sql implementation into a directory.

### DIFF
--- a/tiledb/cloud/dag/dag.py
+++ b/tiledb/cloud/dag/dag.py
@@ -1,6 +1,5 @@
 import collections
 import datetime
-import enum
 import itertools
 import json
 import numbers
@@ -27,7 +26,6 @@ from typing import (
 from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
-from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error as tce
 from tiledb.cloud import udf
 from tiledb.cloud import utils
@@ -39,6 +37,7 @@ from tiledb.cloud.dag import status as st
 from tiledb.cloud.dag import visualization as viz
 from tiledb.cloud.dag.mode import Mode
 from tiledb.cloud.rest_api import models
+from tiledb.cloud.sql import _execution as _sql_exec
 from tiledb.cloud.taskgraphs import _codec
 
 Status = st.Status  # Re-export for compabitility.
@@ -905,7 +904,7 @@ class DAG:
         :return: Node that is created
         """
         return self._add_prewrapped_node(
-            sql.exec_base,
+            _sql_exec.exec_base,
             *args,
             _internal_accepts_stored_params=False,
             _fallback_name="SQL query",

--- a/tiledb/cloud/sql/__init__.py
+++ b/tiledb/cloud/sql/__init__.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from tiledb.cloud.sql._execution import exec
+from tiledb.cloud.sql._execution import exec_and_fetch
+from tiledb.cloud.sql._execution import exec_async
+
+last_sql_task_id: Optional[str] = None
+
+__all__ = (
+    "exec",
+    "exec_and_fetch",
+    "exec_async",
+    "last_sql_task_id",
+)

--- a/tiledb/cloud/sql/_execution.py
+++ b/tiledb/cloud/sql/_execution.py
@@ -8,14 +8,13 @@ import tiledb
 from tiledb.cloud import array
 from tiledb.cloud import client
 from tiledb.cloud import rest_api
+from tiledb.cloud import sql
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud import utils
 from tiledb.cloud._results import decoders
 from tiledb.cloud._results import results
 from tiledb.cloud._results import sender
 from tiledb.cloud.rest_api import models
-
-last_sql_task_id: Optional[str] = None
 
 
 def exec_base(
@@ -188,6 +187,5 @@ def exec_async(*args, **kwargs) -> "results.AsyncResult":
 
 
 def _maybe_set_last_task_id(task_id: Optional[uuid.UUID]):
-    global last_sql_task_id
     if task_id:
-        last_sql_task_id = str(task_id)
+        sql.last_sql_task_id = str(task_id)


### PR DESCRIPTION
This prepares for the inclusion of the TileDB Cloud Python Database API connector.  All names are exported and available from the same place, so there is no impact on user code.