### PR TITLE
Exportation Function 2TIFF for BioImg in TileDB Cloud

### DIFF
--- a/src/tiledb/cloud/bioimg/__init__.py
+++ b/src/tiledb/cloud/bioimg/__init__.py
@@ -1,3 +1,4 @@
+from tiledb.cloud.bioimg.exportation import export
 from tiledb.cloud.bioimg.ingestion import ingest
 
-__all__ = ("ingest",)
+__all__ = ("ingest", "export")

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -56,9 +56,8 @@ def export(
         from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 
         conf = tiledb.Config(params=config)
-        with tiledb.scope_ctx(ctx_or_config=conf):
-            for input, output in io_uris:
-                OMETiffConverter.from_tiledb(input, output, **kwargs)
+        for input, output in io_uris:
+            OMETiffConverter.from_tiledb(input, output, config=conf, **kwargs)
 
     if isinstance(source, str):
         # Handle only lists

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -18,10 +18,9 @@ def export(
     *args: Any,
     taskgraph_name: Optional[str] = None,
     num_batches: Optional[int] = None,
-    threads: Optional[int] = 8,
     resources: Optional[Mapping[str, Any]] = None,
     compute: bool = True,
-    namespace: Optional[str],
+    namespace: Optional[str] = None,
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
     """The function exports microscopy images from TileDB arrays
@@ -68,7 +67,7 @@ def export(
     batch_size, max_workers = scale_calc(source, num_batches)
 
     # Build the task graph
-    dag_name = DEFAULT_DAG_NAME if taskgraph_name is None else taskgraph_name
+    dag_name = taskgraph_name or DEFAULT_DAG_NAME
     task_prefix = f"{dag_name} - Task"
 
     logger.info("Building graph")
@@ -85,7 +84,6 @@ def export(
             export_tiff_udf,
             work,
             config,
-            threads,
             *args,
             name=f"{task_prefix} - {i}/{num_batches}",
             mode=tiledb.cloud.dag.Mode.BATCH,

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -65,7 +65,7 @@ def export(
         source = [source]
 
     # Get the list of all BioImg samples input/out
-    samples = get_uris(source, output, config)
+    samples = get_uris(source, output, config, "tiff")
     batch_size, max_workers = scale_calc(source, num_batches)
 
     # Build the task graph

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -5,14 +5,13 @@ from tiledb.cloud._common.utils import logger
 from tiledb.cloud.bioimg.helpers import batch
 from tiledb.cloud.bioimg.helpers import get_uris
 from tiledb.cloud.bioimg.helpers import scale_calc
-from tiledb.cloud.bioimg.helpers import serialize_filter
 
 DEFAULT_RESOURCES = {"cpu": "8", "memory": "4Gi"}
 DEFAULT_IMG_NAME = "3.9-imaging-dev"
-DEFAULT_DAG_NAME = "bioimg-ingestion"
+DEFAULT_DAG_NAME = "bioimg-exportation"
 
 
-def ingest(
+def export(
     source: Union[Sequence[str], str],
     output: str,
     config: Mapping[str, Any],
@@ -25,10 +24,10 @@ def ingest(
     namespace: Optional[str],
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
-    """The function ingests microscopy images into TileDB arrays
+    """The function exports microscopy images from TileDB arrays
 
     :param source: uri / iterable of uris of input files
-    :param output: output dir for the ingested tiledb arrays
+    :param output: output dir for the exported tiledb arrays
     :param config: dict configuration to pass on tiledb.VFS
     :param taskgraph_name: Optional name for taskgraph, defaults to None
     :param num_batches: Number of graph nodes to spawn.
@@ -41,43 +40,25 @@ def ingest(
     :param namespace: The namespace where the DAG will run
     """
 
-    def ingest_tiff_udf(
+    def export_tiff_udf(
         io_uris: Sequence[Tuple],
         config: Mapping[str, Any],
         *args: Any,
         **kwargs,
     ):
-        """Internal udf that ingests server side batch of bioimaging files
-        into tiledb arrays using tiledb-bioimg API
+        """Internal udf that exports server side batch of tiledb arrays
+        2Tiff biomedical images using tiledb-bioimg API
 
         :param io_uris: Pairs of tiff input - output tdb uris
         :param config: dict configuration to pass on tiledb.VFS
         """
 
-        from tiledb import filter
         from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 
-        compressor = kwargs.get("compressor", None)
-        if compressor:
-            compressor_args = dict(compressor)
-            compressor_name = compressor_args.pop("_name")
-            if compressor_name:
-                compressor_args = {
-                    k: None if not v else v for k, v in compressor_args.items()
-                }
-                kwargs["compressor"] = vars(filter).get(compressor_name)(
-                    **compressor_args
-                )
-            else:
-                raise ValueError
-
         conf = tiledb.Config(params=config)
-        vfs = tiledb.VFS(config=conf)
-
         with tiledb.scope_ctx(ctx_or_config=conf):
             for input, output in io_uris:
-                with vfs.open(input) as src:
-                    OMETiffConverter.to_tiledb(src, output, **kwargs)
+                OMETiffConverter.from_tiledb(input, output, **kwargs)
 
     if isinstance(source, str):
         # Handle only lists
@@ -99,14 +80,10 @@ def ingest(
         namespace=namespace,
     )
 
-    # serialize udf arguments
-    compressor = kwargs.pop("compressor", None)
-    compressor_serial = serialize_filter(compressor) if compressor else None
-
     for i, work in enumerate(batch(samples, batch_size)):
         logger.info(f"Adding batch {i}")
         graph.submit(
-            ingest_tiff_udf,
+            export_tiff_udf,
             work,
             config,
             threads,
@@ -115,7 +92,6 @@ def ingest(
             mode=tiledb.cloud.dag.Mode.BATCH,
             resources=DEFAULT_RESOURCES if resources is None else resources,
             image_name=DEFAULT_IMG_NAME,
-            compressor=compressor_serial,
             **kwargs,
         )
 
@@ -124,7 +100,7 @@ def ingest(
     return graph
 
 
-def ingest_udf(*args: Any, **kwargs: Any) -> Dict[str, str]:
-    """Ingestor wrapper function that can be used as a UDF."""
-    grf = ingest(*args, **kwargs)
+def export_udf(*args: Any, **kwargs: Any) -> Dict[str, str]:
+    """Exporter wrapper function that can be used as a UDF."""
+    grf = export(*args, **kwargs)
     return {"status": "started", "graph_id": str(grf.server_graph_uuid)}

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -23,8 +23,13 @@ def get_uris(
             yield uri, create_output_path(uri, output_dir)
 
     if len(source) == 1 and vfs.is_dir(source[0]):
-        # Folder like input
-        return tuple(iter_paths(vfs.ls(source[0])))
+        # Check if the dir is actually a tiledb group for exportation
+        if tiledb.object_type(source[0]) != "group":
+            # Folder like input
+            return tuple(iter_paths(vfs.ls(source[0])))
+        else:
+            # This is the exportation scenario
+            return source[0], create_output_path(source[0], output_dir)
     elif isinstance(source, Sequence):
         # List of input uris - single file is one element list
         return tuple(iter_paths(source))

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -5,7 +5,9 @@ from typing import Any, Iterator, Mapping, Sequence, Tuple
 import tiledb
 
 
-def get_uris(source: Sequence[str], output_dir: str, config: Mapping[str, Any]):
+def get_uris(
+    source: Sequence[str], output_dir: str, config: Mapping[str, Any], output_ext: str
+):
     """Match input uri/s with output destinations
 
     :param source: A sequence of paths or path to input
@@ -14,7 +16,7 @@ def get_uris(source: Sequence[str], output_dir: str, config: Mapping[str, Any]):
     vfs = tiledb.VFS(config=config)
 
     def create_output_path(input_file, output_dir) -> str:
-        return os.path.join(output_dir, os.path.basename(input_file) + ".tdb")
+        return os.path.join(output_dir, os.path.basename(input_file) + f".{output_ext}")
 
     def iter_paths(sequence) -> Iterator[Tuple]:
         for uri in sequence:

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -1,0 +1,64 @@
+import math
+import os
+from typing import Any, Iterator, Mapping, Sequence, Tuple
+
+import tiledb
+
+
+def get_uris(source: Sequence[str], output_dir: str, config: Mapping[str, Any]):
+    """Match input uri/s with output destinations
+
+    :param source: A sequence of paths or path to input
+    :param output_dir: A path to the output directory
+    """
+    vfs = tiledb.VFS(config=config)
+
+    def create_output_path(input_file, output_dir) -> str:
+        return os.path.join(output_dir, os.path.basename(input_file) + ".tdb")
+
+    def iter_paths(sequence) -> Iterator[Tuple]:
+        for uri in sequence:
+            yield uri, create_output_path(uri, output_dir)
+
+    if len(source) == 1 and vfs.is_dir(source[0]):
+        # Folder like input
+        return tuple(iter_paths(vfs.ls(source[0])))
+    elif isinstance(source, Sequence):
+        # List of input uris - single file is one element list
+        return tuple(iter_paths(source))
+
+
+def serialize_filter(filter):
+    if isinstance(filter, tiledb.Filter):
+        filter_dict = filter._attrs_()
+        filter_dict["_name"] = type(filter).__name__
+        return filter_dict
+    else:
+        raise TypeError
+
+
+def batch(iterable, chunks):
+    # Iterator for prividing batches of chunks
+    length = len(iterable)
+    for ndx in range(0, length, chunks):
+        yield iterable[ndx : min(ndx + chunks, length)]
+
+
+def scale_calc(source, num_batches):
+    """Calculate scaling settings for batch_size and max_workers
+
+    :param source: The source iterable containing files to be ingested/exported
+    :param num_batches: The number of batches given by the API
+    :return: Tuple batch_size, max_workers
+    """
+    # If num_batches is default create number of images nodes
+    # constraint node max_workers to 20 fully heuristic
+    if num_batches is None:
+        num_batches = len(source)
+        batch_size = 1
+        max_workers = 20
+    else:
+        batch_size = math.ceil(len(source) / num_batches)
+        max_workers = None
+
+    return batch_size, max_workers

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -24,12 +24,13 @@ def get_uris(
 
     if len(source) == 1 and vfs.is_dir(source[0]):
         # Check if the dir is actually a tiledb group for exportation
-        if tiledb.object_type(source[0]) != "group":
-            # Folder like input
-            return tuple(iter_paths(vfs.ls(source[0])))
-        else:
-            # This is the exportation scenario
-            return source[0], create_output_path(source[0], output_dir)
+        with tiledb.scope_ctx(ctx_or_config=config):
+            if tiledb.object_type(source[0]) != "group":
+                # Folder like input
+                return tuple(iter_paths(vfs.ls(source[0])))
+            else:
+                # This is the exportation scenario
+                return ((source[0], create_output_path(source[0], output_dir)),)
     elif isinstance(source, Sequence):
         # List of input uris - single file is one element list
         return tuple(iter_paths(source))
@@ -45,7 +46,7 @@ def serialize_filter(filter):
 
 
 def batch(iterable, chunks):
-    # Iterator for prividing batches of chunks
+    # Iterator for providing batches of chunks
     length = len(iterable)
     for ndx in range(0, length, chunks):
         yield iterable[ndx : min(ndx + chunks, length)]

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -27,9 +27,13 @@ def get_uris(
         with tiledb.scope_ctx(ctx_or_config=config):
             if tiledb.object_type(source[0]) != "group":
                 # Folder like input
-                return tuple(iter_paths(vfs.ls(source[0])))
+                contents = vfs.ls(source[0])
+                if len(contents) == 1:
+                    return tuple(iter_paths(contents[1:]))
+                else:
+                    raise ValueError("Input bucket should contain images for ingestion")
             else:
-                # This is the exportation scenario
+                # This is the exportation scenario for single tdb image
                 return ((source[0], create_output_path(source[0], output_dir)),)
     elif isinstance(source, Sequence):
         # List of input uris - single file is one element list

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -84,7 +84,7 @@ def ingest(
         source = [source]
 
     # Get the list of all BioImg samples input/out
-    samples = get_uris(source, output, config)
+    samples = get_uris(source, output, config, "tdb")
     batch_size, max_workers = scale_calc(source, num_batches)
 
     # Build the task graph

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -88,7 +88,7 @@ def ingest(
     batch_size, max_workers = scale_calc(source, num_batches)
 
     # Build the task graph
-    dag_name = DEFAULT_DAG_NAME if taskgraph_name is None else taskgraph_name
+    dag_name = taskgraph_name or DEFAULT_DAG_NAME
     task_prefix = f"{dag_name} - Task"
 
     logger.info("Building graph")


### PR DESCRIPTION
This PR:

- Adds a mirror functionality of ingestion API. The exportation uses in DAG's UDF nodes the `from_tiledb` API of `tiledb-bioimg` package to export tiledb arrays back to tiff files. The functionality has been requested by a customer. 
- Minor refactoring - isolating some helper functions

This PR has as dependence the change in tiledb-bioimg https://github.com/TileDB-Inc/TileDB-BioImaging/pull/91 