### PR TITLE
Expose `groups` when importing `tiledb.cloud`

### DIFF
--- a/src/tiledb/cloud/__init__.py
+++ b/src/tiledb/cloud/__init__.py
@@ -2,6 +2,7 @@
 
 from . import compute
 from . import dag
+from . import groups
 from . import sql
 from . import udf
 from ._common import pickle_compat as _pickle_compat
@@ -51,6 +52,7 @@ UDFResultType = ResultFormat
 __all__ = (
     "compute",
     "dag",
+    "groups",
     "sql",
     "udf",
     "array_activity",


### PR DESCRIPTION
This PR exposes the `groups` submodule when importing `tiledb.cloud`
Before:
```python
>>> import tiledb.cloud
>>> 'groups' in dir(tiledb.cloud)
False
>>> import tiledb.cloud.groups
>>> 'groups' in dir(tiledb.cloud)
True
```
After:
```python
>>> import tiledb.cloud
>>> 'groups' in dir(tiledb.cloud)
True
```
This makes it easier (IMO) to find functionality for working with TileDB Cloud groups programmatically