### PR TITLE
Add typing-extensions to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   # tblib transitively enabled, so this is needed for unpickling.
   "tblib~=1.7",
   "tiledb>=0.15.2",
+  "typing-extensions",
   "urllib3>=1.26",
 ]
 


### PR DESCRIPTION
Without this, I get the following in a [package](https://github.com/TileDB-Inc/TileDB-Vector-Search/blob/main/apis/python/pyproject.toml#L21) which depends on Cloud-Py:

```
>   from typing_extensions import Self
E   ModuleNotFoundError: No module named 'typing_extensions'
```