### PR TITLE
Add tool to force function pickling by value.

### DIFF
--- a/src/tiledb/cloud/_common/functions.py
+++ b/src/tiledb/cloud/_common/functions.py
@@ -1,6 +1,7 @@
 """Utilities for dealing with functions for serialization and registration."""
 
 import inspect
+import types
 from typing import Callable, Optional, TypeVar, Union
 
 _T = TypeVar("_T")
@@ -8,6 +9,66 @@ Funcable = Union[str, Callable[..., _T]]
 """Either a Python function or the name of a registered UDF."""
 _builtin_function = type(len)
 """The type of functions implemented in C."""
+
+
+def to_register_by_value(__fn: types.FunctionType) -> types.FunctionType:
+    """Converts the given function into one that can be registered "by value".
+
+    When a function is serialized by reference, the result is roughly equivalent
+    to ``import module.where.it.lives; module.where.it.lives.the_fn(...)``.
+    When it is serialized by value, the function's (compiled) code is serialized
+    and used at the receiving end to execute directly.
+
+    This by itself does not *guarantee* that a function pickled by value will be
+    usable. The same restrictions apply as to existing functions. For instance,
+    if the function refers to globals from a module not importable at the
+    destination, it still won't work.
+    """
+
+    if not isinstance(__fn, types.FunctionType):
+        raise TypeError(
+            "Only regular functions (not methods or built-in functions)"
+            " may be converted to register-by-value."
+        )
+
+    # The value of a __module__ is (part of) how cloudpickle decides whether
+    # to serialize a function by reference or by value.  It assumes that if
+    # a function has a __module__ and is available in that module, it should
+    # be importable on the receiving end (with some exceptions).  If it has no
+    # __module__, or the __module__ is "__main__", it will always serialize
+    # by value.
+    #
+    # This is a fancy way of copying everything but a function's __module__
+    # to a new function object, without mutating the original.
+    # Alas, copy.copy and copy.deepcopy both return the original instance
+    # when used to copy a function object.
+
+    new_fn = types.FunctionType(
+        __fn.__code__, globals=__fn.__globals__, closure=__fn.__closure__
+    )
+    # We don't want the two objects to share the same __dict__ reference.
+    new_fn.__dict__.update(__fn.__dict__)
+    new_fn.__module__ = "<pickled data>"  # fictitious.
+    # Special function attributes:
+    # https://docs.python.org/3.11/reference/datamodel.html#index-33
+    for attr in (
+        "__doc__",
+        "__name__",
+        "__qualname__",
+        # __module__: already set
+        "__defaults__",
+        # __code__: already set
+        # __globals__: read-only, already set
+        # __dict__: copied entry-by-entry above
+        # __closure__: read-only, already set
+        "__annotations__",
+        "__kwdefaults__",
+    ):
+        try:
+            setattr(new_fn, attr, getattr(__fn, attr))
+        except AttributeError:
+            pass  # It's fine if it's missing or unset on the original.
+    return new_fn
 
 
 def check_funcable(**kwargs) -> None:

--- a/tests/common/test_functions.py
+++ b/tests/common/test_functions.py
@@ -1,10 +1,16 @@
+import fractions
 import importlib
+import json
 import os
 import os.path
+import pathlib
+import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
+
+import cloudpickle
 
 from tiledb.cloud._common import functions
 
@@ -72,3 +78,129 @@ class FuncableTest(unittest.TestCase):
             with self.subTest(item):
                 with self.assertRaises(TypeError):
                     functions.check_funcable(item=item)
