### PR TITLE
Re-export group search functions at top level.

### DIFF
--- a/src/tiledb/cloud/__init__.py
+++ b/src/tiledb/cloud/__init__.py
@@ -1,38 +1,41 @@
 # This file imports specifically to re-export.
 
-from tiledb.cloud import compute
-from tiledb.cloud import dag
-from tiledb.cloud import sql
-from tiledb.cloud import udf
-from tiledb.cloud._common import pickle_compat as _pickle_compat
-from tiledb.cloud.array import array_activity
-from tiledb.cloud.array import deregister_array
-from tiledb.cloud.array import info
-from tiledb.cloud.array import list_shared_with
-from tiledb.cloud.array import register_array
-from tiledb.cloud.array import share_array
-from tiledb.cloud.array import unshare_array
-from tiledb.cloud.client import Config
-from tiledb.cloud.client import Ctx
-from tiledb.cloud.client import list_arrays
-from tiledb.cloud.client import list_public_arrays
-from tiledb.cloud.client import list_shared_arrays
-from tiledb.cloud.client import login
-from tiledb.cloud.client import organization
-from tiledb.cloud.client import organizations
-from tiledb.cloud.client import user_profile
-from tiledb.cloud.file import create_file
-from tiledb.cloud.file import export_file
-from tiledb.cloud.notebook import download_notebook_contents
-from tiledb.cloud.notebook import download_notebook_to_file
-from tiledb.cloud.notebook import rename_notebook
-from tiledb.cloud.notebook import upload_notebook_contents
-from tiledb.cloud.notebook import upload_notebook_from_file
-from tiledb.cloud.rest_api import models
-from tiledb.cloud.tasks import last_sql_task
-from tiledb.cloud.tasks import last_udf_task
-from tiledb.cloud.tasks import task
-from tiledb.cloud.tiledb_cloud_error import TileDBCloudError
+from . import compute
+from . import dag
+from . import sql
+from . import udf
+from ._common import pickle_compat as _pickle_compat
+from .array import array_activity
+from .array import deregister_array
+from .array import info
+from .array import list_shared_with
+from .array import register_array
+from .array import share_array
+from .array import unshare_array
+from .client import Config
+from .client import Ctx
+from .client import list_arrays
+from .client import list_groups
+from .client import list_public_arrays
+from .client import list_public_groups
+from .client import list_shared_arrays
+from .client import list_shared_groups
+from .client import login
+from .client import organization
+from .client import organizations
+from .client import user_profile
+from .file import create_file
+from .file import export_file
+from .notebook import download_notebook_contents
+from .notebook import download_notebook_to_file
+from .notebook import rename_notebook
+from .notebook import upload_notebook_contents
+from .notebook import upload_notebook_from_file
+from .rest_api import models
+from .tasks import last_sql_task
+from .tasks import last_udf_task
+from .tasks import task
+from .tiledb_cloud_error import TileDBCloudError
 
 _pickle_compat.patch_cloudpickle()
 _pickle_compat.patch_pandas()
@@ -61,7 +64,10 @@ __all__ = (
     "Ctx",
     "list_arrays",
     "list_public_arrays",
+    "list_public_groups",
     "list_shared_arrays",
+    "list_shared_groups",
+    "list_groups",
     "login",
     "organization",
     "organizations",
@@ -77,5 +83,4 @@ __all__ = (
     "last_udf_task",
     "task",
     "TileDBCloudError",
-    "__version__",
 )


### PR DESCRIPTION
Also rewrites top-level imports to be relative, because there’s no reason to have them be absolute.

[sc-31109]