### PR TITLE
Add require_action in cases where the client picks a namespace for the user

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -603,7 +603,9 @@ class DAG:
         self.nodes: Dict[uuid.UUID, Node] = {}
         self.nodes_by_name: Dict[str, Node] = {}
 
-        self.namespace = namespace or client.default_charged_namespace()
+        self.namespace = namespace or client.default_charged_namespace(
+            required_action=rest_api.NamespaceActions.RUN_JOB
+        )
         self.name = name
         self.server_graph_uuid: Optional[uuid.UUID] = None
         self.max_workers = max_workers
@@ -1749,7 +1751,9 @@ def server_logs(
     if not the_id:
         return None
 
-    namespace = namespace or client.default_charged_namespace()
+    namespace = namespace or client.default_charged_namespace(
+        required_action=rest_api.NamespaceActions.RUN_JOB
+    )
 
     return client.build(rest_api.TaskGraphLogsApi).get_task_graph_log(
         namespace=namespace,

--- a/src/tiledb/cloud/sql/_execution.py
+++ b/src/tiledb/cloud/sql/_execution.py
@@ -76,7 +76,9 @@ def exec_base(
     if output_uri:
         array.split_uri(output_uri)
 
-    namespace = namespace or client.default_charged_namespace()
+    namespace = namespace or client.default_charged_namespace(
+        required_action=rest_api.NamespaceActions.RUN_JOB
+    )
 
     api_instance = client.build(rest_api.SqlApi)
 

--- a/src/tiledb/cloud/taskgraphs/client_executor/impl.py
+++ b/src/tiledb/cloud/taskgraphs/client_executor/impl.py
@@ -130,7 +130,9 @@ class LocalExecutor(_base.IClientExecutor):
 
     @property
     def namespace(self) -> str:
-        return self._namespace or client.default_charged_namespace()
+        return self._namespace or client.default_charged_namespace(
+            required_action=rest_api.NamespaceActions.RUN_JOB
+        )
 
     @namespace.setter
     def namespace(self, new_namespace: Optional[str]) -> None:

--- a/src/tiledb/cloud/udf.py
+++ b/src/tiledb/cloud/udf.py
@@ -81,7 +81,9 @@ def exec_base(
 
     api_instance = client.build(rest_api.UdfApi)
 
-    namespace = namespace or client.default_charged_namespace()
+    namespace = namespace or client.default_charged_namespace(
+        required_action=rest_api.NamespaceActions.RUN_JOB
+    )
 
     user_func: Union[str, Callable]
     if name:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -73,7 +73,9 @@ class DAGClassTest(unittest.TestCase):
             d._build_log_structure(),
             models.TaskGraphLog(
                 name="a cool dag",
-                namespace=client.default_charged_namespace(),
+                namespace=client.default_charged_namespace(
+                    required_action=rest_api.NamespaceActions.RUN_JOB
+                ),
                 nodes=[
                     models.TaskGraphNodeMetadata(
                         client_node_uuid=str(node_1.id),
@@ -146,7 +148,9 @@ class DAGClassTest(unittest.TestCase):
             d._build_log_structure(),
             models.TaskGraphLog(
                 name="a cool server dag",
-                namespace=client.default_charged_namespace(),
+                namespace=client.default_charged_namespace(
+                    required_action=rest_api.NamespaceActions.RUN_JOB
+                ),
                 nodes=[
                     models.TaskGraphNodeMetadata(
                         client_node_uuid=str(node_1.id),
@@ -245,7 +249,9 @@ class DAGClassTest(unittest.TestCase):
         self.assertEqual(
             d._build_log_structure(),
             models.TaskGraphLog(
-                namespace=client.default_charged_namespace(),
+                namespace=client.default_charged_namespace(
+                    required_action=rest_api.NamespaceActions.RUN_JOB
+                ),
                 nodes=[
                     models.TaskGraphNodeMetadata(
                         client_node_uuid=str(node_1.id),

--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -95,7 +95,7 @@ class GenericUDFTest(unittest.TestCase):
             )
 
             namespace = client.find_organization_or_user_for_default_charges(
-                config.user
+                config.user, required_action=rest_api.NamespaceActions.RUN_JOB
             )
 
             response: urllib3.HTTPResponse = client.build(


### PR DESCRIPTION

The intention it to validate that the namespace chosed has this action for example run_job for udfs. If not, it returns a descriptive error message.

Please read the discussion at https://app.shortcut.com/tiledb-inc/story/31330/confusing-error-when-user-has-not-set-default-namespace-to-charge before reviewing.
