### PR TITLE
Dynamic distributed fragment consolidation

### DIFF
--- a/src/tiledb/cloud/utilities/__init__.py
+++ b/src/tiledb/cloud/utilities/__init__.py
@@ -5,6 +5,9 @@ from ._common import read_aws_config
 from ._common import read_file
 from ._common import run_dag
 from ._common import set_aws_context
+from .consolidate import consolidate_fragments
+from .consolidate import convac
+from .consolidate import group_fragments
 from .profiler import Profiler
 from .profiler import create_log_array
 from .profiler import write_log_event
@@ -17,6 +20,9 @@ __all__ = [
     "read_file",
     "run_dag",
     "set_aws_context",
+    "consolidate_fragments",
+    "convac",
+    "group_fragments",
     "Profiler",
     "create_log_array",
     "write_log_event",

--- a/src/tiledb/cloud/utilities/__init__.py
+++ b/src/tiledb/cloud/utilities/__init__.py
@@ -5,8 +5,8 @@ from ._common import read_aws_config
 from ._common import read_file
 from ._common import run_dag
 from ._common import set_aws_context
-from .consolidate import consolidate_fragments
 from .consolidate import consolidate_and_vacuum
+from .consolidate import consolidate_fragments
 from .consolidate import group_fragments
 from .profiler import Profiler
 from .profiler import create_log_array

--- a/src/tiledb/cloud/utilities/__init__.py
+++ b/src/tiledb/cloud/utilities/__init__.py
@@ -6,7 +6,7 @@ from ._common import read_file
 from ._common import run_dag
 from ._common import set_aws_context
 from .consolidate import consolidate_fragments
-from .consolidate import convac
+from .consolidate import consolidate_and_vacuum
 from .consolidate import group_fragments
 from .profiler import Profiler
 from .profiler import create_log_array
@@ -21,7 +21,7 @@ __all__ = [
     "run_dag",
     "set_aws_context",
     "consolidate_fragments",
-    "convac",
+    "consolidate_and_vacuum",
     "group_fragments",
     "Profiler",
     "create_log_array",

--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -1,0 +1,241 @@
+from collections import defaultdict
+from os.path import basename
+from typing import Any, Mapping, Optional, Sequence
+
+import tiledb
+from tiledb.cloud import dag
+from tiledb.cloud.rest_api.models import RetryStrategy
+from tiledb.cloud.utilities import get_logger
+from tiledb.cloud.utilities import max_memory_usage
+from tiledb.cloud.utilities import run_dag
+
+MAX_FRAGMENT_SIZE = 1 << 30  # bytes
+
+
+def group_fragments(
+    array_uri: str,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    group_first_dim: bool = True,
+) -> Sequence[Sequence[tiledb.FragmentInfo]]:
+    """
+    Get a list of fragment info objects, optionally grouping fragments that have the
+    same value for the first dimension.
+
+    :param array_uri: array URI
+    :param config: config dictionary, defaults to None
+    :param group_first_dim: group by first dimension, defaults to True
+    :return: list of lists of fragment info objects
+    """
+
+    logger = get_logger()
+    logger.info("Grouping fragments for array %r", array_uri)
+
+    with tiledb.scope_ctx(config):
+        fragment_info_lists = defaultdict(list)
+
+        fis = tiledb.FragmentInfoList(array_uri)
+
+        for fi in fis:
+            if group_first_dim:
+                fragment_info_lists[fi.nonempty_domain[0]].append(fi)
+            else:
+                fragment_info_lists["all"].append(fi)
+
+        # Create a list of lists of fragment info objects.
+        results = [x for x in list(fragment_info_lists.values())]
+
+        logger.info(f"{len(fis)} fragments grouped into {len(results)} groups")
+        logger.info(f"max memory usage: {max_memory_usage() / (1 << 30):.3f} GiB")
+
+        return results
+
+
+def consolidate(
+    array_uri: str,
+    fragments: Sequence[tiledb.FragmentInfo],
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+):
+    """
+    Consolidate fragments
+
+    :param array_uri: array URI
+    :param fragments: list of fragments
+    :param config: config dictionary, defaults to None
+    """
+
+    logger = get_logger()
+    logger.info(f"Consolidating {len(fragments)} fragments")
+
+    config = tiledb.Config(config)
+    config["sm.consolidation.mode"] = "fragments"
+    config["sm.consolidation.max_fragment_size"] = MAX_FRAGMENT_SIZE
+
+    # Consolidate fragments.
+    fragment_names = [basename(fi.uri) for fi in fragments]
+    with tiledb.open(array_uri, "w", config=config) as array:
+        array.consolidate(fragment_uris=fragment_names)
+
+    logger.info(f"max memory usage: {max_memory_usage() / (1 << 30):.3f} GiB")
+
+
+def convac(
+    array_uri: str,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    vacuum_fragments: bool = False,
+):
+    """
+    Consolidate and vacuum commits and fragment metadata, with an option to
+    vacuum fragments as the first step.
+
+    :param array_uri: array URI
+    :param config: config dictionary, defaults to None
+    :param vacuum_fragments: vacuum fragments first, defaults to False
+    """
+
+    logger = get_logger()
+
+    with tiledb.scope_ctx(config):
+        if vacuum_fragments:
+            try:
+                logger.info("Vacuuming fragments")
+                tiledb.vacuum(
+                    array_uri,
+                    config=tiledb.Config({"sm.vacuum.mode": "fragments"}),
+                )
+            except:
+                raise
+
+        # Modes for consolidate and vacuum
+        modes = ["commits", "fragment_meta"]
+
+        for mode in modes:
+            try:
+                logger.info(f"Consolidating {mode}")
+                tiledb.consolidate(
+                    array_uri,
+                    config=tiledb.Config({"sm.consolidation.mode": mode}),
+                )
+            except:
+                raise
+
+        for mode in modes:
+            try:
+                logger.info(f"Vacuuming {mode}")
+                tiledb.vacuum(
+                    array_uri,
+                    config=tiledb.Config({"sm.vacuum.mode": mode}),
+                )
+            except:
+                raise
+
+    logger.info(f"max memory usage: {max_memory_usage() / (1 << 30):.3f} GiB")
+
+
+def consolidate_fragments(
+    array_uri: str,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    group_first_dim: bool = False,
+    graph: Optional[dag.DAG] = None,
+    dependencies: Optional[Sequence[dag.Node]] = None,
+    consolidate_resources: Optional[Mapping[str, str]] = None,
+    namespace: Optional[str] = None,
+) -> None:
+    """
+    Consolidate fragments in an array.
+
+    If `group_first_dim` is True, fragments with the same value for the first dimension
+    will be consolidated together. Otherwise, all fragments will be consolidated
+    together.
+
+    If `graph` is provided, the consolidation task nodes will be submitted to the graph.
+    If `dependencies` is provided, the consolidation nodes will depend on the nodes in
+    the list.
+
+    If `graph` is not provided, a new graph will be created and submitted to TileDB
+    Cloud.
+
+    :param array_uri: array URI
+    :param config: config dictionary, defaults to None
+    :param group_first_dim: group fragment by first dimension, defaults to True
+    :param graph: graph to submit nodes to, defaults to None
+    :param dependencies: list of nodes in the graph to depend on, defaults to None
+    :param consolidate_resources: resources for the consolidate node, defaults to None
+    :param namespace: TileDB Cloud namespace, defaults to the user's default namespace
+    """
+
+    if graph is None and dependencies is not None:
+        raise ValueError("Graph must be provided if dependencies are provided")
+
+    graph_provided = graph is not None
+
+    # If a graph is not provided, create a new graph and run it at the end of this
+    # function.
+    if not graph_provided:
+        graph = dag.DAG(
+            name="distributed-consolidation-plan",
+            namespace=namespace,
+            mode=dag.Mode.BATCH,
+            max_workers=100,
+            retry_strategy=RetryStrategy(
+                limit=3,
+                retry_policy="Always",
+            ),
+        )
+    elif graph.mode != dag.Mode.BATCH:
+        raise ValueError("Graph mode must be BATCH")
+
+    # Set resources for the consolidate node, if not provided.
+    consolidate_resources = consolidate_resources or {
+        "cpu": "4",
+        "memory": "16Gi",
+    }
+
+    name = basename(array_uri)
+
+    fragment_groups = graph.submit(
+        group_fragments,
+        array_uri,
+        config=config,
+        group_first_dim=group_first_dim,
+        name=f"Groups Fragments - {name}",
+        resources={
+            "cpu": "1",
+            "memory": "1Gi",
+        },
+    )
+
+    if dependencies:
+        for node in dependencies:
+            fragment_groups.depends_on(node)
+
+    consolidate_node = graph.submit_udf_stage(
+        consolidate,
+        array_uri,
+        fragment_groups,
+        config=config,
+        expand_node_output=fragment_groups,
+        name=f"Consolidate Fragments - {name}",
+        resources=consolidate_resources,
+    )
+
+    vacuum_node = graph.submit(
+        convac,
+        array_uri,
+        config=config,
+        vacuum_fragments=True,
+        name=f"Consolidate and Vacuum - {name}",
+        resources=consolidate_resources,
+    )
+
+    vacuum_node.depends_on(consolidate_node)
+
+    if not graph_provided:
+        run_dag(graph, wait=False)
+        print(
+            "Consolidate fragments submitted - ",
+            f"https://cloud.tiledb.com/activity/taskgraphs/{graph.namespace}/{graph.server_graph_uuid}",
+        )

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -14,7 +14,8 @@ import tiledb
 from tiledb.cloud import dag
 from tiledb.cloud.rest_api.models import RetryStrategy
 from tiledb.cloud.utilities import Profiler
-from tiledb.cloud.utilities import consolidate_fragments
+
+# from tiledb.cloud.utilities import consolidate_fragments
 from tiledb.cloud.utilities import create_log_array
 from tiledb.cloud.utilities import get_logger
 from tiledb.cloud.utilities import read_file
@@ -25,6 +26,17 @@ from tiledb.cloud.vcf.utils import create_index_file
 from tiledb.cloud.vcf.utils import find_index
 from tiledb.cloud.vcf.utils import get_record_count
 from tiledb.cloud.vcf.utils import get_sample_name
+
+if True:
+    # Bring code into scope for testing on TileDB Cloud
+    import importlib, os
+
+    path = os.path.dirname(importlib.import_module("tiledb.cloud").__file__)
+    files = [f"{path}/utilities/consolidate.py"]
+    for file in files:
+        with open(file) as f:
+            exec(compile(f.read(), file, "exec"))
+
 
 # Testing hooks
 local_ingest = False

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -1241,7 +1241,7 @@ def ingest_samples_dag(
                 consolidate_fragments(
                     array_uri,
                     config=config,
-                    group_first_dim=True,
+                    group_by_first_dim=True,
                     graph=graph,
                     dependencies=[consolidate],
                 )

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -14,8 +14,7 @@ import tiledb
 from tiledb.cloud import dag
 from tiledb.cloud.rest_api.models import RetryStrategy
 from tiledb.cloud.utilities import Profiler
-
-# from tiledb.cloud.utilities import consolidate_fragments
+from tiledb.cloud.utilities import consolidate_fragments
 from tiledb.cloud.utilities import create_log_array
 from tiledb.cloud.utilities import get_logger
 from tiledb.cloud.utilities import read_file
@@ -26,17 +25,6 @@ from tiledb.cloud.vcf.utils import create_index_file
 from tiledb.cloud.vcf.utils import find_index
 from tiledb.cloud.vcf.utils import get_record_count
 from tiledb.cloud.vcf.utils import get_sample_name
-
-if True:
-    # Bring code into scope for testing on TileDB Cloud
-    import importlib, os
-
-    path = os.path.dirname(importlib.import_module("tiledb.cloud").__file__)
-    files = [f"{path}/utilities/consolidate.py"]
-    for file in files:
-        with open(file) as f:
-            exec(compile(f.read(), file, "exec"))
-
 
 # Testing hooks
 local_ingest = False


### PR DESCRIPTION
Add a distributed fragment consolidation function, which scales fragment consolidation to run on multiple TileDB Cloud nodes.

The fragment consolidation function is run on the VCF stats arrays (`variant_stats` and `allele_count`) at the end of VCF ingestion to improve read query performance of these arrays.