### PR TITLE
Add xarray as test dependency, partial for sc-37280

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install TileDB-Cloud-Py
         run: |
-          pip install .
+          pip install .[tests]
 
       - name: Run tests
         # Test pinned dependencies on commit / tag and fresh installs on nightlies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ viz-plotly = ["networkx>=2", "plotly>=4", "pydot"]
 all = ["networkx>=2", "plotly>=4", "pydot", "tiledb-plot-widget>=0.1.7"]
 
 dev = ["black", "pytest", "ruff"]
+tests = ["xarray"]
 
 [project.urls]
 homepage = "https://tiledb.com"


### PR DESCRIPTION
Seeing this in [the tests](https://github.com/TileDB-Inc/TileDB-Cloud-Py/actions/workflows/tiledb-cloud-py.yaml)
```
    raise ImportError(msg)
E   ImportError: Missing optional dependency 'xarray'.  Use pip or conda to install xarray.
```