+
+
+class ByValueTest(unittest.TestCase):
+    def test_dedent(self):
+        dedent_by_val = functions.to_register_by_value(textwrap.dedent)
+
+        to_dedent = """
+            here is some text
+            it is indented
+        """
+        self.assertEqual(textwrap.dedent(to_dedent), dedent_by_val(to_dedent))
+
+        twd_pickle = cloudpickle.dumps(textwrap.dedent)
+        dbv_pickle = cloudpickle.dumps(dedent_by_val)
+
+        self.assertNotEqual(twd_pickle, dbv_pickle)
+
+    def test_across_processes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = pathlib.Path(tmpdir)
+
+            main_file = tmpdir_path / "dump_pickles"
+            main_file.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env python
+
+                    import json
+
+                    import cloudpickle
+                    import the_module
+
+                    from tiledb.cloud._common import functions
+
+                    def uses_the_module():
+                        # this has the_module in its globals.
+                        return the_module.__name__
+
+                    def imports_the_module():
+                        # this does NOT have the_module in its globals.
+                        import the_module
+                        return the_module.__name__
+
+                    def to_hex_pickles(**args):
+                        return {
+                            key: cloudpickle.dumps(value).hex()
+                            for (key, value) in args.items()
+                        }
+
+                    def main():
+                        ten_thirds_val = functions.to_register_by_value(
+                            the_module.ten_thirds)
+                        print(json.dumps(to_hex_pickles(
+                            ten_thirds=the_module.ten_thirds,
+                            ten_thirds_val=ten_thirds_val,
+                            uses_the_module=uses_the_module,
+                            imports_the_module=imports_the_module,
+                            to_hex_pickles=to_hex_pickles,
+                        )))
+
+                    if __name__ == "__main__":
+                        main()
+                    """
+                )
+            )
+            main_file.chmod(0o550)
+            # When executing a Python file, the directory where the file
+            # is located is placed at the start of sys.path, so the_module.py
+            # will be accessible as the_module.
+            mod_file = tmpdir_path / "the_module.py"
+            mod_file.write_text(
+                textwrap.dedent(
+                    """
+                    import fractions
+                    def ten_thirds() -> fractions.Fraction:
+                        return fractions.Fraction(10, 3)
+                    """
+                )
+            )
+
+            result = subprocess.run((main_file,), stdout=subprocess.PIPE, check=True)
+            pickles = json.loads(result.stdout)
+
+            def unpickle(key):
+                return cloudpickle.loads(bytes.fromhex(pickles[key]))
+
+            with self.assertRaises(ModuleNotFoundError):
+                # Can't unpickle the function-by-reference.
+                unpickle("ten_thirds")
+
+            # Can unpickle the function-by-value.
+            ten_thirds = unpickle("ten_thirds_val")
+            self.assertEqual(fractions.Fraction(10, 3), ten_thirds())
+
+            # Can't unpickle something that references the_module in globals.
+            with self.assertRaises(ModuleNotFoundError):
+                unpickle("uses_the_module")
+
+            # Can unpickle something that imports the_module internally...
+            imports_the_module = unpickle("imports_the_module")
+            # ...but can't execute it.
+            with self.assertRaises(ModuleNotFoundError):
+                imports_the_module()
+
+            # Functions defined in the __main__ module are always by-value.
+            to_hex_pickles = unpickle("to_hex_pickles")
+            self.assertEqual(
+                {
+                    "n": cloudpickle.dumps(None).hex(),
+                    "z": cloudpickle.dumps(0).hex(),
+                },
+                to_hex_pickles(n=None, z=0),
+            )
+
+    def test_bad(self):
+        for case in (
+            int,  # built-in function
+            int.bit_length,  # built-in unbound method
+            "string".join,  # built-in bound method
+            textwrap.TextWrapper,  # type
+            textwrap.TextWrapper().fill,  # bound method
+            os.path,
+            88888,
+        ):
+            with self.assertRaises(TypeError, msg=f"not raised for {case}"):
+                functions.to_register_by_value(case)


### PR DESCRIPTION
When registering certain UDFs, like `trampoline.run_python_function`, we want to ensure that they're registered by reference, not by value. Removing the `__module__` from the function is the simplest way to make that happen with the current version of cloudpickle.

This may be worth exporting in the future, or alternately even using it in the default UDF execution/registration process, but until we have a better idea of how to work with it, I'd like it to stay internal-only.

---

This was originally based on [code in the TileDB-Cloud-UDFs package](https://github.com/TileDB-Inc/TileDB-Cloud-UDFs/blob/35d53852387941cb78f4703cb3a8ad1b065450d0/register_udfs.py#L22-L28), but with some more digging into the exact reason that it worked (notably, that clearing `__globals__` was a red herring).