### PR TITLE
Add VCF create and register functions

### DIFF
--- a/src/tiledb/cloud/vcf/__init__.py
+++ b/src/tiledb/cloud/vcf/__init__.py
@@ -2,6 +2,7 @@ from .allele_frequency import read_allele_frequency
 from .ingestion import Contigs
 from .ingestion import create_dataset_udf as create_dataset
 from .ingestion import ingest
+from .ingestion import register_dataset_udf as register_dataset
 from .query import build_read_dag
 from .query import read
 from .utils import bgzip_and_index
@@ -15,6 +16,7 @@ __all__ = [
     "Contigs",
     "create_dataset",
     "ingest",
+    "register_dataset",
     "build_read_dag",
     "read",
     "read_allele_frequency",

--- a/src/tiledb/cloud/vcf/__init__.py
+++ b/src/tiledb/cloud/vcf/__init__.py
@@ -1,5 +1,6 @@
 from .allele_frequency import read_allele_frequency
 from .ingestion import Contigs
+from .ingestion import create_dataset_udf as create_dataset
 from .ingestion import ingest
 from .query import build_read_dag
 from .query import read
@@ -12,6 +13,7 @@ from .utils import is_bgzipped
 
 __all__ = [
     "Contigs",
+    "create_dataset",
     "ingest",
     "build_read_dag",
     "read",


### PR DESCRIPTION
Add a function to register the dataset on TileDB-Cloud, if it has not been registered already. The dataset will be automatically registered during ingestion if the `register_name` argument is passed to `vcf.ingest`.

```python
import tiledb.cloud.vcf as vcf

# Manually register the dataset
vcf.register_dataset(...)

# Automatically register during ingestion
vcf.ingest(..., register_name="foo", ...)
```

Expose the function to create the VCF dataset, manifest, and log arrays, for users who want to create the dataset before ingesting samples.

```python
import tiledb.cloud.vcf as vcf

vcf.create_dataset(...)
```