### PR TITLE
Adding argument for computing DAG inside ingestion or just returning

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -33,6 +33,8 @@ def ingest(
     :param threads: Number of threads for node side multiprocessing, defaults to 8
     :param resources: configuration for node specs e.g. {"cpu": "8", "memory": "4Gi"},
         defaults to None
+    :param compute: When True the DAG returned will be computed inside the function
+    otherwise DAG will only be returned.
     :param namespace: The namespace where the DAG will run
     """
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -18,6 +18,7 @@ def ingest(
     num_batches: Optional[int] = None,
     threads: Optional[int] = 8,
     resources: Optional[Mapping[str, Any]] = None,
+    compute: bool = True,
     namespace: Optional[str],
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
@@ -129,7 +130,8 @@ def ingest(
             **kwargs,
         )
 
-    graph.compute()
+    if compute:
+        graph.compute()
     return graph
 
 


### PR DESCRIPTION
This PR [sc-30746]:

- Adds a `boolean` argument to the `bioimg.ingestion` function for enabling the return of the DAG without starting computing it.
- Since this function is used in the UI call as well the default behaviour remains the same as before so there is no need for any further changes in other projects.