### PR TITLE
Hotfix of failing job

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -169,7 +169,7 @@ def get_uris(source: Sequence[str], output_dir: str, config: Mapping[str, Any]):
 
     if len(source) == 1 and vfs.is_dir(source[0]):
         # Folder like input
-        return tuple(iter_paths(vfs.ls(source[0])))
+        return tuple(iter_paths(vfs.ls(source[0])[1:]))
     elif isinstance(source, Sequence):
         # List of input uris - single file is one element list
         return tuple(iter_paths(source))


### PR DESCRIPTION
This PR:

- Fixes an always failing ingestion node. This node was being created by the `get_uri` function and was adding an extra pseudosample in the ingestion DAG. It was a result of `vfs.ls` of a `bucket` , which returns not only the bucket contents but the bucket root itself too.