### PR TITLE
Include `README.md` for project `long_description`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "tiledb-cloud"
 description = "TileDB Cloud platform Python client"
+readme = "./README.md"
 dynamic = ["version"]
 
 dependencies = [


### PR DESCRIPTION
To upload a package to PyPI, a `long_description` field is required. This was giving us (deceptive) errors in action runs [1]. Using the `readme` field in the pyproject file fixes this.

[1]: https://github.com/TileDB-Inc/TileDB-Cloud-Py/actions/runs/4257294106/jobs/7407259032