### PR TITLE
Look at the *child* nodes when looking for local child nodes.

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -498,7 +498,7 @@ class Node(futures.FutureLike[_T]):
                     # If this is an intermediate node, download results only if
                     # there is a child node which runs locally.
                     download_results = any(
-                        child.mode == Mode.LOCAL for child in self.parents.values()
+                        child.mode == Mode.LOCAL for child in self.children.values()
                     )
                 else:
                     # If this is a terminal node, always download results.


### PR DESCRIPTION
To find whether to download results, we wanted to check whether either it was terminal or had any local children. But instead of looking at the children, we looked at the *parents*.