### PR TITLE
Filters quasi-serializing UDF passthrough

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -38,7 +38,6 @@ def ingest(
     def ingest_tiff_udf(
         io_uris: Sequence[Tuple],
         config: Mapping[str, Any],
-        workers: int,
         *args: Any,
         **kwargs,
     ):
@@ -47,10 +46,22 @@ def ingest(
 
         :param io_uris: Pairs of tiff input - output tdb uris
         :param config: dict configuration to pass on tiledb.VFS
-        :param workers: Number of threads that will spawn for parallelizing ingestion
         """
 
+        from tiledb import filter as compressors
         from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
+
+        compressor = kwargs.get("compressor", None)
+        if compressor:
+            compressor_type = compressor.get("type", None)
+            if compressor_type:
+                kwargs["compressor"] = vars(compressors).get(compressor_type)(
+                    **compressor.get("attrs", {})
+                )
+            else:
+                raise ValueError
+        else:
+            kwargs["compressor"] = compressor
 
         conf = tiledb.Config(params=config)
         vfs = tiledb.VFS(config=conf)
@@ -58,9 +69,7 @@ def ingest(
         with tiledb.scope_ctx(ctx_or_config=conf):
             for input, output in io_uris:
                 with vfs.open(input) as src:
-                    OMETiffConverter.to_tiledb(
-                        src, output, *args, max_workers=workers, chunked=True, **kwargs
-                    )
+                    OMETiffConverter.to_tiledb(src, output, **kwargs)
 
     if isinstance(source, str):
         # Handle only lists
@@ -87,8 +96,8 @@ def ingest(
     samples = get_uris(source, output, config)
 
     # Build the task graph
-    dag_name = "batch-ingest-bioimg" if taskgraph_name is None else taskgraph_name
-    task_prefix = f"{dag_name}  - Batch Task"
+    dag_name = "bioimg-ingestion" if taskgraph_name is None else taskgraph_name
+    task_prefix = f"{dag_name} - Task"
 
     logger.info("Building graph")
     graph = tiledb.cloud.dag.DAG(
@@ -97,6 +106,12 @@ def ingest(
         max_workers=max_workers,
         namespace=namespace,
     )
+
+    # serialize udf arguments
+    compressor = kwargs.get("compressor", None)
+    compressor_serial = serialize_filter(compressor) if compressor else None
+    if compressor_serial:
+        kwargs.pop("compressor")
 
     for i, work in enumerate(batch(samples, batch_size)):
         logger.info(f"Adding batch {i}")
@@ -110,11 +125,17 @@ def ingest(
             mode=tiledb.cloud.dag.Mode.BATCH,
             resources=DEFAULT_RESOURCES if resources is None else resources,
             image_name=DEFAULT_IMG_NAME,
+            compressor=compressor_serial,
             **kwargs,
         )
 
     graph.compute()
     return graph
+
+
+def serialize_filter(filter):
+    if isinstance(filter, tiledb.Filter):
+        return {"type": type(filter).__name__, "attrs": filter._attrs_()}
 
 
 def ingest_udf(*args: Any, **kwargs: Any) -> Dict[str, str]:

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -53,7 +53,8 @@ def ingest(
 
         compressor = kwargs.get("compressor", None)
         if compressor:
-            compressor_name = compressor.get("_name", None)
+            compressor_args = dict(compressor)
+            compressor_name = compressor_args.pop("_name")
             if compressor_name:
                 compressor_args = {
                     k: None if not v else v
@@ -64,8 +65,6 @@ def ingest(
                 )
             else:
                 raise ValueError
-        else:
-            kwargs["compressor"] = compressor
 
         conf = tiledb.Config(params=config)
         vfs = tiledb.VFS(config=conf)
@@ -137,7 +136,11 @@ def ingest(
 
 def serialize_filter(filter):
     if isinstance(filter, tiledb.Filter):
-        return {"_name": type(filter).__name__, "attrs": filter._attrs_()}
+        filter_dict = filter._attrs_()
+        filter_dict["_name"] = type(filter).__name__
+        return filter_dict
+    else:
+        raise TypeError
 
 
 def ingest_udf(*args: Any, **kwargs: Any) -> Dict[str, str]:


### PR DESCRIPTION
This PR:

- quasi-serializes the filter/compressor to be used during ingestion on the client side
- passes the serialized filter into the udf
- udf deserialises by instantiating filter object by name
- disables `chunked=True` that caused an `IndexError: tuple index out of range` in some images till further investigation of these failed images and the `tiifffile` package where it derives from.

This might be a hotfix for now (needed by Quest) till we standarize the way a user can choose to pass unserialisable tiledb objects into udfs.