### PR TITLE
Use node ID, not node name, to find nodes sent back from server.

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1646,8 +1646,10 @@ class DAG:
             except rest_api.ApiException:
                 raise
             else:
-                for new_node in result.nodes:
-                    node = self.nodes_by_name[new_node.name]
+                for new_node in result.nodes or ():
+                    assert isinstance(new_node, models.TaskGraphNodeMetadata)
+                    node_uuid = uuid.UUID(new_node.client_node_uuid)
+                    node = self.nodes[node_uuid]
                     new_node_status = array_task_status_to_status(new_node.status)
                     if node.status != new_node_status:
                         if new_node_status in (


### PR DESCRIPTION
When associating nodes in a task graph log to those in the graph itself, we were using the node's name. This was not intended to be used for that purpose; instead we should be using its UUID, which is IDentifies it, Uniquely (Universally).