### PR TITLE
Monkey-patch old Pandas to read newer Pandas pickles.

### DIFF
--- a/src/tiledb/cloud/__init__.py
+++ b/src/tiledb/cloud/__init__.py
@@ -4,6 +4,7 @@ from tiledb.cloud import compute
 from tiledb.cloud import dag
 from tiledb.cloud import sql
 from tiledb.cloud import udf
+from tiledb.cloud._common import pickle_compat as _pickle_compat
 from tiledb.cloud.array import array_activity
 from tiledb.cloud.array import deregister_array
 from tiledb.cloud.array import info
@@ -32,6 +33,8 @@ from tiledb.cloud.tasks import last_sql_task
 from tiledb.cloud.tasks import last_udf_task
 from tiledb.cloud.tasks import task
 from tiledb.cloud.tiledb_cloud_error import TileDBCloudError
+
+_pickle_compat.patch_pandas()
 
 try:
     from tiledb.cloud.version import version as __version__

--- a/src/tiledb/cloud/_common/pickle_compat.py
+++ b/src/tiledb/cloud/_common/pickle_compat.py
@@ -1,0 +1,109 @@
+def patch_pandas() -> None:
+    """Makes Pandas v1.2.x able to unpickle Pandas v1.3+ DataFrames."""
+    from pandas.core.internals import blocks
+
+    if hasattr(blocks, "new_block"):
+        # We already support unpickling v1.3+ DataFrames.
+        return
+
+    # Import these extremely lazily so we don't reach into Pandas internals
+    # unless we ABSOLUTELY need to.
+    import pandas._libs.internals as pdinternals
+    from pandas.core.dtypes import dtypes
+
+    # The following code is taken from Pandas v1.5.3 under the BSD license:
+    # BSD 3-Clause License
+    #
+    # Copyright (c) 2008-2011, AQR Capital Management, LLC, Lambda Foundry, Inc.
+    # and PyData Development Team
+    # All rights reserved.
+    #
+    # Copyright (c) 2011-2022, Open source contributors.
+    #
+    # Redistribution and use in source and binary forms, with or without
+    # modification, are permitted provided that the following conditions
+    # are met:
+    #
+    # * Redistributions of source code must retain the above copyright notice,
+    #   this list of conditions and the following disclaimer.
+    #
+    # * Redistributions in binary form must reproduce the above copyright
+    #   notice, this list of conditions and the following disclaimer in the
+    #   documentation and/or other materials provided with the distribution.
+    #
+    # * Neither the name of the copyright holder nor the names of its
+    #   contributors may be used to endorse or promote products derived from
+    #   this software without specific prior written permission.
+    #
+    # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    # INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    # BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    # LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+    # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+    # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+    # OF SUCH DAMAGE.
+    # https://github.com/pandas-dev/pandas/blob/v1.5.3/pandas/core/internals/blocks.py#L2172
+    def _new_block(values, placement, *, ndim: int) -> blocks.Block:
+        # caller is responsible for ensuring values is NOT a PandasArray
+
+        if not isinstance(placement, pdinternals.BlockPlacement):
+            placement = pdinternals.BlockPlacement(placement)
+
+        _check_ndim(values, placement, ndim)
+
+        # don't want to pass `values.dtype` here.
+        klass = blocks.get_block_type(values)
+
+        # OMITTED:
+        #     we don't attempt to coerce values here because all our inputs
+        #     come from Pandas serialization, so we assume that they're valid.
+        # values = maybe_coerce_values(values)
+
+        return klass(values, ndim=ndim, placement=placement)
+
+    # https://github.com/pandas-dev/pandas/blob/v1.5.3/pandas/core/internals/blocks.py#L2186
+    def _check_ndim(values, placement: pdinternals.BlockPlacement, ndim: int) -> None:
+        if values.ndim > ndim:
+            # Check for both np.ndarray and ExtensionArray
+            raise ValueError(
+                "Wrong number of dimensions. "
+                f"values.ndim > ndim [{values.ndim} > {ndim}]"
+            )
+
+        elif not _is_1d_only_ea_dtype(values.dtype):
+            # TODO(EA2D): special case not needed with 2D EAs
+            if values.ndim != ndim:
+                raise ValueError(
+                    "Wrong number of dimensions. "
+                    f"values.ndim != ndim [{values.ndim} != {ndim}]"
+                )
+            if len(placement) != len(values):
+                raise ValueError(
+                    f"Wrong number of items passed {len(values)}, "
+                    f"placement implies {len(placement)}"
+                )
+        elif ndim == 2 and len(placement) != 1:
+            # TODO(EA2D): special case unnecessary with 2D EAs
+            raise ValueError("need to split")
+
+    # https://github.com/pandas-dev/pandas/blob/v1.5.3/pandas/core/dtypes/common.py#L1420
+    def _is_1d_only_ea_dtype(dtype) -> bool:
+        # Note: if other EA dtypes are ever held in HybridBlock, exclude those
+        #  here too.
+        # NB: need to check DatetimeTZDtype and not is_datetime64tz_dtype
+        #  to exclude ArrowTimestampUSDtype
+        return isinstance(dtype, dtypes.ExtensionDtype) and not isinstance(
+            dtype, (dtypes.DatetimeTZDtype, dtypes.PeriodDtype)
+        )
+
+    # https://github.com/pandas-dev/pandas/blob/v1.5.3/pandas/_libs/internals.pyx#L570
+    def _new_block_trampoline(values, placement, ndim) -> blocks.Block:
+        return _new_block(values, placement, ndim=ndim)
+
+    blocks.new_block = _new_block
+    pdinternals._unpickle_block = _new_block_trampoline

