### PR TITLE
Update default VCF ingestion batch size to 100

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -39,10 +39,10 @@ DEFAULT_ATTRIBUTES = ["fmt_GT"]
 # Default values for ingestion parameters
 MANIFEST_BATCH_SIZE = 200
 MANIFEST_WORKERS = 40
-VCF_BATCH_SIZE = 10
+VCF_BATCH_SIZE = 100
 VCF_WORKERS = 40
 VCF_THREADS = 8
-VCF_HEADER_MB = 50  # memory per sample per thread
+VCF_HEADER_MB = 32  # memory per sample per thread
 
 # Consolidation task resources
 CONSOLIDATE_RESOURCES = {


### PR DESCRIPTION
Update the default VCF ingestion batch size to 100 and reduce the VCF header memory usage estimate based on example ingestion profiles.

These numbers are used to estimate the amount of memory needed per UDF node. The actual memory usage will be data dependent. 

UDF node memory resources can be set with the `ingest_resources` arg of `tiledb.cloud.vcf.ingest` to optimize the memory resources for dataset with known memory requirements. 

For example:
```python
ingest_resources = {
    "cpu": "8",
    "memory": "32Gi",
}
```