### PR TITLE
Consolidate VCF stats arrays at the end of ingestion

### DIFF
--- a/src/tiledb/cloud/vcf/__init__.py
+++ b/src/tiledb/cloud/vcf/__init__.py
@@ -1,11 +1,25 @@
 from .allele_frequency import read_allele_frequency
+from .ingestion import Contigs
 from .ingestion import ingest
 from .query import build_read_dag
 from .query import read
+from .utils import bgzip_and_index
+from .utils import create_index_file
+from .utils import find_index
+from .utils import get_record_count
+from .utils import get_sample_name
+from .utils import is_bgzipped
 
 __all__ = [
+    "Contigs",
     "ingest",
     "build_read_dag",
     "read",
     "read_allele_frequency",
+    "bgzip_and_index",
+    "create_index_file",
+    "find_index",
+    "get_sample_name",
+    "get_record_count",
+    "is_bgzipped",
 ]

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -1,10 +1,10 @@
 import enum
-from functools import partial
 import logging
 import subprocess
 import sys
 from collections import defaultdict
 from fnmatch import fnmatch
+from functools import partial
 from math import ceil
 from multiprocessing.pool import ThreadPool
 from os.path import basename
@@ -1274,10 +1274,10 @@ def ingest_samples_dag(
             consolidate_dataset_udf,
             dataset_uri,
             config=config,
-            id=f"vcf-consol-final",
+            id="vcf-consol-final",
             verbose=verbose,
             resources=CONSOLIDATE_RESOURCES,
-            name=f"Consolidate VCF final ",
+            name="Consolidate VCF final ",
             **kwargs,
         )
 


### PR DESCRIPTION
For VCF ingestion, run a consolidation plan on the stats arrays at the end of ingestion to optimize the read query performance.