### PR TITLE
Improve notebook APIs: add timestamp, handle on-exists better.

### DIFF
--- a/src/tiledb/cloud/_common/utils.py
+++ b/src/tiledb/cloud/_common/utils.py
@@ -1,10 +1,11 @@
 import base64
+import datetime
 import functools
 import logging
 import sys
 import threading
 import urllib.parse
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar, Union
 
 import cloudpickle
 import urllib3
@@ -107,3 +108,7 @@ def release_connection(resp: urllib3.HTTPResponse) -> None:
     """
     resp.drain_conn()
     resp.release_conn()
+
+
+def datetime_to_msec(t: Union[datetime.datetime, int, None]) -> Optional[int]:
+    return int(t.timestamp() * 1000) if isinstance(t, datetime.datetime) else t

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,12 +1,15 @@
 import base64
+import datetime
 import pickle
 import unittest
+
+import pytz  # Test-only dependency.
 
 from tiledb.cloud._common import utils
 
 
-class PickleTest(unittest.TestCase):
-    def test_roundtrip(self):
+class UtilsTest(unittest.TestCase):
+    def test_pickle_roundtrip(self):
         cases = (
             None,
             ("a", 1),
@@ -17,6 +20,26 @@ class PickleTest(unittest.TestCase):
                 pickled = utils.b64_pickle(c)
                 unpickled = _b64_unpickle(pickled)
                 self.assertEqual(unpickled, c)
+
+    def test_datetime_to_msec(self):
+        cases = [
+            (0, 0),
+            (
+                datetime.datetime(
+                    1970, 2, 3, microsecond=123999, tzinfo=datetime.timezone.utc
+                ),
+                2851200123,
+            ),
+            (
+                pytz.timezone("America/New_York").localize(
+                    datetime.datetime(2023, 4, 28, 12, 34, 56, 789012)
+                ),
+                1682699696789,
+            ),
+        ]
+        for inval, expected in cases:
+            with self.subTest(inval):
+                self.assertEqual(utils.datetime_to_msec(inval), expected)
 
 
 def _b64_unpickle(x):


### PR DESCRIPTION
- Adds a timestamp parameter to the notebook downloaders to provide time travel directly from the notebook API.
- Sets default values for upload functions to avoid needing to pass every single parameter.
- Handles overwrite-on-exists case better; will not fail if the array doesn't yet exist.