### PR TITLE
Fix check for `resources` on client-side task graphs.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -188,6 +188,15 @@ class DAGClassTest(unittest.TestCase):
         self.assertIsInstance(result, results.RemoteResult)
         return result  # type: ignore
 
+    def test_resource_checks(self):
+        grf = dag.DAG()
+        with self.assertRaises(tce.TileDBCloudError):
+            grf.submit(repr, None, resources={"x": "y"})
+        with self.assertRaises(tce.TileDBCloudError):
+            grf.submit_local(repr, None, resources={"x": "y"})
+        with self.assertRaises(tce.TileDBCloudError):
+            grf.submit_local(repr, None, resource_class="hello")
+
     def test_kwargs(self):
         d = dag.DAG()
 


### PR DESCRIPTION
Because of the way parameters were handled within the `dag.Node` class, on a client-side task graph (i.e., with `Mode.REALTIME`), we would never check to ensure that the unsupported `resources` parameter was not set. This change adds that check, as well as checks to locally-executing nodes (where resources cannot be specified at all).

[sc-35354]