### PR TITLE
Raise an exception in `_default_ns_path_cred` if no storage provider is set up

### DIFF
--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -162,7 +162,8 @@ def _default_ns_path_cred(namespace: Optional[str] = None) -> Tuple[str, str, st
     if storage:
         path = storage.path
         cred_name = storage.credentials_name
-
+    if not path and not principal.default_s3_path:
+        raise ValueError(f"No storage provider configured.")
     path = path or (principal.default_s3_path + "/groups")
     cred_name = cred_name or principal.default_s3_path_credentials_name
     return namespace, path, cred_name

--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -163,7 +163,7 @@ def _default_ns_path_cred(namespace: Optional[str] = None) -> Tuple[str, str, st
         path = storage.path
         cred_name = storage.credentials_name
     if not path and not principal.default_s3_path:
-        raise ValueError(f"No storage provider configured.")
+        raise ValueError("No storage provider configured.")
     path = path or (principal.default_s3_path + "/groups")
     cred_name = cred_name or principal.default_s3_path_credentials_name
     return namespace, path, cred_name


### PR DESCRIPTION
### What
When running [apis/python/test/test_cloud.py](https://github.com/TileDB-Inc/TileDB-Vector-Search/blob/main/apis/python/test/test_cloud.py#L21) in TileDB-Vector-Search I got:
```
______________________________________________ ERROR at setup of CloudTests.test_cloud_flat _______________________________________________

cls = <class 'test_cloud.CloudTests'>

    @classmethod
    def setUpClass(cls):
        if not os.getenv("TILEDB_REST_TOKEN"):
            raise ValueError("TILEDB_REST_TOKEN not set")
        tiledb.cloud.login(token=os.getenv("TILEDB_REST_TOKEN"))
>       namespace, storage_path, _ = groups._default_ns_path_cred()

test/test_cloud.py:23: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

namespace = 'paris-morgan'

    def _default_ns_path_cred(namespace: Optional[str] = None) -> Tuple[str, str, str]:
        principal: Union[rest_api.User, rest_api.Organization]
        if namespace:
            try:
                principal = client.build(rest_api.UserApi).get_user_with_username(namespace)
            except rest_api.ApiException:
                try:
                    principal = client.build(rest_api.OrganizationApi).get_organization(
                        namespace
                    )
                except rest_api.ApiException:
                    raise ValueError(f"Could not find namespace {namespace!r}.")
        else:
            principal = client.default_user()
            namespace = principal.username
            assert namespace
    
        locs: Optional[rest_api.AssetLocations] = principal.asset_locations
        # Weird structure to silence mypy complaints.
        storage: Optional[rest_api.StorageLocation] = locs.groups if locs else None
    
        path: Optional[str] = None
        cred_name: Optional[str] = None
        if storage:
            path = storage.path
            cred_name = storage.credentials_name
    
>       path = path or (principal.default_s3_path + "/groups")
E       TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
This was because I am using my new TileDB account and I haven't set up any storage provider yet, as you can see here:
```
storage None
principal.default_s3_path None
```

<img width="700" alt="Screenshot 2023-12-12 at 3 14 33 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-Py/assets/1396242/d93c993a-174c-44a0-9af1-ae5e9de70c9f">

<img width="700" alt="Screenshot 2023-12-12 at 3 14 41 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-Py/assets/1396242/b2cbd830-8238-4aa0-9c65-5b8c131ef835">

It seems that we can raise an exception if the user hasn't set up any storage provider yet, so we do that here. With this change the code now leads to this:
```
test/test_cloud.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

namespace = 'paris-morgan'

    def _default_ns_path_cred(namespace: Optional[str] = None) -> Tuple[str, str, str]:
        principal: Union[rest_api.User, rest_api.Organization]
        if namespace:
            try:
                principal = client.build(rest_api.UserApi).get_user_with_username(namespace)
            except rest_api.ApiException:
                try:
                    principal = client.build(rest_api.OrganizationApi).get_organization(
                        namespace
                    )
                except rest_api.ApiException:
                    raise ValueError(f"Could not find namespace {namespace!r}.")
        else:
            principal = client.default_user()
            namespace = principal.username
            assert namespace
        print('principal', principal)
        print('namespace', namespace)
        locs: Optional[rest_api.AssetLocations] = principal.asset_locations
        # Weird structure to silence mypy complaints.
        storage: Optional[rest_api.StorageLocation] = locs.groups if locs else None
    
        path: Optional[str] = None
        cred_name: Optional[str] = None
        if storage:
            path = storage.path
            cred_name = storage.credentials_name
        print('storage', storage)
        print('principal.default_s3_path', principal.default_s3_path)
        if not path and not principal.default_s3_path:
>           raise ValueError(f"No storage provider configured.")
E           ValueError: No storage provider configured.

/opt/homebrew/anaconda3/envs/TileDB-Vector-Search/lib/python3.9/site-packages/tiledb/cloud/groups.py:169: ValueError
```

### Testing
* I ran pytest on this repo and it looks okay:
```
(TileDB-Cloud-Py) ~/repo/TileDB-Cloud-Py pytest                                                                                                                                                                  error-with-no-storage 
========================================================================================================= test session starts ==========================================================================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Cloud-Py
configfile: pytest.ini
collected 209 items                                                                                                                                                                                                                    

tests/test_basic.py s....s...ss......s..                                                                                                                                                                                         [  9%]
tests/test_bioimg.py ....                                                                                                                                                                                                        [ 11%]
tests/test_dag.py ................................................                                                                                                                                                               [ 34%]
tests/test_delayed.py ..................                                                                                                                                                                                         [ 43%]
tests/test_file.py .                                                                                                                                                                                                             [ 43%]
tests/test_generic_udf.py .......                                                                                                                                                                                                [ 46%]
tests/test_groups.py .                                                                                                                                                                                                           [ 47%]
tests/test_sql.py .....                                                                                                                                                                                                          [ 49%]
tests/test_threaded_import.py .                                                                                                                                                                                                  [ 50%]
tests/common/test_functions.py ........                                                                                                                                                                                          [ 54%]
tests/common/test_ordered.py ...                                                                                                                                                                                                 [ 55%]
tests/common/test_pickle_compat.py ssssss...                                                                                                                                                                                     [ 59%]
tests/common/test_trampoline.py ...                                                                                                                                                                                              [ 61%]
tests/common/test_utils.py ..                                                                                                                                                                                                    [ 62%]
tests/db_connector/test_connector.py ......                                                                                                                                                                                      [ 65%]
tests/taskgraphs/test_builder.py .........                                                                                                                                                                                       [ 69%]
tests/taskgraphs/test_client_executor.py ...................                                                                        [ 78%]
tests/taskgraphs/test_codec.py ...........                                                                                          [ 83%]
tests/taskgraphs/test_depgraph.py .....                                                                                             [ 86%]
tests/taskgraphs/test_registration.py ..                                                                                            [ 87%]
tests/taskgraphs/test_replacers.py ........                                                                                         [ 90%]
tests/taskgraphs/test_retries.py ...                                                                                                [ 92%]
tests/taskgraphs/test_taskgraphs.py .                                                                                               [ 92%]
tests/taskgraphs/test_types.py .                                                                                                    [ 93%]
tests/taskgraphs/delayed/test_build.py ...                                                                                          [ 94%]
tests/taskgraphs/delayed/test_delayed_funcs.py ...........                                                                          [100%]

============================================================ warnings summary =============================================================
tests/test_basic.py: 10 warnings
tests/test_dag.py: 155 warnings
tests/test_delayed.py: 70 warnings
tests/test_file.py: 1 warning
tests/test_generic_udf.py: 5 warnings
tests/test_groups.py: 13 warnings
tests/test_sql.py: 3 warnings
tests/taskgraphs/test_client_executor.py: 39 warnings
tests/taskgraphs/test_codec.py: 1 warning
tests/taskgraphs/test_registration.py: 6 warnings
tests/taskgraphs/test_retries.py: 13 warnings
tests/taskgraphs/test_taskgraphs.py: 4 warnings
tests/taskgraphs/delayed/test_delayed_funcs.py: 34 warnings
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/rest_api/rest.py:47: DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).
    return self.urllib3_response.getheader(name, default)

tests/test_basic.py: 2 warnings
tests/test_dag.py: 3 warnings
tests/test_generic_udf.py: 1 warning
tests/taskgraphs/test_client_executor.py: 3 warnings
tests/taskgraphs/test_registration.py: 1 warning
tests/taskgraphs/test_retries.py: 2 warnings
tests/taskgraphs/delayed/test_delayed_funcs.py: 5 warnings
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/rest_api/exceptions.py:89: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
    self.headers = http_resp.getheaders()

tests/test_basic.py: 15 warnings
tests/test_dag.py: 33 warnings
tests/test_delayed.py: 22 warnings
tests/test_generic_udf.py: 8 warnings
tests/test_sql.py: 6 warnings
tests/db_connector/test_connector.py: 1 warning
tests/taskgraphs/test_client_executor.py: 39 warnings
tests/taskgraphs/test_registration.py: 3 warnings
tests/taskgraphs/test_retries.py: 14 warnings
tests/taskgraphs/test_taskgraphs.py: 6 warnings
tests/taskgraphs/delayed/test_delayed_funcs.py: 38 warnings
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/rest_api/api_client.py:211: DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).
    content_type = response_data.getheader("content-type")

tests/test_basic.py::BasicTests::test_quickstart_sql_async
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_basic.py:241: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_basic.py::BasicTests::test_quickstart_sql_async
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_basic.py:258: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_dag.py::DAGFailureTest::test_retry_cancelled
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/_common/futures.py:94: UserWarning: UUID('26a60fdd-c6bc-4dd7-895b-e569afa1f720') in callback <bound method DAG.report_node_complete of <tiledb.cloud.dag.dag.DAG object at 0x12eeeb490>>(<tiledb.cloud.dag.dag.Node object at 0x12eef29a0>)
    warnings.warn(UserWarning(f"{exc} in callback {cb}({thing!r})"))

tests/test_dag.py: 7 warnings
tests/test_delayed.py: 4 warnings
tests/taskgraphs/test_client_executor.py: 25 warnings
tests/taskgraphs/test_codec.py: 4 warnings
tests/taskgraphs/test_retries.py: 5 warnings
tests/taskgraphs/test_taskgraphs.py: 2 warnings
tests/taskgraphs/delayed/test_delayed_funcs.py: 19 warnings
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/_results/codecs.py:204: DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).
    full_mime = resp.getheader("Content-type") or "application/octet-stream"