--- a/tests/common/test_pickle_compat.py
+++ b/tests/common/test_pickle_compat.py
@@ -1,0 +1,75 @@
+import base64
+import pickle
+import unittest
+
+import pandas as pd
+
+# We import tiledb.cloud but don't use it so that we can be sure that
+# Pandas is immediately patched upon importing `tiledb.cloud`.
+import tiledb.cloud  # noqa: F401
+
+_WANT_DF = pd.DataFrame(
+    [
+        [1, 1.1, "one"],
+        [2, 2.2, "two"],
+    ],
+    columns=("nt", "flt", "strng"),
+)
+
+
+class PickleCompatTest(unittest.TestCase):
+    def test_old_pickle(self):
+        # Produced by pickling _WANT_DF with Pandas 1.2.5.
+        old_pickle = base64.b64decode(
+            """
+            gASV9gMAAAAAAACMEXBhbmRhcy5jb3JlLmZyYW1llIwJRGF0YUZyYW1llJOUKYGUfZQo
+            jARfbWdylIwecGFuZGFzLmNvcmUuaW50ZXJuYWxzLm1hbmFnZXJzlIwMQmxvY2tNYW5h
+            Z2VylJOUKYGUKF2UKIwYcGFuZGFzLmNvcmUuaW5kZXhlcy5iYXNllIwKX25ld19JbmRl
+            eJSTlGgLjAVJbmRleJSTlH2UKIwEZGF0YZSMFW51bXB5LmNvcmUubXVsdGlhcnJheZSM
+            DF9yZWNvbnN0cnVjdJSTlIwFbnVtcHmUjAduZGFycmF5lJOUSwCFlEMBYpSHlFKUKEsB
+            SwOFlGgVjAVkdHlwZZSTlIwCTziUiYiHlFKUKEsDjAF8lE5OTkr/////Sv////9LP3SU
+            YoldlCiMAm50lIwDZmx0lIwFc3RybmeUZXSUYowEbmFtZZROdYaUUpRoDYwZcGFuZGFz
+            LmNvcmUuaW5kZXhlcy5yYW5nZZSMClJhbmdlSW5kZXiUk5R9lChoKU6MBXN0YXJ0lEsA
+            jARzdG9wlEsCjARzdGVwlEsBdYaUUpRlXZQoaBRoF0sAhZRoGYeUUpQoSwFLAUsChpRo
+            HowCZjiUiYiHlFKUKEsDjAE8lE5OTkr/////Sv////9LAHSUYolDEJqZmZmZmfE/mpmZ
+            mZmZAUCUdJRiaBRoF0sAhZRoGYeUUpQoSwFLAUsChpRoHowCaTiUiYiHlFKUKEsDaD1O
+            Tk5K/////0r/////SwB0lGKJQxABAAAAAAAAAAIAAAAAAAAAlHSUYmgUaBdLAIWUaBmH
+            lFKUKEsBSwFLAoaUaCGJXZQojANvbmWUjAN0d2+UZXSUYmVdlChoDWgPfZQoaBFoFGgX
+            SwCFlGgZh5RSlChLAUsBhZRoIYldlGgmYXSUYmgpTnWGlFKUaA1oD32UKGgRaBRoF0sA
+            hZRoGYeUUpQoSwFLAYWUaCGJXZRoJWF0lGJoKU51hpRSlGgNaA99lChoEWgUaBdLAIWU
+            aBmHlFKUKEsBSwGFlGghiV2UaCdhdJRiaClOdYaUUpRlfZSMBjAuMTQuMZR9lCiMBGF4
+            ZXOUaAqMBmJsb2Nrc5RdlCh9lCiMBnZhbHVlc5RoOIwIbWdyX2xvY3OUjAhidWlsdGlu
+            c5SMBXNsaWNllJOUSwFLAksBh5RSlHV9lChodmhDaHdoeksASwFLAYeUUpR1fZQoaHZo
+            TWh3aHpLAksDSwGHlFKUdWV1c3SUYowEX3R5cJSMCWRhdGFmcmFtZZSMCV9tZXRhZGF0
+            YZRdlIwFYXR0cnOUfZSMBl9mbGFnc5R9lIwXYWxsb3dzX2R1cGxpY2F0ZV9sYWJlbHOU
+            iHN1Yi4=
+            """
+        )
+        got_df = pickle.loads(old_pickle)
+        self.assertTrue(_WANT_DF.equals(got_df))
+
+    def test_new_pickle(self):
+        # Produced by pickling _WANT_DF with Pandas 1.5.3.
+        new_pickle = base64.b64decode(
+            """
+            gASVSQMAAAAAAACMEXBhbmRhcy5jb3JlLmZyYW1llIwJRGF0YUZyYW1llJOUKYGUfZQo
+            jARfbWdylIwecGFuZGFzLmNvcmUuaW50ZXJuYWxzLm1hbmFnZXJzlIwMQmxvY2tNYW5h
+            Z2VylJOUjBZwYW5kYXMuX2xpYnMuaW50ZXJuYWxzlIwPX3VucGlja2xlX2Jsb2NrlJOU
+            jBVudW1weS5jb3JlLm11bHRpYXJyYXmUjAxfcmVjb25zdHJ1Y3SUk5SMBW51bXB5lIwH
+            bmRhcnJheZSTlEsAhZRDAWKUh5RSlChLAUsBSwKGlGgPjAVkdHlwZZSTlIwCaTiUiYiH
+            lFKUKEsDjAE8lE5OTkr/////Sv////9LAHSUYolDEAEAAAAAAAAAAgAAAAAAAACUdJRi
+            jAhidWlsdGluc5SMBXNsaWNllJOUSwBLAUsBh5RSlEsCh5RSlGgLaA5oEUsAhZRoE4eU
+            UpQoSwFLAUsChpRoGIwCZjiUiYiHlFKUKEsDaBxOTk5K/////0r/////SwB0lGKJQxCa
+            mZmZmZnxP5qZmZmZmQFAlHSUYmgiSwFLAksBh5RSlEsCh5RSlGgLaA5oEUsAhZRoE4eU
+            UpQoSwFLAUsChpRoGIwCTziUiYiHlFKUKEsDjAF8lE5OTkr/////Sv////9LP3SUYold
+            lCiMA29uZZSMA3R3b5RldJRiaCJLAksDSwGHlFKUSwKHlFKUh5RdlCiMGHBhbmRhcy5j
+            b3JlLmluZGV4ZXMuYmFzZZSMCl9uZXdfSW5kZXiUk5RoSIwFSW5kZXiUk5R9lCiMBGRh
+            dGGUaA5oEUsAhZRoE4eUUpQoSwFLA4WUaDuJXZQojAJudJSMA2ZsdJSMBXN0cm5nlGV0
+            lGKMBG5hbWWUTnWGlFKUaEqMGXBhbmRhcy5jb3JlLmluZGV4ZXMucmFuZ2WUjApSYW5n
+            ZUluZGV4lJOUfZQoaFhOjAVzdGFydJRLAIwEc3RvcJRLAowEc3RlcJRLAXWGlFKUZYaU
+            UpSMBF90eXCUjAlkYXRhZnJhbWWUjAlfbWV0YWRhdGGUXZSMBWF0dHJzlH2UjAZfZmxh
+            Z3OUfZSMF2FsbG93c19kdXBsaWNhdGVfbGFiZWxzlIhzdWIu
+            """
+        )
+        got_df = pickle.loads(new_pickle)
+        self.assertTrue(_WANT_DF.equals(got_df))


### PR DESCRIPTION
This extracts the necessary parts of the pickle-reading code from Pandas v1.5.3 and monkey-patches older Pandas versions to be able to read pickles produced by the newer Pandas versions.  This enables forwards compatibility of deserialization and will eventually eliminate the need to hold Pandas back to v1.2.5.

[sc-8724]