### PR TITLE
Ensure that server-side task failures are not double-reported.

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1049,10 +1049,12 @@ class DAG:
                 # If the parent failed, put this back onto the "unstarted" pile.
                 self.not_started_nodes[node.id] = node
                 to_report = None
-            else:
-                assert node.status is Status.FAILED
+            elif node.status is Status.FAILED:
                 self.failed_nodes[node.id] = node
-                to_report = models.ArrayTaskStatus.FAILED
+                if node.mode == Mode.LOCAL:
+                    to_report = models.ArrayTaskStatus.FAILED
+            else:
+                raise AssertionError(f"Unknown node status {node.status}")
 
             if self.mode != Mode.BATCH:
                 for child in node.children.values():


### PR DESCRIPTION
We were mistakenly reporting all failures of tasks to the server, even those that already failed on the server.

[sc-33689]