### PR TITLE
Refactoring and moving io part in UDF lister

### DIFF
--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -29,7 +29,7 @@ def build_io_uris_exportation(source: Sequence[str], output_dir: str, output_ext
             if vfs.is_dir(uri) and tiledb.object_type(uri) != "group":
                 # Folder for exploration
                 contents = vfs.ls(uri)
-                yield from tuple(iter_paths(contents))
+                yield from tuple(iter_paths(contents)[1:])
             elif tiledb.object_type(uri) == "group":
                 # For exportation we require the source path to be a tiledb group
                 yield uri, create_output_path(uri, output_dir)

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -55,8 +55,8 @@ def build_input_batches(
 def export(
     source: Union[Sequence[str], str],
     output: str,
-    config: Mapping[str, Any],
     *args: Any,
+    config: Optional[Mapping[str, Any]] = None,
     taskgraph_name: Optional[str] = None,
     num_batches: Optional[int] = None,
     resources: Optional[Mapping[str, Any]] = None,
@@ -102,9 +102,12 @@ def export(
         """
         from tiledb.bioimg import Converters
         from tiledb.bioimg import to_bioimg
+        from tiledb.ctx import default_ctx
 
-        src_cfg = tiledb.VFS().config
-        dest_cfg = tiledb.Config(params=config)
+        # if writer config not given assume same as source
+        src_cfg = default_ctx().config()
+        dest_cfg = src_cfg if not config else config
+
         for input, output in io_uris:
             to_bioimg(
                 input,
@@ -123,7 +126,7 @@ def export(
     # Build the task graph
     dag_name = taskgraph_name or DEFAULT_DAG_NAME
 
-    logger.info("Building graph")
+    logger.debug("Building graph")
     graph = dag.DAG(
         name=dag_name,
         mode=dag.Mode.REALTIME if local else dag.Mode.BATCH,

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -1,7 +1,4 @@
 import logging
-import math
-import os
-from typing import Any, Iterator, Mapping, Sequence, Tuple
 
 import tiledb
 from tiledb.cloud.utilities import get_logger
@@ -30,52 +27,6 @@ def get_logger_wrapper(
     return logger
 
 
-_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".tdb")
-
-
-def get_uris(
-    source: Sequence[str], output_dir: str, config: Mapping[str, Any], output_ext: str
-):
-    """Match input uri/s with output destinations
-
-    :param source: A sequence of paths or path to input
-    :param output_dir: A path to the output directory
-    """
-    vfs = tiledb.VFS(config=config)
-
-    def create_output_path(input_file, output_dir) -> str:
-        filename = os.path.splitext(os.path.basename(input_file))[0]
-        return os.path.join(output_dir, filename + f".{output_ext}")
-
-    def iter_paths(sequence) -> Iterator[Tuple]:
-        for uri in sequence:
-            if uri.endswith(_SUPPORTED_EXTENSIONS):
-                yield uri, create_output_path(uri, output_dir)
-
-    if len(source) == 1:
-        if source[0].startswith("tiledb://"):
-            # Support tiledb uri single image
-            return ((source[0], create_output_path(source[0], output_dir)),)
-        elif vfs.is_dir(source[0]):
-            # Check if the dir is actually a tiledb group for exportation on VFS
-            with tiledb.scope_ctx(ctx_or_config=config):
-                if tiledb.object_type(source[0]) != "group":
-                    # Folder like input
-                    contents = vfs.ls(source[0])
-                    if len(contents) != 0:
-                        return tuple(iter_paths(contents))
-                    else:
-                        raise ValueError(
-                            "Input bucket should contain images for ingestion"
-                        )
-                else:
-                    # This is the exportation scenario for single tdb image
-                    return ((source[0], create_output_path(source[0], output_dir)),)
-    elif isinstance(source, Sequence):
-        # List of input uris - single file is one element list
-        return tuple(iter_paths(source))
-
-
 def serialize_filter(filter):
     if isinstance(filter, tiledb.Filter):
         filter_dict = filter._attrs_()
@@ -83,24 +34,3 @@ def serialize_filter(filter):
         return filter_dict
     else:
         raise TypeError
-
-
-def batch(iterable, chunks):
-    # Iterator for providing batches of chunks
-    length = len(iterable)
-    for ndx in range(0, length, chunks):
-        yield iterable[ndx : min(ndx + chunks, length)]
-
-
-def scale_calc(samples, num_batches):
-    """Calculate scaling settings for batch_size and max_workers
-
-    :param source: The source iterable containing files to be ingested/exported
-    :param num_batches: The number of batches given by the API
-    :return: Tuple batch_size, max_workers
-    """
-    # If num_batches is default create number of images nodes
-    # constraint node max_workers to 20 fully heuristic
-    batch_size = 1 if num_batches is None else math.ceil(len(samples) / num_batches)
-    max_workers = 20 if num_batches is None else None
-    return batch_size, max_workers

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -87,6 +87,7 @@ def ingest(
     otherwise DAG will only be returned.
     :param namespace: The namespace where the DAG will run
     :param verbose: verbose logging, defaults to False
+    :output_ext: extension for the output images in tiledb
     """
 
     logger = get_logger_wrapper(verbose)

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Tuple, Unio
 import tiledb
 import tiledb.bioimg
 from tiledb.cloud import dag
-from tiledb.cloud.rest_api.models import RetryStrategy
 from tiledb.cloud.bioimg.helpers import get_logger_wrapper
 from tiledb.cloud.bioimg.helpers import serialize_filter
+from tiledb.cloud.rest_api.models import RetryStrategy
 from tiledb.cloud.utilities._common import run_dag
 
 DEFAULT_RESOURCES = {"cpu": "8", "memory": "4Gi"}
@@ -31,9 +31,9 @@ def build_io_uris_ingestion(source: Sequence[str], output_dir: str, output_ext: 
     def iter_paths(source: Sequence[str]) -> Iterator[Tuple]:
         for uri in source:
             if vfs.is_dir(uri):
-                # Folder for exploration 
-                contents = vfs.ls(uri)  
-                # excluding root folder  - ls returns it    
+                # Folder for exploration
+                contents = vfs.ls(uri)
+                # excluding root folder  - ls returns it
                 yield from tuple(iter_paths(contents[1:]))
             elif uri.endswith(_SUPPORTED_EXTENSIONS):
                 yield uri, create_output_path(uri, output_dir)
@@ -154,6 +154,10 @@ def ingest(
         mode=dag.Mode.BATCH,
         max_workers=max_workers,
         namespace=namespace,
+        retry_strategy=RetryStrategy(
+            limit=3,
+            retry_policy="Always",
+        ),
     )
 
     # The lister doesn't need many resources.

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -1,16 +1,56 @@
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
+import os
+from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import tiledb
-from tiledb.cloud.bioimg.helpers import batch
+from tiledb.cloud import dag
 from tiledb.cloud.bioimg.helpers import get_logger_wrapper
-from tiledb.cloud.bioimg.helpers import get_uris
-from tiledb.cloud.bioimg.helpers import scale_calc
 from tiledb.cloud.bioimg.helpers import serialize_filter
 from tiledb.cloud.utilities._common import run_dag
 
 DEFAULT_RESOURCES = {"cpu": "8", "memory": "4Gi"}
 DEFAULT_IMG_NAME = "3.9-imaging-dev"
 DEFAULT_DAG_NAME = "bioimg-ingestion"
+_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs")
+
+
+def build_io_uris_ingestion(source: Sequence[str], output_dir: str, output_ext: str):
+    """Match input uri/s with output destinations
+
+    :param source: A sequence of paths or path to input
+    :param output_dir: A path to the output directory
+    """
+    vfs = tiledb.VFS()
+
+    def create_output_path(input_file, output_dir) -> str:
+        filename = os.path.splitext(os.path.basename(input_file))[0]
+        output_filename = filename + f".{output_ext}" if output_ext else filename
+        return os.path.join(output_dir, output_filename)
+
+    def iter_paths(source: Sequence[str]) -> Iterator[Tuple]:
+        for uri in source:
+            if vfs.is_dir(uri):
+                # Folder for exploration
+                contents = vfs.ls(uri)
+                yield from tuple(iter_paths(contents))
+            elif uri.endswith(_SUPPORTED_EXTENSIONS):
+                yield uri, create_output_path(uri, output_dir)
+
+    if len(source) == 0:
+        raise ValueError("The source files cannot be empty")
+    return tuple(iter_paths(source))
+
+
+def build_input_batches(
+    source: Sequence[str], output: str, num_batches: int, out_ext: str
+):
+    """Groups input URIs into batches."""
+    uri_pairs = build_io_uris_ingestion(source, output, out_ext)
+    # If the user didn't specify a number of batches, run every import
+    # as its own task.
+    my_num_batches = num_batches or len(uri_pairs)
+    # If they specified too many batches, don't create empty tasks.
+    my_num_batches = min(len(uri_pairs), my_num_batches)
+    return [uri_pairs[n::my_num_batches] for n in range(my_num_batches)]
 
 
 def ingest(
@@ -26,6 +66,7 @@ def ingest(
     namespace: Optional[str],
     verbose: bool = False,
     exclude_metadata: bool = False,
+    output_ext: str = "",
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
     """The function ingests microscopy images into TileDB arrays
@@ -46,6 +87,7 @@ def ingest(
     """
 
     logger = get_logger_wrapper(verbose)
+    max_workers = None if num_batches else 20  # Default picked heuristically.
 
     def ingest_tiff_udf(
         io_uris: Sequence[Tuple],
@@ -80,67 +122,70 @@ def ingest(
             else:
                 raise ValueError
 
-        conf = tiledb.Config(params=config)
-        vfs = tiledb.VFS(config=conf)
+        write_context = tiledb.Ctx(config)
+        vfs = tiledb.VFS()
 
-        with tiledb.scope_ctx(ctx_or_config=conf):
-            for input, output in io_uris:
-                with vfs.open(input) as src:
+        for input, output in io_uris:
+            with vfs.open(input) as src:
+                with tiledb.scope_ctx(ctx_or_config=write_context):
                     from_bioimg(
                         src,
                         output,
                         converter=Converters.OMETIFF,
                         exclude_metadata=exclude_metadata,
+                        verbose=verbose,
                         **kwargs,
                     )
 
     if isinstance(source, str):
         # Handle only lists
         source = [source]
-
     logger.info("Ingesting files: %s", source)
-
-    # Get the list of all BioImg samples input/out
-    samples = get_uris(source, output, config, "tdb")
-    logger.debug("Input-Output pairs: %s", samples)
-
-    batch_size, max_workers = scale_calc(samples, num_batches)
-    logger.debug("Batch Size: %d and Workers: %d", batch_size, max_workers)
 
     # Build the task graph
     dag_name = taskgraph_name or DEFAULT_DAG_NAME
-    task_prefix = f"{dag_name} - Task"
 
     logger.info("Building graph")
-    graph = tiledb.cloud.dag.DAG(
+    graph = dag.DAG(
         name=dag_name,
-        mode=tiledb.cloud.dag.Mode.BATCH,
+        mode=dag.Mode.BATCH,
         max_workers=max_workers,
         namespace=namespace,
     )
+
+    # The lister doesn't need many resources.
+    input_list_node = graph.submit(
+        build_input_batches,
+        source,
+        output,
+        num_batches,
+        output_ext,
+        access_credentials_name=kwargs.get("access_credentials_name"),
+        name=f"{dag_name} input collector",
+        result_format="json",
+    )
+
+    logger.debug("Batched Input-Output pairs: %s", input_list_node)
 
     # serialize udf arguments
     compressor = kwargs.pop("compressor", None)
     logger.debug("Compressor: %r", compressor)
     compressor_serial = serialize_filter(compressor) if compressor else None
 
-    for i, work in enumerate(batch(samples, batch_size)):
-        logger.info("Adding batch %d with pairs %s", i, work[0])
-        graph.submit(
-            ingest_tiff_udf,
-            work,
-            config,
-            verbose,
-            exclude_metadata,
-            threads,
-            *args,
-            name=f"{task_prefix} - {i}",
-            mode=tiledb.cloud.dag.Mode.BATCH,
-            resources=DEFAULT_RESOURCES if resources is None else resources,
-            image_name=DEFAULT_IMG_NAME,
-            compressor=compressor_serial,
-            **kwargs,
-        )
+    graph.submit(
+        ingest_tiff_udf,
+        input_list_node,
+        config,
+        verbose,
+        threads,
+        *args,
+        name=f"{dag_name} ingestor",
+        expand_node_output=input_list_node,
+        resources=DEFAULT_RESOURCES if resources is None else resources,
+        image_name=DEFAULT_IMG_NAME,
+        compressor=compressor_serial,
+        **kwargs,
+    )
 
     if compute:
         run_dag(graph, debug=verbose)

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -2,7 +2,6 @@ import os
 from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import tiledb
-import tiledb.bioimg
 from tiledb.cloud import dag
 from tiledb.cloud.bioimg.helpers import get_logger_wrapper
 from tiledb.cloud.bioimg.helpers import serialize_filter

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -1,10 +1,9 @@
-import math
 import unittest
 from unittest import mock
 
-from tiledb.cloud.bioimg.helpers import batch
-from tiledb.cloud.bioimg.helpers import get_uris
-from tiledb.cloud.bioimg.helpers import scale_calc
+import tiledb
+from tiledb.cloud.bioimg.exportation import build_io_uris_exportation
+from tiledb.cloud.bioimg.ingestion import build_io_uris_ingestion
 from tiledb.vfs import VFS
 
 
@@ -13,7 +12,7 @@ class BioimgTest(unittest.TestCase):
         self.out_path = "out"
         return super().setUp()
 
-    def test_get_uris_ingestion(self):
+    def test_build_io_uris_ingestion(self):
         ingest_uri_sample = {
             "test1": ["test1.tiff", "test2.tiff", "test3.tiff"],
             "test2": [],
@@ -23,32 +22,33 @@ class BioimgTest(unittest.TestCase):
         # Case 1-1 Ingestion - Ingest mode has tdb as target suffix
         out_suffix = "tdb"
         test1 = ingest_uri_sample["test1"]
-        with mock.patch.object(VFS, "ls", return_value=test1):
-            out_suffix = "tdb"
-            result_1 = get_uris(test1, self.out_path, None, out_suffix)
-            expected_1 = (
-                ("test1.tiff", "out/test1.tdb"),
-                ("test2.tiff", "out/test2.tdb"),
-                ("test3.tiff", "out/test3.tdb"),
-            )
-            self.assertTupleEqual(result_1, expected_1)
+        with mock.patch.object(VFS, "is_dir", return_value=False):
+            with mock.patch.object(VFS, "ls", return_value=test1):
+                result_1 = build_io_uris_ingestion(test1, self.out_path, out_suffix)
+                expected_1 = (
+                    ("test1.tiff", "out/test1.tdb"),
+                    ("test2.tiff", "out/test2.tdb"),
+                    ("test3.tiff", "out/test3.tdb"),
+                )
+                self.assertTupleEqual(result_1, expected_1)
 
-        # Case 1-2 Ingestion - Empty input list
-        with mock.patch.object(VFS, "ls", return_value=ingest_uri_sample["test2"]):
-            # Empty input list raises error
-            self.assertRaises(
-                get_uris(ingest_uri_sample["test2"], self.out_path, None, out_suffix)
-            )
+            # Case 1-2 Ingestion - Empty input list
+            with mock.patch.object(VFS, "ls", return_value=ingest_uri_sample["test2"]):
+                # Empty input list raises error
+                with self.assertRaises(ValueError):
+                    build_io_uris_ingestion(
+                        ingest_uri_sample["test2"], self.out_path, out_suffix
+                    )
 
-        # Case 1-3 Ingestion - Files with different suffices
-        test3 = ingest_uri_sample["test3"]
-        with mock.patch.object(VFS, "ls", return_value=test3):
-            result_3 = get_uris(test3, self.out_path, None, out_suffix)
-            expected_3 = (
-                ("test1.tiff", "out/test1.tdb"),
-                ("test2.tiff", "out/test2.tdb"),
-            )
-            self.assertTupleEqual(result_3, expected_3)
+            # Case 1-3 Ingestion - Files with different suffices
+            test3 = ingest_uri_sample["test3"]
+            with mock.patch.object(VFS, "ls", return_value=test3):
+                result_3 = build_io_uris_ingestion(test3, self.out_path, out_suffix)
+                expected_3 = (
+                    ("test1.tiff", "out/test1.tdb"),
+                    ("test2.tiff", "out/test2.tdb"),
+                )
+                self.assertTupleEqual(result_3, expected_3)
 
     def test_get_uris_exportation(self):
         export_uri_sample = {
@@ -60,70 +60,19 @@ class BioimgTest(unittest.TestCase):
         # Case 2-1 Exportation normal mode has tiff as target suffix
         out_suffix = "tiff"
         test1 = export_uri_sample["test1"]
-        with mock.patch.object(VFS, "ls", return_value=test1):
-            result = get_uris(test1, self.out_path, None, out_suffix)
-            expected = (
-                ("test1.tdb", "out/test1.tiff"),
-                ("test2.tdb", "out/test2.tiff"),
-                ("test3.tdb", "out/test3.tiff"),
-            )
-            self.assertTupleEqual(result, expected)
+        with mock.patch.object(tiledb, "object_type", return_value="group"):
+            with mock.patch.object(VFS, "ls", return_value=test1):
+                result = build_io_uris_exportation(test1, self.out_path, out_suffix)
+                expected = (
+                    ("test1.tdb", "out/test1.tiff"),
+                    ("test2.tdb", "out/test2.tiff"),
+                    ("test3.tdb", "out/test3.tiff"),
+                )
+                self.assertTupleEqual(result, expected)
 
-        # Case 2-2 Exportation empty list
-        test2 = export_uri_sample["test2"]
-        with mock.patch.object(VFS, "ls", return_value=test2):
-            # Empty input list raises error
-            self.assertRaises(get_uris(test2, self.out_path, None, out_suffix))
-
-        # Case 2-3 Exportation  Files with different suffices
-        test3 = export_uri_sample["test3"]
-        with mock.patch.object(VFS, "ls", return_value=test3):
-            result_3 = get_uris(test3, self.out_path, None, out_suffix)
-            expected_3 = (
-                ("test1.tdb", "out/test1.tiff"),
-                ("test2.tdb", "out/test2.tiff"),
-            )
-            self.assertTupleEqual(result_3, expected_3)
-
-    def test_batch(self):
-        samples = (
-            ("test1.tiff", "out/test1.tdb"),
-            ("test2.tiff", "out/test2.tdb"),
-            ("test3.tiff", "out/test3.tdb"),
-        )
-
-        # Three nodes with 1 job are expected
-        batch_size = 1
-        result = batch(samples, batch_size)
-        expected = 3
-        self.assertEqual(len(tuple(result)), expected)
-
-        # Two nodes with 2,1 jobs are expected
-        batch_size = 2
-        result = batch(samples, batch_size)
-        expected = 2
-        self.assertEqual(len(tuple(result)), expected)
-
-        # One node with all jobs is expected
-        batch_size = 3
-        result = batch(samples, batch_size)
-        expected = 1
-        self.assertEqual(len(tuple(result)), expected)
-
-    def test_scale_calc(self):
-        samples = (
-            ("test1.tiff", "out/test1.tdb"),
-            ("test2.tiff", "out/test2.tdb"),
-            ("test3.tiff", "out/test3.tdb"),
-        )
-
-        result = scale_calc(samples, None)
-        self.assertEqual(result, (1, 20))
-
-        expected = math.ceil(len(samples) / 2)
-        result = scale_calc(samples, 2)
-        self.assertEqual(result, (expected, None))
-
-        expected = math.ceil(len(samples) / 3)
-        result = scale_calc(samples, 3)
-        self.assertEqual(result, (expected, None))
+            # Case 2-2 Exportation empty list
+            test2 = export_uri_sample["test2"]
+            with mock.patch.object(VFS, "ls", return_value=test2):
+                # Empty input list raises error
+                with self.assertRaises(ValueError):
+                    build_io_uris_exportation(test2, self.out_path, out_suffix)


### PR DESCRIPTION
This PR:

- Moves the i/o related tasks in the server-side task graph of the code following #412
- Refactors the `get_uri` function to a more resilient, readable and maintainable form
- The newly introduced `iter_paths` allows recursive exploration and generalises the way we look up files to be ingested under the given source.
- Removes unused tests
- Deprecates/Removes some helper functions
- Introduces some API arguments to the Exportation API to sync it with the Ingestion one
