### PR TITLE
Add "trampoline" function for executing installed functions.

### DIFF
--- a/src/tiledb/cloud/_common/trampoline.py
+++ b/src/tiledb/cloud/_common/trampoline.py
@@ -1,0 +1,34 @@
+"""Trampoline function to execute functions from installed libraries.
+
+This exists to make it easy for code not written in Python to access and execute
+installed Python functions in UDFs without having to register a specific UDF
+for each function that the non-Python code might want to access. It is intended
+for internal consumption by the TileDB Cloud UI.
+"""
+
+import importlib
+
+
+def run_python_function(__name, *args, **kwargs):
+    """Executes the named function with the given args and kwargs.
+
+    This executes the function named with `the syntax used by the setuptools
+    ``entry_points`` system`__: ``module:object[.attribute]*``. For instance,
+    the function ``join`` in the ``os.path`` module is specified as
+    ``os.path:join``.
+
+    Arguments and kwargs are passed directly to the function.
+
+    .. __: https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-syntax
+    """
+
+    def _find_object(name: str):
+        mod_name, sep, member_name = name.partition(":")
+        result = importlib.import_module(mod_name)
+        while sep:
+            first, sep, member_name = member_name.partition(".")
+            result = getattr(result, first)
+        return result
+
+    func = _find_object(__name)
+    return func(*args, **kwargs)  # type: ignore

--- a/tests/common/test_trampoline.py
+++ b/tests/common/test_trampoline.py
@@ -1,0 +1,38 @@
+import os.path
+import unittest
+
+from tiledb.cloud._common import trampoline
+
+
+class TrampolineTest(unittest.TestCase):
+    def test_trampoline(self):
+        self.assertEqual(9765625, trampoline.run_python_function("builtins:pow", 5, 10))
+        self.assertEqual(
+            os.path.join("a", "b"),
+            trampoline.run_python_function("os.path:join", "a", "b"),
+        )
+
+    def test_find_wrong_type(self):
+        with self.assertRaises(TypeError):
+            # This should find the module but raise a TypeError when it tries
+            # to call a non-callable.
+            trampoline.run_python_function("tiledb.cloud")
+        with self.assertRaises(TypeError):
+            # This should find the object but raise a TypeError when it tries
+            # to call a non-callable.
+            trampoline.run_python_function("tiledb.cloud.dag:Mode.LOCAL")
+
+    def test_find_missing(self):
+        # These will all fail prior to reaching the call.
+        with self.assertRaises(ValueError):
+            trampoline.run_python_function("")
+        with self.assertRaises(ImportError):
+            trampoline.run_python_function("tiledb.cloud.dag.Mode")
+        with self.assertRaises(AttributeError):
+            trampoline.run_python_function("os:invalid")
+        with self.assertRaises(ValueError):
+            trampoline.run_python_function(":no_module")
+        with self.assertRaises(AttributeError):
+            trampoline.run_python_function("builtins:")
+        with self.assertRaises(AttributeError):
+            trampoline.run_python_function("tiledb.cloud.dag:Mode.")


### PR DESCRIPTION
To make calling functions from the frontend easier (particularly for ingestion), without having to register a separate UDF for each ingestor that just refers to the installed function, this function can be registered as a UDF and it can then call into other functions.

Functionally, this works the same way as registering the named functions themselves, because registering a function from an installed module via cloudpickle registers a reference to that function rather than the serialized code of the function (i.e., calling `udf.register(x.y.z)` registers the equivalent of `import x.y; x.y.z(...)`, not the code of the function `x.y.z` as it appears in the user's install).

So instead of having to do something like:

 1. Register tiledb.cloud.data_a.ingest as TileDB-Inc/ingest-a
 2. Register tiledb.cloud.data_b.ingest as TileDB-Inc/ingest-b
 3. On the frontend, call TileDB-Inc/ingest-a with params X, Y, Z
 4. On the frontend, call TileDB-Inc/ingest-b with params R, S, T
 5. We have a new ingestor function! It can't be used until it is registered.

We can instead:

 1. Register tiledb.cloud._common.trampoline.run_python_function as TileDB-Inc/run_python_function.
 2. On the frontend, call TileDB-Inc/run_python_function with params "tiledb.cloud.data_a:ingest", X, Y, Z
 3. On the frontend, call TileDB-Inc/run_python_function with params "tiledb.cloud.data_b:ingest", R, S, T
 4. On the frontend, call TileDB-Inc/run_python_function with params "path.to.new:function", ...

This doesn't *preclude* later promoting the functions to full-fledged UDFs, but does eliminate a step in the deployment process.