### PR TITLE
Add new VCF ingestion options

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -19,21 +19,10 @@ from tiledb.cloud.utilities import read_file
 from tiledb.cloud.utilities import run_dag
 from tiledb.cloud.utilities import set_aws_context
 from tiledb.cloud.utilities import write_log_event
-
-if True:
-    # Bring code into scope for testing on TileDB Cloud
-    import importlib, os
-
-    path = os.path.dirname(importlib.import_module("tiledb.cloud").__file__)
-    files = [f"{path}/vcf/utils.py"]
-    for file in files:
-        with open(file) as f:
-            exec(compile(f.read(), file, "exec"))
-else:
-    from .utils import create_index_file
-    from .utils import find_index
-    from .utils import get_record_count
-    from .utils import get_sample_name
+from tiledb.cloud.vcf.utils import create_index_file
+from tiledb.cloud.vcf.utils import find_index
+from tiledb.cloud.vcf.utils import get_record_count
+from tiledb.cloud.vcf.utils import get_sample_name
 
 # Testing hooks
 local_ingest = False

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -498,7 +498,7 @@ def ingest_manifest_udf(
                     records = 0
                 else:
                     records = get_record_count(vcf_uri, index_uri)
-                    if records == 0:
+                    if records is None:
                         status = "" if status == "ok" else status + ","
                         status += "bad index"
 
@@ -845,7 +845,7 @@ def ingest_samples_dag(
     batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
     compute: bool = True,
-) -> Tuple[dag.DAG, Sequence[str]]:
+) -> Tuple[Optional[dag.DAG], Sequence[str]]:
     """
     Create a DAG to ingest samples into the dataset.
 
@@ -873,7 +873,7 @@ def ingest_samples_dag(
     logger = setup(config, verbose)
 
     batch_mode = batch_mode or bool(access_credentials_name)
-    dag_mode = dag.Mode.BATCH if access_credentials_name else dag.Mode.REALTIME
+    dag_mode = dag.Mode.BATCH if batch_mode else dag.Mode.REALTIME
 
     # Only pass `access_credentials_name` to `submit` when running in batch mode.
     kwargs = {"access_credentials_name": access_credentials_name} if batch_mode else {}
@@ -1046,7 +1046,7 @@ def ingest(
     batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
     compute: bool = True,
-) -> Tuple[dag.DAG, Sequence[str]]:
+) -> Tuple[Optional[dag.DAG], Sequence[str]]:
     """
     Ingest samples into a dataset.
 

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 from math import ceil
 from multiprocessing.pool import ThreadPool
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -20,10 +20,20 @@ from tiledb.cloud.utilities import run_dag
 from tiledb.cloud.utilities import set_aws_context
 from tiledb.cloud.utilities import write_log_event
 
-from .utils import create_index_file
-from .utils import find_index
-from .utils import get_record_count
-from .utils import get_sample_name
+if True:
+    # Bring code into scope for testing on TileDB Cloud
+    import importlib, os
+
+    path = os.path.dirname(importlib.import_module("tiledb.cloud").__file__)
+    files = [f"{path}/vcf/utils.py"]
+    for file in files:
+        with open(file) as f:
+            exec(compile(f.read(), file, "exec"))
+else:
+    from .utils import create_index_file
+    from .utils import find_index
+    from .utils import get_record_count
+    from .utils import get_sample_name
 
 # Testing hooks
 local_ingest = False