tests/test_dag.py::DAGCancelTest::test_dag_cancel
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/_common/futures.py:94: UserWarning: UUID('488e3a10-f5a7-486b-ae80-4c4009ae502e') in callback <bound method DAG.report_node_complete of <tiledb.cloud.dag.dag.DAG object at 0x12ec939a0>>(<tiledb.cloud.dag.dag.Node object at 0x12ec93cd0>)
    warnings.warn(UserWarning(f"{exc} in callback {cb}({thing!r})"))

tests/test_delayed.py::DelayedCancelTest::test_cancel
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/_common/futures.py:94: UserWarning: UUID('edfd026e-17ab-4d16-b6d1-a9d6f41c916f') in callback <bound method DAG.report_node_complete of <tiledb.cloud.dag.dag.DAG object at 0x12ec80310>>(<tiledb.cloud.compute.delayed.Delayed object at 0x12ec80430>)
    warnings.warn(UserWarning(f"{exc} in callback {cb}({thing!r})"))

tests/test_groups.py::GroupsTest::test_create_deregister
tests/test_groups.py::GroupsTest::test_create_deregister
tests/test_groups.py::GroupsTest::test_create_deregister
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/site-packages/tiledb/cloud/rest_api/rest.py:43: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
    return self.urllib3_response.getheaders()

tests/test_sql.py::BasicTests::test_quickstart_sql_arrow
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:98: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_sql.py::BasicTests::test_quickstart_sql_async
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:23: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_sql.py::BasicTests::test_quickstart_sql_async
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:40: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_sql.py::BasicTests::test_quickstart_sql_json
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:126: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_sql.py::BasicTests::test_sql_init_commands
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:55: FutureWarning: Calling int on a single element Series is deprecated and will raise a TypeError in the future. Use int(ser.iloc[0]) instead
    int(

tests/test_sql.py::BasicTests::test_sql_parameters
  /Users/parismorgan/repo/TileDB-Cloud-Py/tests/test_sql.py:69: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
    float(

tests/taskgraphs/test_codec.py::PandasArrowTest::test_pickle_fallback
  /opt/homebrew/anaconda3/envs/TileDB-Cloud-Py/lib/python3.9/unittest/case.py:1140: DeprecationWarning: assertDictContainsSubset is deprecated
    warnings.warn('assertDictContainsSubset is deprecated',

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================= 198 passed, 11 skipped, 637 warnings in 1941.69s (0:32:21) ========================================
```
* I then set up a storage provider and don't raise this exception