### PR TITLE
Local ingestion and use of run_dag

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -23,6 +23,7 @@ def ingest(
     threads: Optional[int] = 8,
     resources: Optional[Mapping[str, Any]] = None,
     compute: bool = True,
+    local: bool = False,
     namespace: Optional[str],
     verbose: bool = False,
     exclude_metadata: bool = False,
@@ -150,6 +151,8 @@ def ingest(
                         verbose=verbose,
                         **kwargs,
                     )
+
+    submit = graph.submit_local if local else graph.submit
 
     if isinstance(source, str):
         # Handle only lists

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -163,7 +163,7 @@ def ingest(
     logger.debug("Building graph")
     graph = dag.DAG(
         name=dag_name,
-        mode=dag.Mode.BATCH,
+        mode=dag.Mode.REALTIME if local else dag.Mode.BATCH,
         max_workers=max_workers,
         namespace=namespace,
         retry_strategy=RetryStrategy(

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -152,8 +152,6 @@ def ingest(
                         **kwargs,
                     )
 
-    submit = graph.submit_local if local else graph.submit
-
     if isinstance(source, str):
         # Handle only lists
         source = [source]
@@ -186,6 +184,7 @@ def ingest(
         name=f"{dag_name} input collector",
         result_format="json",
     )
+    submit = graph.submit_local if local else graph.submit
 
     # serialize udf arguments
     compressor = kwargs.pop("compressor", None)
@@ -206,7 +205,6 @@ def ingest(
         compressor=compressor_serial,
         **kwargs,
     )
-
     if compute:
         run_dag(graph, debug=verbose)
     return graph


### PR DESCRIPTION
This PR:

- introduces a boolean flag `local= False` for ingesting a bioimg in local mode.
- substitutes the `graph.compute` function with it's wrapper `run_dag` from the `utilities._common` package