### PR TITLE
Add `raw_json` TDBUDF sentinel.

### DIFF
--- a/src/tiledb/cloud/_results/tiledb_json.py
+++ b/src/tiledb/cloud/_results/tiledb_json.py
@@ -79,8 +79,20 @@ class Decoder(visitor.ReplacingVisitor):
             return visitor.Replacement(
                 {k: self.visit(v) for (k, v) in inner_value.items()}
             )
+        if kind == "raw_json":
+            # `raw_json` is a special sentinel indicating that the value in
+            # the `raw_json` field is pure JSON with no TileDB values inside it.
+            # This means we can avoid descending into it. For example:
+            #
+            #   {"__tdbudf__": "raw_json", "raw_json": [some huge matrix]}
+            #
+            # Initially we only use it to write parameters and not results.
+            return visitor.Replacement(value["raw_json"])
         if kind == "immediate":
             # "immediate" values are values of the format
+            #   {fmt: format name, base64_data: data_string}
+            # where the format name is one of the codecs in codecs.py
+            # and the base64_data is the encoded data.
             fmt = value["format"]
             base64d = value["base64_data"]
             return visitor.Replacement(

--- a/tests/taskgraphs/test_codec.py
+++ b/tests/taskgraphs/test_codec.py
@@ -115,6 +115,34 @@ class EscapingTest(unittest.TestCase):
                 actual = esc.visit(native_value)
                 self.assertEqual(json_data, actual)
 
+    def test_raw_json(self):
+        """Verifies that visiting ``raw_json`` nodes short-circuits."""
+        basic_case = {
+            "__tdbudf__": "raw_json",
+            "raw_json": {
+                "__tdbudf__": "who-cares",
+                "dont-visit-me": "hello",
+            },
+        }
+
+        me = self
+
+        class DontVisitVerifier(tiledb_json.Decoder):
+            def visit(self, value: object):
+                if isinstance(value, dict):
+                    me.assertNotIn("dont-visit-me", value)
+                return super().visit(value)
+
+        dec = DontVisitVerifier()
+        actual = dec.visit(basic_case)
+        self.assertEqual(
+            {
+                "__tdbudf__": "who-cares",
+                "dont-visit-me": "hello",
+            },
+            actual,
+        )
+
 
 class BinaryResultTest(unittest.TestCase):
     def test_binary_result_of(self):


### PR DESCRIPTION
When users pass in deep, nested JSON structures, we want to avoid descending into them for encoding/decoding any more than strictly necessary. By adding `raw_json` to the set of sentinel flags, we can say "this is a raw JSON value; you don't need to examine it any more."

This change adds the decoding side. A future change will enable using it in argument encoding (its primary use case).