### PR TITLE
Use replacing visitor so we actually descend into batch args.

### DIFF
--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -716,6 +716,17 @@ class DAGBatchModeTest(unittest.TestCase):
         d.wait(300)
         self.assertEqual(print_node.result(), [99.0, 299.0, 499.0, 699.0])
 
+    def test_param_replacement(self):
+        d = dag.DAG(mode=Mode.BATCH)
+        in_node = d.submit(lambda x: "out" + x[2:], "input")
+        wrap_node = d.submit(repr, [in_node])
+        dict_node = d.submit(lambda d: tuple(d.items()), {"wrapped": wrap_node})
+        d.compute()
+        d.wait(300)
+        self.assertEqual(in_node.result(), "output")
+        self.assertEqual(wrap_node.result(), "['output']")
+        self.assertEqual(dict_node.result(), (("wrapped", "['output']"),))
+
     def test_batch_dag_retries(self):
         def random_failure():
             import random


### PR DESCRIPTION
When server-side ("batch") DAG execution was added, the implementation used custom code for finding parent nodes, rather than the existing visitor system. This meant that if a Node was passed in not at the top level, it would not work.

This change replaces it with a visitor-based system that allows users to pass in nodes just as they would in client-side execution.