### PR TITLE
Support single file tiledb uris for exportation

### DIFF
--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -85,7 +85,7 @@ def export(
             work,
             config,
             *args,
-            name=f"{task_prefix} - {i}/{num_batches}",
+            name=f"{task_prefix} - {i}",
             mode=tiledb.cloud.dag.Mode.BATCH,
             resources=DEFAULT_RESOURCES if resources is None else resources,
             image_name=DEFAULT_IMG_NAME,

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -111,7 +111,7 @@ def ingest(
             config,
             threads,
             *args,
-            name=f"{task_prefix} - {i}/{num_batches}",
+            name=f"{task_prefix} - {i}",
             mode=tiledb.cloud.dag.Mode.BATCH,
             resources=DEFAULT_RESOURCES if resources is None else resources,
             image_name=DEFAULT_IMG_NAME,


### PR DESCRIPTION
This PR:

- allows a single bioimg group (multi-resolution image) to be exported by giving as an argument the tiledb uri.
- Since touching these files fixes also a bug in the taskgraph UI for when the number of batches is by default None