### PR TITLE
Remove pin on TileDB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pyarrow>=3.0.0",
   "python-dateutil",
   "six>=1.10",
-  "tiledb<0.21",
+  "tiledb>=0.15.2",
   "urllib3>=1.26",
 ]
 


### PR DESCRIPTION
Needs tiledb>=0.15.2 to have group support