### PR TITLE
Disable VCF stats consolidation

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -1298,7 +1298,7 @@ def ingest(
     batch_mode: bool = True,
     access_credentials_name: Optional[str] = None,
     compute: bool = True,
-    consolidate_stats: bool = True,
+    consolidate_stats: bool = False,
     aws_find_mode: bool = False,
 ) -> Tuple[Optional[dag.DAG], Sequence[str]]:
     """


### PR DESCRIPTION
This PR disables VCF stats consolidation by default to avoid an access credentials issue, which is being addressed separately. 