### PR TITLE
VCF ingestion updates

### DIFF
--- a/src/tiledb/cloud/utilities/__init__.py
+++ b/src/tiledb/cloud/utilities/__init__.py
@@ -1,5 +1,6 @@
 from ._common import get_logger
 from ._common import max_memory_usage
+from ._common import process_stream
 from ._common import read_aws_config
 from ._common import read_file
 from ._common import run_dag
@@ -11,6 +12,7 @@ from .profiler import write_log_event
 __all__ = [
     "get_logger",
     "max_memory_usage",
+    "process_stream",
     "read_aws_config",
     "read_file",
     "run_dag",

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -233,7 +233,8 @@ def process_stream(
                 try:
                     process.stdin.write(data)
                 except BrokenPipeError:
-                    # The subprocess has exited, stop reading
+                    # The subprocess has exited, stop reading.
+                    # This is an expected situation.
                     break
                 data = fp.read(read_size)
             try:

--- a/src/tiledb/cloud/utilities/profiler.py
+++ b/src/tiledb/cloud/utilities/profiler.py
@@ -61,6 +61,9 @@ def write_log_event(
     """
     Write an event to the log array.
 
+    When writing large amounts of data, store the data in the `extra` parameter
+    to improve query performance when the `extra` data is not needed.
+
     :param uri: array URI
     :param id: event id
     :param op: event operation, defaults to ""
@@ -199,6 +202,9 @@ class Profiler(object):
     def write(self, op: str = "", data: str = "", extra: str = "") -> None:
         """
         Write an event to the log array.
+
+        When writing large amounts of data, store the data in the `extra` parameter
+        to improve query performance when the `extra` data is not needed.
 
         :param op: event op, defaults to ""
         :param data: event data, defaults to ""

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -570,15 +570,6 @@ def ingest_samples_udf(
             pool.map(create_index_file_worker, sample_uris)
 
         # TODO: Handle un-bgzipped files
-        """
-        new_sample_uris = []
-        for uri in sample_uris:
-            if not is_bgzipped(uri):
-                logger.debug("bgzipping and indexing %r", uri)
-                uri = bgzip_and_index(uri)
-            new_sample_uris.append(uri)
-        sample_uris = new_sample_uris
-        """
 
         level = "debug" if verbose else "info"
         tiledbvcf.config_logging(level, "ingest.log")

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -67,8 +67,7 @@ def get_record_count(vcf_uri: str, index_uri: str) -> int:
     open(vcf_file, "w").close()
 
     # Make a local copy of the index file.
-    local_file = os.path.basename(index_uri)
-    # tiledb.VFS().copy_file(index_uri, local_file)
+    local_file = os.path.basename(index_uri).replace(".csi", ".tbi")
     cmd = f"cp /dev/stdin {local_file}"
     _, stderr = process_stream(index_uri, cmd)
     if stderr:

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -1,0 +1,128 @@
+import os
+import subprocess
+import tempfile
+import tiledb
+from tiledb.cloud.utilities import process_stream
+
+
+def find_index(vcf_uri: str) -> str:
+    """
+    Find the index file for a VCF file or an empty string if not found.
+
+    :param vcf_uri: URI of the VCF file
+    :return: URI of the index file
+    """
+
+    for ext in ["tbi", "csi"]:
+        index = f"{vcf_uri}.{ext}"
+        if tiledb.VFS().is_file(index):
+            return index
+    return ""
+
+
+def is_bgzipped(vcf_uri: str) -> bool:
+    """
+    Returns True if the VCF file is bgzipped.
+
+    :param vcf_uri: URI of the VCF file
+    :return: True if the VCF file is bgzipped
+    """
+
+    cmd = "file -b -"
+    stdout, stderr = process_stream(vcf_uri, cmd, read_size=1024)
+    if stderr:
+        raise RuntimeError(f"Failed to check file type: {stderr}")
+    return "BGZF" in stdout
+
+
+def get_sample_name(vcf_uri: str) -> str:
+    """
+    Returns the sample name in a VCF file.
+
+    If there are multiple samples, return a comma-separated list of sample names.
+
+    :param vcf_uri: URI of the VCF file
+    :return: sample name
+    """
+
+    cmd = "bcftools query -l"
+    stdout, stderr = process_stream(vcf_uri, cmd, read_size=1024)
+    if stderr:
+        raise RuntimeError(f"Failed to get sample names: {stderr}")
+    return ",".join(stdout.splitlines())
+
+
+def get_record_count(vcf_uri: str, index_uri: str) -> int:
+    """
+    Return the record count in a VCF file.
+
+    :param vcf_uri: URI of the VCF file
+    :param index_uri: URI of the VCF index file
+    :return: record count or 0 if there is an error
+    """
+
+    # Create an empty VCF file in the current working directory
+    # for `bcftools index -n`, which only reads the index file.
+    vcf_file = os.path.basename(vcf_uri)
+    open(vcf_file, "w").close()
+
+    # Make a local copy of the index file.
+    local_file = os.path.basename(index_uri)
+    # tiledb.VFS().copy_file(index_uri, local_file)
+    cmd = f"cp /dev/stdin {local_file}"
+    _, stderr = process_stream(index_uri, cmd)
+    if stderr:
+        raise RuntimeError(f"Failed to create index: {stderr}")
+
+    # Get the record count using bcftools
+    cmd = f"bcftools index -n {vcf_file}##idx##{local_file}"
+    res = subprocess.run(cmd.split(), capture_output=True, text=True)
+
+    # If there is an error, this means there was a problem reading the
+    # index file or the index file is an old format that does not
+    # contain the required metadata. In either case, return 0 to
+    # indicate a problem with the index that needs to be addressed
+    # before ingesting the sample.
+    if res.stderr:
+        print(res.stderr)
+        return 0
+
+    return int(res.stdout)
+
+
+def create_index_file(vcf_uri: str) -> str:
+    """
+    Create a VCF index file in the current working directory.
+
+    :param vcf_uri: URI of the VCF file
+    :return: index file name
+    """
+
+    index_file = f"{os.path.basename(vcf_uri)}.csi"
+
+    cmd = f"bcftools index -f -o {index_file}"
+    _, stderr = process_stream(vcf_uri, cmd, read_size=64 << 20)
+    if stderr:
+        raise RuntimeError(f"Failed to create index: {stderr}")
+
+    return index_file
+
+
+def bgzip_and_index(vcf_uri: str) -> str:
+    """
+    Create a bgzipped VCF file and index file in the current working directory.
+
+    :param vcf_uri: URI of the VCF file
+    :return: bgzipped VCF file name
+    """
+
+    bgzip_file = f"{os.path.basename(vcf_uri)}.gz"
+
+    cmd = f"bcftools view -Oz -o {bgzip_file}"
+    _, stderr = process_stream(vcf_uri, cmd)
+    if stderr:
+        raise RuntimeError(f"Failed to bgzip: {stderr}")
+
+    create_index_file(bgzip_file)
+
+    return bgzip_file

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import tempfile
+
 import tiledb
 from tiledb.cloud.utilities import process_stream
 
@@ -66,7 +66,7 @@ def get_record_count(vcf_uri: str, index_uri: str) -> int:
     vcf_file = os.path.basename(vcf_uri)
     open(vcf_file, "w").close()
 
-    # Make a local copy of the index file.
+    # Make a local copy of the index file, rename extension to avoid issue in bcftools.
     local_file = os.path.basename(index_uri).replace(".csi", ".tbi")
     cmd = f"cp /dev/stdin {local_file}"
     _, stderr = process_stream(index_uri, cmd)

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -28,7 +28,7 @@ def is_bgzipped(vcf_uri: str) -> bool:
     :return: True if the VCF file is bgzipped
     """
 
-    cmd = "file -b -"
+    cmd = ("file", "-b", "-")
     stdout, stderr = process_stream(vcf_uri, cmd, read_size=1024)
     if stderr:
         raise RuntimeError(f"Failed to check file type: {stderr}")
@@ -45,7 +45,7 @@ def get_sample_name(vcf_uri: str) -> str:
     :return: sample name
     """
 
-    cmd = "bcftools query -l"
+    cmd = ("bcftools", "query", "-l")
     stdout, stderr = process_stream(vcf_uri, cmd, read_size=1024)
     if stderr:
         raise RuntimeError(f"Failed to get sample names: {stderr}")
@@ -68,14 +68,14 @@ def get_record_count(vcf_uri: str, index_uri: str) -> int:
 
     # Make a local copy of the index file, rename extension to avoid issue in bcftools.
     local_file = os.path.basename(index_uri).replace(".csi", ".tbi")
-    cmd = f"cp /dev/stdin {local_file}"
+    cmd = ("cp", "/dev/stdin", local_file)
     _, stderr = process_stream(index_uri, cmd)
     if stderr:
         raise RuntimeError(f"Failed to create index: {stderr}")
 
     # Get the record count using bcftools
-    cmd = f"bcftools index -n {vcf_file}##idx##{local_file}"
-    res = subprocess.run(cmd.split(), capture_output=True, text=True)
+    cmd = ("bcftools", "index", "-n", f"{vcf_file}##idx##{local_file}")
+    res = subprocess.run(cmd, capture_output=True, text=True)
 
     # If there is an error, this means there was a problem reading the
     # index file or the index file is an old format that does not
@@ -99,7 +99,7 @@ def create_index_file(vcf_uri: str) -> str:
 
     index_file = f"{os.path.basename(vcf_uri)}.csi"
 
-    cmd = f"bcftools index -f -o {index_file}"
+    cmd = ("bcftools", "index", "-f", "-o", index_file)
     _, stderr = process_stream(vcf_uri, cmd, read_size=64 << 20)
     if stderr:
         raise RuntimeError(f"Failed to create index: {stderr}")
@@ -117,7 +117,7 @@ def bgzip_and_index(vcf_uri: str) -> str:
 
     bgzip_file = f"{os.path.basename(vcf_uri)}.gz"
 
-    cmd = f"bcftools view -Oz -o {bgzip_file}"
+    cmd = ("bcftools", "view", "-Oz", "-o", bgzip_file)
     _, stderr = process_stream(vcf_uri, cmd)
     if stderr:
         raise RuntimeError(f"Failed to bgzip: {stderr}")


### PR DESCRIPTION
Updates to VCF ingestion:
* Add `access_credentials_name` parameter to support AWS assume role.
* Add task graph retry strategy and enable `resume` by default.
* Support creating index files on the fly.
* Add `anchor_gap` parameter to set the anchor gap length, which is useful for structural variant VCFs.
* Add `max_sample` parameter to limit the number of samples ingested, which is different than using `max_files` to limit the number of samples added to the manifest.
* Add `process_stream` utility function to stream a file into a subprocess using VFS. This replaces use cases like `aws s3 cp - | bcftools` and enables all storage backends supported by VFS.