@@ -632,7 +642,7 @@ def consolidate_dataset_udf(
                 continue
 
             # NOTE: REST currently only supports fragment_meta, commits, metadata
-            modes = ["commits", "fragment_meta", "array_meta"]
+            modes = ["commits", "fragment_meta"]
 
             # Consolidate fragments for selected arrays
             if name in [LOG_ARRAY, MANIFEST_ARRAY, "vcf_headers"]:
@@ -674,6 +684,7 @@ def ingest_manifest_dag(
     vcf_attrs: Optional[str] = None,
     anchor_gap: Optional[int] = None,
     verbose: bool = False,
+    batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
 ) -> None:
     """
@@ -693,17 +704,17 @@ def ingest_manifest_dag(
     :param vcf_attrs: VCF with all INFO/FORMAT fields to materialize, defaults to None
     :param anchor_gap: anchor gap for VCF dataset, defaults to None
     :param verbose: verbose logging, defaults to False
+    :param batch_mode: run all DAGs in batch mode, defaults to True
     :param access_credentials_name: name of role in TileDB Cloud to use in tasks
     """
 
     logger = get_logger()
 
-    dag_mode = dag.Mode.BATCH if access_credentials_name else dag.Mode.REALTIME
-    kwargs = (
-        {"access_credentials_name": access_credentials_name}
-        if access_credentials_name
-        else {}
-    )
+    batch_mode = batch_mode or bool(access_credentials_name)
+    dag_mode = dag.Mode.BATCH if batch_mode else dag.Mode.REALTIME
+
+    # Only pass `access_credentials_name` to `submit` when running in batch mode.
+    kwargs = {"access_credentials_name": access_credentials_name} if batch_mode else {}
 
     graph = dag.DAG(
         name="vcf-filter-uris",
@@ -842,8 +853,10 @@ def ingest_samples_dag(
     ingest_resources: Optional[Mapping[str, str]] = None,
     verbose: bool = False,
     trace_id: Optional[str] = None,
+    batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
-) -> dag.DAG:
+    build_only: bool = False,
+) -> Tuple[dag.DAG, Sequence[str]]:
     """
     Create a DAG to ingest samples into the dataset.
 
@@ -861,18 +874,19 @@ def ingest_samples_dag(
     :param ingest_resources: manual override for ingest UDF resources, defaults to None
     :param verbose: verbose logging, defaults to False
     :param trace_id: trace ID for logging, defaults to None
+    :param batch_mode: run all DAGs in batch mode, defaults to True
     :param access_credentials_name: name of role in TileDB Cloud to use in tasks
-    :return: sample ingestion DAG for visualization
+    :param build_only: only build the DAG, do not run the DAG, defaults to False
+    :return: sample ingestion DAG and list of sample URIs ingested
     """
 
     logger = setup(config, verbose)
 
+    batch_mode = batch_mode or bool(access_credentials_name)
     dag_mode = dag.Mode.BATCH if access_credentials_name else dag.Mode.REALTIME
-    kwargs = (
-        {"access_credentials_name": access_credentials_name}
-        if access_credentials_name
-        else {}
-    )
+
+    # Only pass `access_credentials_name` to `submit` when running in batch mode.
+    kwargs = {"access_credentials_name": access_credentials_name} if batch_mode else {}
 
     graph = dag.DAG(
         name="vcf-filter-samples",
@@ -899,7 +913,7 @@ def ingest_samples_dag(
 
     if not sample_uris:
         logger.info("No new samples to ingest.")
-        return
+        return None, []
 
     # Limit number of samples to ingest
     if max_samples:
@@ -997,18 +1011,19 @@ def ingest_samples_dag(
         if consolidate:
             consolidate.depends_on(ingest)
 
-    logger.debug("Submitting DAG")
-    run_dag(graph, wait=local_ingest)
+    if not build_only:
+        logger.debug("Submitting DAG")
+        run_dag(graph, wait=local_ingest)
 
-    if not local_ingest:
-        logger.info(
-            "Batch ingestion submitted -"
-            " https://cloud.tiledb.com/activity/taskgraphs/%s/%s",
-            graph.namespace,
-            graph.server_graph_uuid,
-        )
+        if not local_ingest:
+            logger.info(
+                "Batch ingestion submitted -"
+                " https://cloud.tiledb.com/activity/taskgraphs/%s/%s",
+                graph.namespace,
+                graph.server_graph_uuid,
+            )
 
-    return graph
+    return graph, sample_uris
 
 
 # --------------------------------------------------------------------
@@ -1040,8 +1055,10 @@ def ingest(
     ingest_resources: Optional[Mapping[str, str]] = None,
     verbose: bool = False,
     trace_id: Optional[str] = None,
+    batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
-) -> dag.DAG:
+    build_only: bool = False,
+) -> Tuple[dag.DAG, Sequence[str]]:
     """
     Ingest samples into a dataset.
 
@@ -1074,8 +1091,11 @@ def ingest(
     :param ingest_resources: manual override for ingest UDF resources, defaults to None
     :param verbose: verbose logging, defaults to False
     :param trace_id: trace ID for logging, defaults to None
+    :param batch_mode: run all DAGs in batch mode, only set to False for dev or demos,
+        defaults to True
     :param access_credentials_name: name of role in TileDB Cloud to use in tasks
-    :return: sample ingestion DAG for visualization
+    :param build_only: only build the DAG, do not run the DAG, defaults to False
+    :return: sample ingestion DAG and list of sample URIs ingested
     """
 
     # Validate user input
@@ -1088,17 +1108,16 @@ def ingest(
     if sample_list_uri and (pattern or ignore):
         raise ValueError("Cannot specify `pattern` or `ignore` with `sample_list_uri`.")
 
+    if not batch_mode and access_credentials_name:
+        raise ValueError(
+            "Cannot specify `access_credentials_name` with `batch_mode=False`."
+        )
+
     # Remove any trailing slashes
     dataset_uri = dataset_uri.rstrip("/")
 
     logger = setup(config, verbose)
     logger.info("Ingesting VCF samples into %r", dataset_uri)
-
-    kwargs = (
-        {"access_credentials_name": access_credentials_name}
-        if access_credentials_name
-        else {}
-    )
 
     # Add VCF URIs to the manifest
     ingest_manifest_dag(
@@ -1116,11 +1135,12 @@ def ingest(
         vcf_attrs=vcf_attrs,
         anchor_gap=anchor_gap,
         verbose=verbose,
-        **kwargs,
+        batch_mode=batch_mode,
+        access_credentials_name=access_credentials_name,
     )
 
     # Ingest VCFs using URIs in the manifest
-    return ingest_samples_dag(
+    dag, sample_uris = ingest_samples_dag(
         dataset_uri,
         config=config,
         namespace=namespace,
@@ -1133,5 +1153,9 @@ def ingest(
         ingest_resources=ingest_resources,
         verbose=verbose,
         trace_id=trace_id,
-        **kwargs,
+        batch_mode=batch_mode,
+        access_credentials_name=access_credentials_name,
+        build_only=build_only,
     )
+
+    return dag, sample_uris

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -844,7 +844,7 @@ def ingest_samples_dag(
     trace_id: Optional[str] = None,
     batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
-    build_only: bool = False,
+    compute: bool = True,
 ) -> Tuple[dag.DAG, Sequence[str]]:
     """
     Create a DAG to ingest samples into the dataset.
@@ -865,7 +865,8 @@ def ingest_samples_dag(
     :param trace_id: trace ID for logging, defaults to None
     :param batch_mode: run all DAGs in batch mode, defaults to True
     :param access_credentials_name: name of role in TileDB Cloud to use in tasks
-    :param build_only: only build the DAG, do not run the DAG, defaults to False
+    :param compute: when True the DAG will be computed before it is returned,
+        defaults to True
     :return: sample ingestion DAG and list of sample URIs ingested
     """
 
@@ -907,8 +908,6 @@ def ingest_samples_dag(
     # Limit number of samples to ingest
     if max_samples:
         sample_uris = sample_uris[:max_samples]
-
-    logger.info("Ingesting %d samples.", len(sample_uris))
 
     contig_fragment_merging = True
     if type(contigs) == list:
@@ -1000,8 +999,8 @@ def ingest_samples_dag(
         if consolidate:
             consolidate.depends_on(ingest)
 
-    if not build_only:
-        logger.debug("Submitting DAG")
+    if compute:
+        logger.info("Ingesting %d samples.", len(sample_uris))
         run_dag(graph, wait=local_ingest)
 
         if not local_ingest:
@@ -1046,7 +1045,7 @@ def ingest(
     trace_id: Optional[str] = None,
     batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
-    build_only: bool = False,
+    compute: bool = True,
 ) -> Tuple[dag.DAG, Sequence[str]]:
     """
     Ingest samples into a dataset.
@@ -1083,7 +1082,8 @@ def ingest(
     :param batch_mode: run all DAGs in batch mode, only set to False for dev or demos,
         defaults to True
     :param access_credentials_name: name of role in TileDB Cloud to use in tasks
-    :param build_only: only build the DAG, do not run the DAG, defaults to False
+    :param compute: when True the DAG will be computed before it is returned,
+        defaults to True
     :return: sample ingestion DAG and list of sample URIs ingested
     """
 
@@ -1144,7 +1144,7 @@ def ingest(
         trace_id=trace_id,
         batch_mode=batch_mode,
         access_credentials_name=access_credentials_name,
-        build_only=build_only,
+        compute=compute,
     )
 
     return dag, sample_uris

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -68,8 +68,8 @@ def get_record_count(vcf_uri: str, index_uri: str) -> Optional[int]:
     vcf_file = os.path.basename(vcf_uri)
     open(vcf_file, "w").close()
 
-    # Make a local copy of the index file, rename extension to avoid issue in bcftools.
-    local_file = os.path.basename(index_uri).replace(".csi", ".tbi")
+    # Make a local copy of the index file
+    local_file = os.path.basename(index_uri)
     with tiledb.VFS().open(index_uri) as infile:
         with open(local_file, "wb") as outfile:
             shutil.copyfileobj(infile, outfile, length=16 << 20)
@@ -80,10 +80,10 @@ def get_record_count(vcf_uri: str, index_uri: str) -> Optional[int]:
 
     # If there is an error, this means there was a problem reading the
     # index file or the index file is an old format that does not
-    # contain the required metadata. In either case, return 0 to
+    # contain the required metadata. In either case, return None to
     # indicate a problem with the index that needs to be addressed
     # before ingesting the sample.
-    if res.stderr:
+    if res.returncode != 0:
         print(res.stderr)
         return None
 


### PR DESCRIPTION
* Return the DAG without running the DAG, set the argument `compute=False`. [sc-30743]
* Return URIs of VCF samples ingested. [sc-30744]
* Run all VCF ingestion DAGs in batch mode. [sc-30799]