### PR TITLE
Expose alternate graph return value on ingest

### DIFF
--- a/src/tiledb/cloud/soma/__init__.py
+++ b/src/tiledb/cloud/soma/__init__.py
@@ -1,4 +1,4 @@
-from .ingest import get_ingest_workflow_graph
+from .ingest import build_ingest_workflow_graph
 from .ingest import run_ingest_workflow
 
-__all__ = ["get_ingest_workflow_graph", "run_ingest_workflow"]
+__all__ = ["build_ingest_workflow_graph", "run_ingest_workflow"]

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -59,7 +59,7 @@ def run_ingest_workflow(
         manage execution and monitor progress.
     """
 
-    grf = get_ingest_workflow_graph(
+    grf = build_ingest_workflow_graph(
         output_uri=output_uri,
         input_uri=input_uri,
         measurement_name=measurement_name,
@@ -78,7 +78,7 @@ def run_ingest_workflow(
     }
 
 
-def get_ingest_workflow_graph(
+def build_ingest_workflow_graph(
     *,
     output_uri: str,
     input_uri: str,


### PR DESCRIPTION
This maintains compatibility with the one-click API. Additionally, it allows the caller to get the graph object itself so they can do `grf.compute()` and `grf.wait()` on it, and then directly obtain resultst from the computation.

The alternative is `dag.server_logs` and `tasks.fetch_result`, which are cumbersome at best for users who have synchronous needs.

This pattern will be user in the collection-mapper logic, which _absolutely must_ provide a usable synchronous entrypoint.