### PR TITLE
Implement Batch DAG cancel and retries

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1622,7 +1622,6 @@ class DAG:
                     node = self.nodes_by_name[new_node.name]
                     new_node_status = array_task_status_to_status(new_node.status)
                     if node.status != new_node_status:
-                        self.report_node_status_change(node, new_node_status)
                         if new_node_status in (
                             Status.FAILED,
                             Status.CANCELLED,
@@ -1645,7 +1644,10 @@ class DAG:
 
                             else:
                                 raise RuntimeError("No executions found for done Node.")
+                            self.report_node_status_change(node, new_node_status)
                             self.report_node_complete(node)
+                        else:
+                            self.report_node_status_change(node, new_node_status)
                 new_workflow_status = task_graph_log_status_to_status(result.status)
                 if self._status != new_workflow_status:
                     with self._lifecycle_condition:

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1186,8 +1186,6 @@ class DAG:
                 client.build(rest_api.TaskGraphLogsApi).stop_task_graph_execution(
                     namespace=self.namespace, id=self.server_graph_uuid
                 )
-            except rest_api.ApiException as apix:
-                raise
             with self._lifecycle_condition:
                 self._set_status(Status.CANCELLED)
         else:

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1182,10 +1182,9 @@ class DAG:
 
     def cancel(self):
         if self.mode == Mode.BATCH:
-            try:
-                client.build(rest_api.TaskGraphLogsApi).stop_task_graph_execution(
-                    namespace=self.namespace, id=self.server_graph_uuid
-                )
+            client.build(rest_api.TaskGraphLogsApi).stop_task_graph_execution(
+                namespace=self.namespace, id=self.server_graph_uuid
+            )
             with self._lifecycle_condition:
                 self._set_status(Status.CANCELLED)
         else:


### PR DESCRIPTION
Implement `cancel()` and `retry_all()` DAG calls for Batch taskgraphs.

This is using the server side API calls to stop and retry the taskgraph as well as update the client side states accordingly.