### PR TITLE
Setup readthedocs for python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: setuptools


### PR DESCRIPTION
Setup readthedocs for python 3.9. This is temporary to allow the existing docs to be refreshed while we move to quarto self hosted docs.