### PR TITLE
Add ingest_annotations to __init__.py for tiledb.cloud.vcf

### DIFF
--- a/src/tiledb/cloud/vcf/__init__.py
+++ b/src/tiledb/cloud/vcf/__init__.py
@@ -2,6 +2,7 @@ from .allele_frequency import read_allele_frequency
 from .ingestion import Contigs
 from .ingestion import create_dataset_udf as create_dataset
 from .ingestion import ingest
+from .ingestion import ingest_annotations
 from .ingestion import register_dataset_udf as register_dataset
 from .query import build_read_dag
 from .query import read
@@ -16,6 +17,7 @@ __all__ = [
     "Contigs",
     "create_dataset",
     "ingest",
+    "ingest_annotations",
     "register_dataset",
     "build_read_dag",
     "read",


### PR DESCRIPTION
Add `ingest_annotations` to `__intit__.py` for `tiledb.cloud.vcf`, which was missing from #498.