### PR TITLE
Pass parameters as `tiledb_json`.

### DIFF
--- a/src/tiledb/cloud/_results/stored_params.py
+++ b/src/tiledb/cloud/_results/stored_params.py
@@ -5,7 +5,7 @@ import dataclasses
 import uuid
 from typing import Any, Dict, Generic, TypeVar
 
-from tiledb.cloud._results import decoders
+from . import decoders
 
 _T = TypeVar("_T")
 

--- a/src/tiledb/cloud/_results/types.py
+++ b/src/tiledb/cloud/_results/types.py
@@ -1,4 +1,7 @@
-from typing import List, NewType, Tuple, TypeVar, Union
+import itertools
+from typing import Callable, Dict, List, NewType, Tuple, TypeVar, Union
+
+import attrs
 
 _T = TypeVar("_T")
 NativeSequence = Union[Tuple[_T, ...], List[_T]]
@@ -16,3 +19,40 @@ TileDBJSONValue = NewType("TileDBJSONValue", object)
 For instance, this will not include stored parameter references, or node output
 values.
 """
+
+
+@attrs.define(frozen=True, slots=True)
+class Arguments:
+    """The arguments and keyword arguments that can be sent to a function.
+
+    You usually shouldn't call the constructor directly; instead use
+    :meth:``of``.
+    """
+
+    args: Tuple[object, ...] = attrs.field(converter=tuple, default=())
+    kwargs: Dict[str, object] = attrs.Factory(dict)
+
+    @classmethod
+    def of(cls, *args: object, **kwargs: object) -> "Arguments":
+        """Creates an Arguments object representing the given call.
+
+        Calling this with any parameters will give you an ``Arguments``
+        representing that call:
+
+        >>> Arguments.of(1, 2, a=1, b="two", **{"c": b"four"})
+        args(1, 2, a=1, b="two", c=b"four")
+
+        """
+        return cls(args, kwargs)
+
+    def apply(self, to: Callable[..., _T]) -> _T:
+        return to(*self.args, **self.kwargs)
+
+    def __repr__(self):
+        """A representation of this which looks like a function call."""
+        parts = itertools.chain(
+            map(repr, self.args),
+            (f"{k}={v!r}" for (k, v) in self.kwargs.items()),
+        )
+        joined = ", ".join(parts)
+        return f"args({joined})"

--- a/src/tiledb/cloud/taskgraphs/builder.py
+++ b/src/tiledb/cloud/taskgraphs/builder.py
@@ -558,7 +558,7 @@ class _UDFNode(Node[_T]):
         if isinstance(func, str) and local:
             raise ValueError("Registered UDFs may only be executed server-side.")
         jsoner = _ParameterEscaper()
-        self.args = jsoner.arguments_to_json(args)
+        self.args = jsoner.encode_arguments(args)
         if local and any(isinstance(node, _ArrayNode) for node in jsoner.seen_nodes):
             raise ValueError(
                 "UDFs that take array data as input must be run server-side."
@@ -632,14 +632,6 @@ class _ParameterEscaper(tiledb_json.Encoder):
             self.seen_nodes.add(arg)
             return visitor.Replacement(arg._tdb_to_json())
         return super().maybe_replace(arg)
-
-    def arguments_to_json(self, arg: types.Arguments) -> types.RegisteredArg:
-        arg_outputs = [{"value": self.visit(val)} for val in arg.args]
-        kwarg_outputs = [
-            {"name": name, "value": self.visit(value)}
-            for (name, value) in arg.kwargs.items()
-        ]
-        return arg_outputs + kwarg_outputs
 
 
 def _set_add(s: Set[_T], elem: _T) -> _T:

--- a/src/tiledb/cloud/taskgraphs/types.py
+++ b/src/tiledb/cloud/taskgraphs/types.py
@@ -1,17 +1,15 @@
 """User-facing types used in task graphs."""
 
 import enum
-import itertools
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Optional, Union
 
-import attrs
 import numpy as np
 
 from .._results import types
 
-_T = TypeVar("_T")
-
-# Re-exports.
+# Re-exports of things that were previously in this module.
+Arguments = types.Arguments
+args = Arguments.of
 NativeSequence = types.NativeSequence
 NativeValue = types.NativeValue
 TileDBJSONValue = types.TileDBJSONValue
@@ -74,42 +72,4 @@ class Layout(enum.Enum):
 
 LayoutOrStr = Union[Layout, str]
 
-
-@attrs.define(frozen=True, slots=True)
-class Arguments:
-    """The arguments and keyword arguments that can be sent to a function.
-
-    You usually shouldn't call the constructor directly; instead use
-    :meth:``of``.
-    """
-
-    args: Tuple[object, ...] = attrs.field(converter=tuple, default=())
-    kwargs: Dict[str, object] = attrs.Factory(dict)
-
-    @classmethod
-    def of(cls, *args: object, **kwargs: object) -> "Arguments":
-        """Creates an Arguments object representing the given call.
-
-        Calling this with any parameters will give you an ``Arguments``
-        representing that call:
-
-        >>> Arguments.of(1, 2, a=1, b="two", **{"c": b"four"})
-        args(1, 2, a=1, b="two", c=b"four")
-
-        """
-        return cls(args, kwargs)
-
-    def apply(self, to: Callable[..., _T]) -> _T:
-        return to(*self.args, **self.kwargs)
-
-    def __repr__(self):
-        """A representation of this which looks like a function call."""
-        parts = itertools.chain(
-            map(repr, self.args),
-            (f"{k}={v!r}" for (k, v) in self.kwargs.items()),
-        )
-        joined = ", ".join(parts)
-        return f"args({joined})"
-
-
-args = Arguments.of
+# Re-export Arguments type.

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -33,6 +33,7 @@ class GroupsTest(unittest.TestCase):
         inner_name = testonly.random_name("inner")
         groups.create(inner_name, parent_uri=outer_uri)
         self.assert_group_exists(inner_name)
+        time.sleep(3)  # Hack: this test keeps failing
         groups.deregister(outer_uri, recursive=True)
         self.assert_group_not_exists(outer_name)
         self.assert_group_not_exists(inner_name)


### PR DESCRIPTION
This enables passing all parameters to UDFs, even those executed via the `udf.exec` APIs, to use the TileDB JSON arguments format. This specifically will enable the new Pandas-as-Arrow codec for parameters.

We also enable using the `raw_json` sentinel type, which means that inside the UDF runtime environment, we will not need to dig deep into deeply nested JSON objects if they do not contain special encoded data.

---

This is the first half of finalizing [sc-34367]. The second half will be to enable using this format for *returning* serialized data (incl. dataframes) but I want to do that separately. (Everything should already be *ready* for that, but I want to make sure everything will work as expected without blocking this side of the work.)