### PR TITLE
Make 3 attempts to run Python tests before failing the build.

### DIFF
--- a/.github/scripts/retry
+++ b/.github/scripts/retry
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Retries the given command up to N times.
+# Usage:
+#   retry 5 do-some-command param1 param2
+
+ATTEMPTS="$1"
+shift
+
+while (( ATTEMPTS-- )); do
+  if "$@"; then
+    exit 0
+  fi
+done
+
+exit 1

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -103,7 +103,11 @@ jobs:
         # Test pinned dependencies on commit / tag and fresh installs on nightlies
         if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule')
         run: |
-          pytest -s -v --junitxml=junit/test-results.xml --cov=tiledb/cloud/ --cov-report=xml --cov-report=html
+          .github/scripts/retry 3 \
+            pytest -sv \
+            --last-failed \
+            --tb short \
+            --color yes
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 


### PR DESCRIPTION
On the best of days, automated tests that access the network can be flaky and prone to hiccups, and our tests here are no different. For this reason, we want to retry them to avoid the hassle of repeatedly manually retrying the tests waiting for them all to succeed. We use pytest to rerun only failed tests.