### PR TITLE
Pass actual used namespace to task graph logs endpoint.

### DIFF
--- a/src/tiledb/cloud/taskgraphs/client_executor/impl.py
+++ b/src/tiledb/cloud/taskgraphs/client_executor/impl.py
@@ -475,6 +475,7 @@ class LocalExecutor(_base.IClientExecutor):
             api_st = _API_STATUSES[st]
         except KeyError:
             warnings.warn(UserWarning(f"Task graph ended in invalid state {st!r}"))
+            return
 
         do_update = utils.ephemeral_thread(
             client.build(rest_api.TaskGraphLogsApi).update_task_graph_log,
@@ -482,7 +483,7 @@ class LocalExecutor(_base.IClientExecutor):
         )
         do_update(
             id=str(self._server_graph_uuid),
-            namespace=self._namespace,
+            namespace=self.namespace,
             log=rest_api.TaskGraphLog(status=api_st),
             _request_timeout=_REPORT_TIMEOUT_SECS,
         )


### PR DESCRIPTION
After some server-side changes, reporting completion of a task graph where the user did not specify a namespace explicitly would fail because we weren't passing in the right one. This ensures that we always pass the namespace that was actually used to execute the graph.

---

[sc-30722]