### PR TITLE
SOMA multi-file ingest

### DIFF
--- a/src/tiledb/cloud/soma.py
+++ b/src/tiledb/cloud/soma.py
@@ -122,7 +122,7 @@ def run_ingest_workflow(
         basename is appended to the ``output_uri`` to form the entry's output URI.
         For example, if ``a.h5ad` and ``b.h5ad`` are present within ``input_uri`` of
         ``s3://bucket/h5ads/`` and ``output_uri`` is
-        `tiledb://namespace/s3://bucket/somas``, then
+        ``tiledb://namespace/s3://bucket/somas``, then
         ``tiledb://namespace/s3://bucket/somas/a`` and
         ``tiledb://namespace/s3://bucket/somas/b`` are written.
     :param measurement_name: The name of the Measurement within the Experiment
@@ -189,7 +189,7 @@ def run_ingest_workflow(
                 entry_output_uri += "/"
             entry_output_uri += base
 
-            if pattern is not None and not bool(re.match(pattern, entry_input_uri)):
+            if pattern is not None and not re.match(pattern, entry_input_uri):
                 continue
 
             node = grf.submit(

--- a/src/tiledb/cloud/soma.py
+++ b/src/tiledb/cloud/soma.py
@@ -81,7 +81,7 @@ def ingest_h5ad(
     if extra_tiledb_config:
         soma_ctx = soma_ctx.replace(tiledb_config=extra_tiledb_config)
     with tiledb.VFS().open(input_uri) as input_file:
-        with _hack_patch_anndata():
+        with _hack_patch_anndata_byval():
             input_data = anndata.read_h5ad(_FSPathWrapper(input_file, input_uri), "r")
         output_uri = io.from_anndata(
             experiment_uri=output_uri,
@@ -199,3 +199,4 @@ def run_ingest_workflow(
 # to refer to `ingest_h5ad` by value rather than by reference.
 _ingest_h5ad_byval = functions.to_register_by_value(ingest_h5ad)
 _run_ingest_workflow = functions.to_register_by_value(run_ingest_workflow)
+_hack_patch_anndata_byval = functions.to_register_by_value(_hack_patch_anndata)

--- a/src/tiledb/cloud/soma.py
+++ b/src/tiledb/cloud/soma.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import re
 from typing import ContextManager, Dict, Optional
 from unittest import mock
 
@@ -80,7 +82,7 @@ def ingest_h5ad(
     soma_ctx = tiledbsoma.SOMATileDBContext()
     if extra_tiledb_config:
         soma_ctx = soma_ctx.replace(tiledb_config=extra_tiledb_config)
-    with tiledb.VFS().open(input_uri) as input_file:
+    with tiledb.VFS(ctx=soma_ctx.tiledb_ctx).open(input_uri) as input_file:
         with _hack_patch_anndata_byval():
             input_data = anndata.read_h5ad(_FSPathWrapper(input_file, input_uri), "r")
         output_uri = io.from_anndata(
@@ -99,6 +101,7 @@ def run_ingest_workflow(
     output_uri: str,
     input_uri: str,
     measurement_name: str,
+    pattern: Optional[str] = None,
     extra_tiledb_config: Optional[Dict[str, object]] = None,
     platform_config: Optional[Dict[str, object]] = None,
     ingest_mode: str = "write",
@@ -111,12 +114,20 @@ def run_ingest_workflow(
     :param output_uri: The output URI to write to. This will probably look like
         ``tiledb://namespace/some://storage/uri``.
     :param input_uri: The URI of the H5AD file(s) to read from. These are read
-        using TileDB VFS, so any path supported (and accessible) will work.  If the ``input_uri``
-        passes ``vfs.is_file``, it's ingested.  If the ``input_uri`` passes ``vfs.is_dir``, then all
-        first-level entries are ingested .  In either case, an input file is skipped if ``pattern``
-        is provided and doesn't match the input file.
+        using TileDB VFS, so any path supported (and accessible) will work.  If the
+        ``input_uri`` passes ``vfs.is_file``, it's ingested.  If the ``input_uri``
+        passes ``vfs.is_dir``, then all first-level entries are ingested .  In the
+        latter, directory case, an input file is skipped if ``pattern`` is provided
+        and doesn't match the input file. As well, in the directory case, each entry's
+        basename is appended to the ``output_uri`` to form the entry's output URI.
+        For example, if ``a.h5ad` and ``b.h5ad`` are present within ``input_uri`` of
+        ``s3://bucket/h5ads/`` and ``output_uri`` is
+        `tiledb://namespace/s3://bucket/somas``, then
+        ``tiledb://namespace/s3://bucket/somas/a`` and
+        ``tiledb://namespace/s3://bucket/somas/b`` are written.
     :param measurement_name: The name of the Measurement within the Experiment
         to store the data.
+    :param pattern: As described for ``input_uri``.
     :param extra_tiledb_config: Extra configuration for TileDB.
     :param platform_config: The SOMA ``platform_config`` value to pass in,
         if any.
@@ -130,13 +141,11 @@ def run_ingest_workflow(
     :return: A dictionary of ``{"status": "started", "graph_id": ...}``,
         with the UUID of the graph on the server side, which can be used to
         manage execution and monitor progress.
-    :param pattern: As described for ``input_uri``.
     """
 
-    vfs = tiledb.VFS()
+    vfs = tiledb.VFS(config=extra_tiledb_config)
 
     if vfs.is_file(input_uri):
-        # XXX pattern-match check
         grf = dag.DAG(
             name="ingest-h5ad-file",
             mode=dag.Mode.BATCH,
@@ -167,17 +176,26 @@ def run_ingest_workflow(
         )
 
         collector = grf.submit(
-            _write_me,
+            lambda output_uri: output_uri,
             output_uri=output_uri,
-            input_uri=input_uri,
         )
 
-        for entry_uri in vfs.ls(input_uri):
-            # XXX pattern-match check
-            node = submitter(
+        for entry_input_uri in vfs.ls(input_uri):
+            base = os.path.basename(entry_input_uri)
+            base, _ = os.path.splitext(base)
+
+            entry_output_uri = output_uri + "/" + base
+            if not output_uri.endswith("/"):
+                entry_output_uri += "/"
+            entry_output_uri += base
+
+            if pattern is not None and not bool(re.match(pattern, entry_input_uri)):
+                continue
+
+            node = grf.submit(
                 _ingest_h5ad_byval,
-                output_uri=output_uri,
-                input_uri=input_uri,
+                output_uri=entry_output_uri,
+                input_uri=entry_input_uri,
                 measurement_name=measurement_name,
                 extra_tiledb_config=extra_tiledb_config,
                 ingest_mode=ingest_mode,
@@ -185,7 +203,7 @@ def run_ingest_workflow(
                 resources=_DEFAULT_RESOURCES if resources is None else resources,
                 access_credentials_name=access_credentials_name,
             )
-            parent.depends_on(node)
+            collector.depends_on(node)
 
         grf.compute()
         return {
@@ -195,8 +213,12 @@ def run_ingest_workflow(
 
     raise ValueError(f"input_uri {input_uri!r} is neither file nor directory")
 
-# Until we fully get this version of tiledb.cloud deployed server-side, we want
-# to refer to `ingest_h5ad` by value rather than by reference.
+
+# Until we fully get this version of tiledb.cloud deployed server-side, we must
+# refer to all functions by value rather than by reference -- which is a fancy way
+# of saying these functions _will not work at all_ until and unless they are
+# checked into tiledb-cloud-py and deployed server-side. _All_ dev work _must_
+# use this idiom.
 _ingest_h5ad_byval = functions.to_register_by_value(ingest_h5ad)
 _run_ingest_workflow = functions.to_register_by_value(run_ingest_workflow)
 _hack_patch_anndata_byval = functions.to_register_by_value(_hack_patch_anndata)

--- a/src/tiledb/cloud/soma.py
+++ b/src/tiledb/cloud/soma.py
@@ -94,11 +94,6 @@ def ingest_h5ad(
     logging.info("Successfully wrote data from %r to %r", input_uri, output_uri)
 
 
-# Until we fully get this version of tiledb.cloud deployed server-side, we want
-# to refer to `ingest_h5ad` by value rather than by reference.
-_ingest_h5ad_byval = functions.to_register_by_value(ingest_h5ad)
-
-
 def run_ingest_workflow(
     *,
     output_uri: str,
@@ -137,6 +132,8 @@ def run_ingest_workflow(
         manage execution and monitor progress.
     :param pattern: As described for ``input_uri``.
     """
+
+    vfs = tiledb.VFS()
 
     if vfs.is_file(input_uri):
         # XXX pattern-match check
@@ -177,7 +174,7 @@ def run_ingest_workflow(
 
         for entry_uri in vfs.ls(input_uri):
             # XXX pattern-match check
-            node = grf.submit(
+            node = submitter(
                 _ingest_h5ad_byval,
                 output_uri=output_uri,
                 input_uri=input_uri,
@@ -197,3 +194,8 @@ def run_ingest_workflow(
         }
 
     raise ValueError(f"input_uri {input_uri!r} is neither file nor directory")
+
+# Until we fully get this version of tiledb.cloud deployed server-side, we want
+# to refer to `ingest_h5ad` by value rather than by reference.
+_ingest_h5ad_byval = functions.to_register_by_value(ingest_h5ad)
+_run_ingest_workflow = functions.to_register_by_value(run_ingest_workflow)

--- a/src/tiledb/cloud/soma.py
+++ b/src/tiledb/cloud/soma.py
@@ -98,6 +98,35 @@ def ingest_h5ad(
 # to refer to `ingest_h5ad` by value rather than by reference.
 _ingest_h5ad_byval = functions.to_register_by_value(ingest_h5ad)
 
+def ingest_multiple(
+    *,
+    output_uri: str,
+    input_uri: str,
+    measurement_name: str,
+    extra_tiledb_config: Optional[Dict[str, object]],
+    platform_config: Optional[Dict[str, object]],
+    ingest_mode: str,
+    pattern: Optional[str] = None,
+) -> None:
+    """Performs the actual work of ingesting H5AD data into TileDB.
+
+    :param output_uri: The output URI to write to. This will probably look like
+        ``tiledb://namespace/some://storage/uri``.
+    :param input_uri: The URI of the H5AD file(s) to read from. These are read
+        using TileDB VFS, so any path supported (and accessible) will work.  If the ``input_uri``
+        passes ``vfs.is_file``, it's ingested.  If the ``input_uri`` passes ``vfs.is_dir``, then all
+        first-level entries are ingested .  In either case, an input file is skipped if ``pattern``
+        is provided and doesn't match the input file.
+    :param measurement_name: The name of the Measurement within the Experiment
+        to store the data.
+    :param extra_tiledb_config: Extra configuration for TileDB.
+    :param platform_config: The SOMA ``platform_config`` value to pass in,
+        if any.
+    :param ingest_mode: One of the ingest modes supported by
+        ``tiledbsoma.io.read_h5ad``.
+    :param pattern: As described for ``input_uri``.
+    """
+
 
 def run_ingest_workflow(
     *,
@@ -155,3 +184,42 @@ def run_ingest_workflow(
         "status": "started",
         "graph_id": str(grf.server_graph_uuid),
     }
+
+# BIOIMG
+# def ingest(
+#     XXX source: Union[Sequence[str], str],
+#     output: str,
+#     *args: Any,
+#     threads: Optional[int] = 8,
+#     resources: Optional[Mapping[str, Any]] = None,
+#     compute: bool = True,
+#     namespace: Optional[str],
+#     **kwargs,
+# ) -> tiledb.cloud.dag.DAG:
+#     """The function ingests microscopy images into TileDB arrays
+#     :param source: uri / iterable of uris of input files
+#     :param output: output dir for the ingested tiledb arrays
+#     :param config: dict configuration to pass on tiledb.VFS
+#     :param taskgraph_name: Optional name for taskgraph, defaults to None
+#     :param num_batches: Number of graph nodes to spawn.
+#         Performs it sequentially if default, defaults to 1
+#     :param threads: Number of threads for node side multiprocessing, defaults to 8
+#     :param resources: configuration for node specs e.g. {"cpu": "8", "memory": "4Gi"},
+#         defaults to None
+#     :param compute: When True the DAG returned will be computed inside the function
+#     otherwise DAG will only be returned.
+#     :param namespace: The namespace where the DAG will run
+#     """
+
+# VCF
+#def ingest(
+#    dataset_uri: str,
+#    *,
+#    XXX search_uri: Optional[str] = None,
+#    XXX pattern: Optional[str] = None,
+#    XXX resume: bool = True,
+#    XXX verbose: bool = False,
+#    XXX trace_id: Optional[str] = None,
+#    XXX batch_mode: bool = True,
+#    XXX compute: bool = True,
+#) -> Tuple[Optional[dag.DAG], Sequence[str]]:


### PR DESCRIPTION
Unit-test-scenario conversations are welcome and encouraged.

Current sandbox driver:

```
#!/usr/bin/env python

import tiledb.cloud
import tiledb.cloud.soma
import sys
import os

measurement_name = "RNA"
namespace        = "TileDB-Inc"

if len(sys.argv) != 3:
    print("Usage: %s {output_uri} {input_uri}" % (sys.argv[0]))
    sys.exit(1)
output_uri = sys.argv[1]
input_uri  = sys.argv[2]

extra_tiledb_config = {
    'vfs.s3.aws_access_key_id': os.getenv('AWS_ACCESS_KEY_ID'),
    'vfs.s3.aws_secret_access_key': os.getenv('AWS_SECRET_ACCESS_KEY'),
    'vfs.s3.region': os.getenv('AWS_DEFAULT_REGION'),
}

dikt = tiledb.cloud.soma._run_ingest_workflow(
    output_uri=output_uri,
    input_uri=input_uri,
    measurement_name=measurement_name,
    namespace=namespace,
    access_credentials_name="tiledb-cloud-sandbox-role",
    extra_tiledb_config=extra_tiledb_config,
)

print(dikt)
```

which I've driven with single inputs like

```
$ aws s3 ls $s3k/s/a/pbmc-small.h5ad
2022-09-18 23:29:16     235392 pbmc-small.h5ad

$ aws s3 ls $s3k/s/a/stack-small/
2023-06-26 11:13:13      20200 stack1.h5ad
2023-06-26 11:13:13      20200 stack2.h5ad
2023-06-26 11:13:13      20200 stack3.h5ad
2023-06-26 11:13:13      20200 stack4.h5ad
```

through to

* https://cloud.tiledb.com/activity/taskgraphs/TileDB-Inc/9bbeab49-1e3a-47e1-8ca7-937859364893
* https://cloud.tiledb.com/activity/taskgraphs/TileDB-Inc/04285b7a-a806-48b7-825c-8ced0f052817

<img width="653" alt="Screenshot 2023-07-24 at 7 18 50 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-Py/assets/2008794/8b824986-c5da-43dd-9ac4-2cd4bfa0a0b9">
