### PR TITLE
Mapping argument for renaming ingested files

### DIFF
--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -48,22 +48,16 @@ def validate_io_paths(source: Sequence[str], output: Sequence[str]):
     if len(source) == 0:
         raise ValueError("Source list must not be empty.")
 
-    # Case 1: If source is a list of files
-    if all(not is_folder(path) for path in source):
-        # Destination is a folder
-        if len(output) == 1 and is_folder(output[0]):
-            return True
-        # Destination has the same number of paths with source - rename at destination
-        elif len(output) == len(source) and all(not is_folder(path) for path in output):
-            return True
+    if len(output) == 1 and is_folder(output[0]):
+        return True
 
-    # Case 2: If source is a list with length one
-    elif len(source) == 1:
-        if is_folder(source[0]):
-            if len(output) == 1 and is_folder(output[0]):
-                return True
-        else:
-            if len(output) == 1 and (is_folder(output[0]) or not is_folder(output[0])):
+    if all(is_folder(path) for path in output):
+        if all(is_folder(path) for path in source):
+            if len(output) == len(source):
                 return True
 
+    if all(not is_folder(path) for path in output):
+        if all(not is_folder(path) for path in source):
+            if len(output) == len(source):
+                return True
     raise ValueError("Invalid combination of source and output paths.")

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -36,21 +36,23 @@ def serialize_filter(filter):
         raise TypeError
 
 
+def is_folder(path: str) -> bool:
+    return path.endswith("/")
+
+
 def validate_io_paths(source, output):
     if isinstance(source, str):
-        # Handle only lists
-        if source.endswith("/"):
-            # Source is folder
+        if is_folder(source):
             if not isinstance(output, str):
                 # Output is list of possible 1 or multiple records
-                if not (len(output) == 1 and output[0].endswith("/")):
+                if not (len(output) == 1 and is_folder(output[0])):
                     raise ValueError(
                         "For directory input the output should be also a \
                         directory with a trailing '/'"
                     )
             else:
                 # Output is one record
-                if not output.endswith("/"):
+                if not is_folder(output):
                     raise ValueError(
                         "For directory input the output should \
                         be also a directory with a trailing '/'"
@@ -60,36 +62,40 @@ def validate_io_paths(source, output):
             if not isinstance(output, str):
                 # If 1 record list and folder allow
                 if len(output) != 1:
-                    raise ValueError(
+                    raise NotImplementedError(
                         "Single file input cannot correspond \
                         to multiple files output"
                     )
-
-    elif not isinstance(source, str):
+    else:
         if isinstance(output, str):
             if len(source) == 1:
-                if source.endswith("/"):
-                    if not output.endswith("/"):
+                if is_folder(source[0]):
+                    if not is_folder(output):
                         raise ValueError(
                             "For dir sources the output should \
                             point to a dir with a trailing '/'"
                         )
             else:
-                if not output.endswith("/"):
+                if not all(not is_folder(s) for s in source):
+                    raise ValueError(
+                        "For multiple inputs in source list \
+                        the inputs cannot contain a dir"
+                    )
+                if not is_folder(output):
                     raise ValueError(
                         "For multiple inputs the output should \
                         correspond to a dir with a trailing '/'"
                     )
         else:
             if len(source) != len(output):
-                if not all(not s.endswith("/") for s in source):
+                if not all(not is_folder(s) for s in source):
                     raise ValueError(
                         "For multiple inputs in source list \
                         the inputs cannot contain a dir"
                     )
                 else:
                     if len(output) == 1:
-                        if not output[0].endswith("/"):
+                        if not is_folder(output[0]):
                             raise ValueError(
                                 "For multiple files in source list \
                                 the output should be a unique folder"
@@ -102,13 +108,13 @@ def validate_io_paths(source, output):
             else:
                 if len(source) != 1:
                     for z, o in zip(source, output):
-                        if z.endswith("/") or o.endswith("/"):
+                        if is_folder(z) or is_folder(o):
                             raise NotImplementedError(
                                 "Sequence of multiple inputs \
                                 can only contain files and not directories"
                             )
                 else:
-                    if source[0].endswith("/") and not output[0].endswith("/"):
+                    if is_folder(source[0]) and not is_folder(output[0]):
                         raise ValueError(
                             "For dir sources the output should point \
                             to a dir with a trailing '/'"

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Sequence
 
 import tiledb
 from tiledb.cloud.utilities import get_logger
@@ -40,83 +41,29 @@ def is_folder(path: str) -> bool:
     return path.endswith("/")
 
 
-def validate_io_paths(source, output):
-    if isinstance(source, str):
-        if is_folder(source):
-            if not isinstance(output, str):
-                # Output is list of possible 1 or multiple records
-                if not (len(output) == 1 and is_folder(output[0])):
-                    raise ValueError(
-                        "For directory input the output should be also a \
-                        directory with a trailing '/'"
-                    )
-            else:
-                # Output is one record
-                if not is_folder(output):
-                    raise ValueError(
-                        "For directory input the output should \
-                        be also a directory with a trailing '/'"
-                    )
+def validate_io_paths(source: Sequence[str], output: Sequence[str]):
+    if not isinstance(source, list) or not isinstance(output, list):
+        raise ValueError("Both source and output must be lists.")
+
+    if len(source) == 0:
+        raise ValueError("Source list must not be empty.")
+
+    # Case 1: If source is a list of files
+    if all(not is_folder(path) for path in source):
+        # Destination is a folder
+        if len(output) == 1 and is_folder(output[0]):
+            return True
+        # Destination has the same number of paths with source - rename at destination
+        elif len(output) == len(source) and all(not is_folder(path) for path in output):
+            return True
+
+    # Case 2: If source is a list with length one
+    elif len(source) == 1:
+        if is_folder(source[0]):
+            if len(output) == 1 and is_folder(output[0]):
+                return True
         else:
-            # Source is a file
-            if not isinstance(output, str):
-                # If 1 record list and folder allow
-                if len(output) != 1:
-                    raise NotImplementedError(
-                        "Single file input cannot correspond \
-                        to multiple files output"
-                    )
-    else:
-        if isinstance(output, str):
-            if len(source) == 1:
-                if is_folder(source[0]):
-                    if not is_folder(output):
-                        raise ValueError(
-                            "For dir sources the output should \
-                            point to a dir with a trailing '/'"
-                        )
-            else:
-                if not all(not is_folder(s) for s in source):
-                    raise ValueError(
-                        "For multiple inputs in source list \
-                        the inputs cannot contain a dir"
-                    )
-                if not is_folder(output):
-                    raise ValueError(
-                        "For multiple inputs the output should \
-                        correspond to a dir with a trailing '/'"
-                    )
-        else:
-            if len(source) != len(output):
-                if not all(not is_folder(s) for s in source):
-                    raise ValueError(
-                        "For multiple inputs in source list \
-                        the inputs cannot contain a dir"
-                    )
-                else:
-                    if len(output) == 1:
-                        if not is_folder(output[0]):
-                            raise ValueError(
-                                "For multiple files in source list \
-                                the output should be a unique folder"
-                            )
-                    else:
-                        raise NotImplementedError(
-                            "Multiple inputs containing dirs \
-                            with multiple outputs is not supported"
-                        )
-            else:
-                if len(source) != 1:
-                    for z, o in zip(source, output):
-                        if is_folder(z) or is_folder(o):
-                            raise NotImplementedError(
-                                "Sequence of multiple inputs \
-                                can only contain files and not directories"
-                            )
-                else:
-                    if is_folder(source[0]) and not is_folder(output[0]):
-                        raise ValueError(
-                            "For dir sources the output should point \
-                            to a dir with a trailing '/'"
-                        )
-    return source, output
+            if len(output) == 1 and (is_folder(output[0]) or not is_folder(output[0])):
+                return True
+
+    raise ValueError("Invalid combination of source and output paths.")

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -34,3 +34,83 @@ def serialize_filter(filter):
         return filter_dict
     else:
         raise TypeError
+
+
+def validate_io_paths(source, output):
+    if isinstance(source, str):
+        # Handle only lists
+        if source.endswith("/"):
+            # Source is folder
+            if not isinstance(output, str):
+                # Output is list of possible 1 or multiple records
+                if not (len(output) == 1 and output[0].endswith("/")):
+                    raise ValueError(
+                        "For directory input the output should be also a \
+                        directory with a trailing '/'"
+                    )
+            else:
+                # Output is one record
+                if not output.endswith("/"):
+                    raise ValueError(
+                        "For directory input the output should \
+                        be also a directory with a trailing '/'"
+                    )
+        else:
+            # Source is a file
+            if not isinstance(output, str):
+                # If 1 record list and folder allow
+                if len(output) != 1:
+                    raise ValueError(
+                        "Single file input cannot correspond \
+                        to multiple files output"
+                    )
+
+    elif not isinstance(source, str):
+        if isinstance(output, str):
+            if len(source) == 1:
+                if source.endswith("/"):
+                    if not output.endswith("/"):
+                        raise ValueError(
+                            "For dir sources the output should \
+                            point to a dir with a trailing '/'"
+                        )
+            else:
+                if not output.endswith("/"):
+                    raise ValueError(
+                        "For multiple inputs the output should \
+                        correspond to a dir with a trailing '/'"
+                    )
+        else:
+            if len(source) != len(output):
+                if not all(not s.endswith("/") for s in source):
+                    raise ValueError(
+                        "For multiple inputs in source list \
+                        the inputs cannot contain a dir"
+                    )
+                else:
+                    if len(output) == 1:
+                        if not output[0].endswith("/"):
+                            raise ValueError(
+                                "For multiple files in source list \
+                                the output should be a unique folder"
+                            )
+                    else:
+                        raise NotImplementedError(
+                            "Multiple inputs containing dirs \
+                            with multiple outputs is not supported"
+                        )
+            else:
+                if len(source) != 1:
+                    for z, o in zip(source, output):
+                        if z.endswith("/") or o.endswith("/"):
+                            raise NotImplementedError(
+                                "Sequence of multiple inputs \
+                                can only contain files and not directories"
+                            )
+                else:
+                    if source[0].endswith("/") and not output[0].endswith("/"):
+                        raise ValueError(
+                            "For dir sources the output should point \
+                            to a dir with a trailing '/'"
+                        )
+    return source, output

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -95,8 +95,17 @@ def ingest(
                     if s.endswith("/"):
                         # Folder for exploration
                         contents = vfs.ls(s)
-                        # [1:] till the SC-40049 is resolved
-                        yield from iter_paths(contents[1:], output)
+                        # [1:] till the SC-40049 is resolved this will restrict
+                        filtered_contents = [
+                            c
+                            for c in contents
+                            if not (
+                                vfs.is_dir(c)
+                                and vfs.is_file(c)
+                                and vfs.file_size(c) == 0
+                            )
+                        ]
+                        yield from iter_paths(filtered_contents, output)
                     elif s.endswith(supported_exts):
                         yield s, create_output_path(s, output[0])
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -34,8 +34,10 @@ def ingest(
 ) -> tiledb.cloud.dag.DAG:
     """The function ingests microscopy images into TileDB arrays
 
-    :param source: uri / iterable of uris of input files
-    :param output: output dir for the ingested tiledb arrays
+    :param source: uri / iterable of uris of input files.
+        If the uri points to a directory of files make sure it ends with a trailing '/'
+    :param output: uri / iterable of uris of input files.
+        If the uri points to a directory of files make sure it ends with a trailing '/'
     :param config: dict configuration to pass on tiledb.VFS
     :param taskgraph_name: Optional name for taskgraph, defaults to None
     :param num_batches: Number of graph nodes to spawn.

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -52,7 +52,8 @@ def ingest(
     :param namespace: The namespace where the DAG will run
     :param verbose: verbose logging, defaults to False
     :param output_ext: extension for the output images in tiledb
-    :param traverse: If true then traverse the src paths for exploring images in
+    :param traverse: If true then traverse the src paths recursively
+        to find images to convert in
         depths > 1. Default: (False) Check only in depth 1.
     """
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -107,12 +107,9 @@ def ingest(
         num_batches: int,
         out_ext: str,
         supported_exts: Tuple,
-        name_map: Mapping[str, str],
     ):
         """Groups input URIs into batches."""
-        uri_pairs = build_io_uris_ingestion(
-            source, output, out_ext, supported_exts, name_map
-        )
+        uri_pairs = build_io_uris_ingestion(source, output, out_ext, supported_exts)
         # If the user didn't specify a number of batches, run every import
         # as its own task.
         my_num_batches = num_batches or len(uri_pairs)

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -95,7 +95,8 @@ def ingest(
                     if s.endswith("/"):
                         # Folder for exploration
                         contents = vfs.ls(s)
-                        yield from iter_paths(contents, output)
+                        # [1:] till the SC-40049 is resolved
+                        yield from iter_paths(contents[1:], output)
                     elif s.endswith(supported_exts):
                         yield s, create_output_path(s, output[0])
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -167,9 +167,9 @@ def ingest(
                         **kwargs,
                     )
 
-    source, output = validate_io_paths(source, output)
     source = [source] if isinstance(source, str) else source
     output = [output] if isinstance(output, str) else output
+    validate_io_paths(source, output)
 
     logger.debug("Ingesting files: %s", source)
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -29,7 +29,7 @@ def ingest(
     verbose: bool = False,
     exclude_metadata: bool = False,
     output_ext: str = "",
-    rename_hashmap: Optional[Mapping[str, str]] = None,
+    name_map: Optional[Mapping[str, str]] = None,
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
     """The function ingests microscopy images into TileDB arrays
@@ -59,7 +59,7 @@ def ingest(
         output: str,
         output_ext: str,
         supported_exts: Tuple[str],
-        name_hashmap: Mapping[str, str],
+        name_map: Mapping[str, str],
     ):
         """Match input uri/s with output destinations
 
@@ -75,7 +75,7 @@ def ingest(
         supported_exts = tuple(supported_exts)
 
         def create_output_path(
-            input_file: str, output: str, name_hashmap: Mapping[str, str]
+            input_file: str, output: str, name_map: Mapping[str, str]
         ) -> str:
             # Check if output is dir
             if output.endswith("/"):
@@ -83,17 +83,17 @@ def ingest(
                 # If output is a directory the target name is the input filename
                 # with possible user ext if a hashmap is not defined otherwise
                 # we use the mapping.
-                if name_hashmap:
-                    hashed_name = name_hashmap.get(filename, None)
-                    if not hashed_name:
+                if name_map:
+                    mapped_name = name_map.get(filename, None)
+                    if not mapped_name:
                         raise ValueError(
                             f"File {filename} has no corresponding rename value"
                         )
                     else:
                         output_filename = (
-                            hashed_name + f".{output_ext}"
+                            mapped_name + f".{output_ext}"
                             if output_ext
-                            else hashed_name
+                            else mapped_name
                         )
                 else:
                     output_filename = (
@@ -123,7 +123,7 @@ def ingest(
                 "For multiple files the output arg \
                              should end with a trailing '/'"
             )
-        return tuple(iter_paths(source, name_hashmap))
+        return tuple(iter_paths(source, name_map))
 
     def build_input_batches(
         source: Sequence[str],
@@ -131,11 +131,11 @@ def ingest(
         num_batches: int,
         out_ext: str,
         supported_exts: Tuple,
-        name_hashmap: Mapping[str, str],
+        name_map: Mapping[str, str],
     ):
         """Groups input URIs into batches."""
         uri_pairs = build_io_uris_ingestion(
-            source, output, out_ext, supported_exts, name_hashmap
+            source, output, out_ext, supported_exts, name_map
         )
         # If the user didn't specify a number of batches, run every import
         # as its own task.
@@ -221,7 +221,7 @@ def ingest(
         num_batches,
         output_ext,
         _SUPPORTED_EXTENSIONS,
-        rename_hashmap,
+        name_map,
         access_credentials_name=kwargs.get("access_credentials_name"),
         name=f"{dag_name} input collector",
         result_format="json",

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -1,16 +1,12 @@
-import math
 import unittest
-from unittest import mock
 
 from tiledb.cloud.bioimg.helpers import validate_io_paths
-from tiledb.cloud.bioimg.ingestion import build_io_uris_ingestion, _SUPPORTED_EXTENSIONS
-from tiledb.vfs import VFS
 
 
 class BioimgTest(unittest.TestCase):
     def setUp(self) -> None:
         self.out_path = "out"
-        self.accepted_pairs = {            
+        self.accepted_pairs = {
             # One file in one file out
             "test1": ("s3://test_in/a.tiff", "s3://test_out/b"),
             # One file in one file out - out 1-elem list
@@ -19,7 +15,6 @@ class BioimgTest(unittest.TestCase):
             "test3": (["s3://test_in/a.tiff"], "s3://test_out/b"),
             # One file in one file out - in & out 1-elem list
             "test4": (["s3://test_in/a.tiff"], ["s3://test_out/b"]),
-            
             # One folder in one folder out
             "test5": ("s3://test_in/a/", "s3://test_out/b/"),
             # One folder in one file out - in & out 1-elem list
@@ -28,7 +23,6 @@ class BioimgTest(unittest.TestCase):
             "test7": ("s3://test_in/a/", ["s3://test_out/b/"]),
             # One folder in one file out - in 1-elem list
             "test8": (["s3://test_in/a/"], "s3://test_out/b/"),
-
             # One file in one folder out
             "test9": ("s3://test_in/a.tiff", "s3://test_out/b/"),
             # One file in one folder out - in 1- elem list
@@ -37,25 +31,27 @@ class BioimgTest(unittest.TestCase):
             "test11": ("s3://test_in/a.tiff", ["s3://test_out/b/"]),
             # One file in one folder out - in & out 1- elem list
             "test12": (["s3://test_in/a.tiff"], ["s3://test_out/b/"]),
-
             # Multiple files in one folder out
-            "test13": (["s3://test_in/a.tiff", 
-                       "s3://test_in/c.tiff"], "s3://test_out/b/"),
+            "test13": (
+                ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
+                "s3://test_out/b/",
+            ),
             # Multiple files in one folder out
-            "test14": (["s3://test_in/a.tiff", 
-                       "s3://test_in/c.tiff"], ["s3://test_out/b/"]),
+            "test14": (
+                ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
+                ["s3://test_out/b/"],
+            ),
             # Multiple files in multiple files out - equal length
             # a -> b & c -> d
-            "test15": (["s3://test_in/a.tiff", 
-                       "s3://test_in/c.tiff"], 
-                       ["s3://test_out/b",
-                        "s3://test_out/d"]),
+            "test15": (
+                ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
+                ["s3://test_out/b", "s3://test_out/d"],
+            ),
         }
 
         return super().setUp()
 
     def test_validate_io_paths(self):
-
         # Accepted cases
         for test_name, io_tuple in self.accepted_pairs.items():
             source, dest = io_tuple
@@ -63,9 +59,7 @@ class BioimgTest(unittest.TestCase):
             validate_io_paths(source, dest)
 
         io_validation_ni_errors = {
-            "test3": ("s3://test_in/a",
-                       ["s3://test_out/b/",
-                        "s3://test_out/d/"]),
+            "test3": ("s3://test_in/a", ["s3://test_out/b/", "s3://test_out/d/"]),
         }
 
         for test_name, io_tuple in io_validation_ni_errors.items():
@@ -75,26 +69,16 @@ class BioimgTest(unittest.TestCase):
                 validate_io_paths(source, dest)
 
         io_validation_value_errors = {
-            # Folder in - single file out 
-            "test1": ("s3://test_in/a/",
-                      "s3://test_out/b"),
-            "test2": (["s3://test_in/a/"],
-                      "s3://test_out/b"),
-            "test3": ("s3://test_in/a/",
-                      ["s3://test_out/b"]),
-            "test4": (["s3://test_in/a/"],
-                      ["s3://test_out/b"]),
-            
+            # Folder in - single file out
+            "test1": ("s3://test_in/a/", "s3://test_out/b"),
+            "test2": (["s3://test_in/a/"], "s3://test_out/b"),
+            "test3": ("s3://test_in/a/", ["s3://test_out/b"]),
+            "test4": (["s3://test_in/a/"], ["s3://test_out/b"]),
             # Input list cannot contain dir
             # One of the input is folder - out is folder
-            "test16": (["s3://test_in/a",
-                       "s3://test_in/c/"],
-                      "s3://test_out/b/"),
+            "test16": (["s3://test_in/a", "s3://test_in/c/"], "s3://test_out/b/"),
             # One of the input is folder - out is folder and list
-            "test17": (["s3://test_in/a",
-                       "s3://test_in/c/"],
-                      ["s3://test_out/b/"]),
-            
+            "test17": (["s3://test_in/a", "s3://test_in/c/"], ["s3://test_out/b/"]),
         }
 
         for test_name, io_tuple in io_validation_value_errors.items():
@@ -112,7 +96,7 @@ class BioimgTest(unittest.TestCase):
     #             source, output = pair
     #             source = [source] if isinstance(source, str) else source
     #             output = [output] if isinstance(output, str) else output
-                
+
     #             paths = build_io_uris_ingestion(source,
     #                                     output,
     #                                     out_suffix,

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -55,6 +55,8 @@ class BioimgTest(unittest.TestCase):
         # Accepted cases
         for test_name, io_tuple in self.accepted_pairs.items():
             source, dest = io_tuple
+            source = [source] if isinstance(source, str) else source
+            dest = [dest] if isinstance(dest, str) else dest
             print(f"{test_name}:", source, dest)
             validate_io_paths(source, dest)
 
@@ -64,8 +66,10 @@ class BioimgTest(unittest.TestCase):
 
         for test_name, io_tuple in io_validation_ni_errors.items():
             source, dest = io_tuple
+            source = [source] if isinstance(source, str) else source
+            dest = [dest] if isinstance(dest, str) else dest
             print(f"{test_name}:", source, dest)
-            with self.assertRaises(NotImplementedError):
+            with self.assertRaises(ValueError):
                 validate_io_paths(source, dest)
 
         io_validation_value_errors = {
@@ -83,22 +87,8 @@ class BioimgTest(unittest.TestCase):
 
         for test_name, io_tuple in io_validation_value_errors.items():
             source, dest = io_tuple
+            source = [source] if isinstance(source, str) else source
+            dest = [dest] if isinstance(dest, str) else dest
             print(f"{test_name}:", source, dest)
             with self.assertRaises(ValueError):
                 validate_io_paths(source, dest)
-
-    # def test_build_io_uris_ingestion(self):
-    #     out_suffix = "tdb"
-    #     mock_contents = ['s3://test_in/a/x.svs', 's3://test_in/a/y.svs']
-    #     with mock.patch.object(VFS, "ls", return_value=mock_contents):
-    #         out_suffix = "tdb"
-    #         for test_name, pair in self.accepted_pairs.items():
-    #             source, output = pair
-    #             source = [source] if isinstance(source, str) else source
-    #             output = [output] if isinstance(output, str) else output
-
-    #             paths = build_io_uris_ingestion(source,
-    #                                     output,
-    #                                     out_suffix,
-    #                                     _SUPPORTED_EXTENSIONS)
-    #             print(f"{test_name}: {pair} -> {paths}")

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -7,48 +7,87 @@ class BioimgTest(unittest.TestCase):
     def setUp(self) -> None:
         self.out_path = "out"
         self.accepted_pairs = {
-            # One file in one file out
-            "test1": ("s3://test_in/a.tiff", "s3://test_out/b"),
-            # One file in one file out - out 1-elem list
-            "test2": ("s3://test_in/a.tiff", ["s3://test_out/b"]),
-            # One file in one file out - in 1-elem list
-            "test3": (["s3://test_in/a.tiff"], "s3://test_out/b"),
-            # One file in one file out - in & out 1-elem list
-            "test4": (["s3://test_in/a.tiff"], ["s3://test_out/b"]),
-            # One folder in one folder out
-            "test5": ("s3://test_in/a/", "s3://test_out/b/"),
-            # One folder in one file out - in & out 1-elem list
-            "test6": (["s3://test_in/a/"], ["s3://test_out/b/"]),
-            # One folder in one file out - out 1-elem list
-            "test7": ("s3://test_in/a/", ["s3://test_out/b/"]),
-            # One folder in one file out - in 1-elem list
-            "test8": (["s3://test_in/a/"], "s3://test_out/b/"),
-            # One file in one folder out
-            "test9": ("s3://test_in/a.tiff", "s3://test_out/b/"),
-            # One file in one folder out - in 1- elem list
-            "test10": (["s3://test_in/a.tiff"], "s3://test_out/b/"),
-            # One file in one folder out - out 1- elem list
-            "test11": ("s3://test_in/a.tiff", ["s3://test_out/b/"]),
-            # One file in one folder out - in & out 1- elem list
-            "test12": (["s3://test_in/a.tiff"], ["s3://test_out/b/"]),
-            # Multiple files in one folder out
-            "test13": (
-                ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
-                "s3://test_out/b/",
-            ),
-            # Multiple files in one folder out
-            "test14": (
+            # 1 File -> Output: 1 Folder
+            "test1": (["s3://test_in/a.tiff"], ["s3://test_out/b/"]),
+            # 1 File -> Output: 1 File
+            "test3": (["s3://test_in/a.tiff"], ["s3://test_out/b"]),
+            # 1 Folder -> Output: 1 Folder
+            "test5": (["s3://test_in/a/"], ["s3://test_out/b/"]),
+            # Multiple Files -> Output: 1 Folder
+            "test10": (
                 ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
                 ["s3://test_out/b/"],
             ),
-            # Multiple files in multiple files out - equal length
-            # a -> b & c -> d
-            "test15": (
+            # Multiple Files -> Output: Multiple Files (Matching number)
+            "test11": (
                 ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
                 ["s3://test_out/b", "s3://test_out/d"],
             ),
+            # Multiple Folders -> Output: 1 Folder
+            "test14": (["s3://test_in/a/", "s3://test_in/c/"], ["s3://test_out/b/"]),
+            # Mix of Files and Folders -> Output: 1 Folder
+            "test16": (["s3://test_in/a", "s3://test_in/c/"], ["s3://test_out/b/"]),
         }
-
+        self.non_accepted_pairs = {
+            # 1 File -> Output: Multiple Folders
+            "test2": (
+                ["s3://test_in/a.tiff"],
+                ["s3://test_out/b/", "s3://test_out/c/"],
+            ),
+            # 1 File -> Output: Multiple Files
+            "test4": (["s3://test_in/a"], ["s3://test_out/b", "s3://test_out/c"]),
+            # 1 Folder -> Output: 1 File
+            "test6": (["s3://test_in/a/"], ["s3://test_out/b"]),
+            #  1 Folder -> Output: Multiple Files
+            "test7": (["s3://test_in/a/"], ["s3://test_out/b", "s3://test_out/c"]),
+            # 1 Folder -> Output: Multiple Folders
+            "test8": (["s3://test_in/a/"], ["s3://test_out/b/", "s3://test_out/c/"]),
+            # Multiple Files -> Output: 1 File
+            "test9": (["s3://test_in/a", "s3://test_in/c"], ["s3://test_out/b"]),
+            # Multiple Files -> Output: Multiple Files  (Non-Matching number)
+            "test12": (
+                ["s3://test_in/a", "s3://test_in/c"],
+                ["s3://test_out/b", "s3://test_out/d", "s3://test_out/e"],
+            ),
+            # Multiple Files -> Output: Multiple Folders
+            # (Matching or non-matching length)
+            # Non-matching
+            "test13a": (
+                ["s3://test_in/a", "s3://test_in/c"],
+                ["s3://test_out/b/", "s3://test_out/d/", "s3://test_out/e/"],
+            ),
+            # matching
+            "test13b": (
+                ["s3://test_in/a", "s3://test_in/c"],
+                ["s3://test_out/b/", "s3://test_out/d/"],
+            ),
+            # Multiple Folders -> Output: 1 File
+            "test15": (["s3://test_in/a/", "s3://test_in/c/"], ["s3://test_out/b"]),
+            # Multiple Folders -> Output: Multiple Files
+            # (Matching or non-matching length)
+            # Matching
+            "test17a": (
+                ["s3://test_in/a/", "s3://test_in/c/"],
+                ["s3://test_out/b", "s3://test_out/d", "s3://test_out/e"],
+            ),
+            # Non Matching
+            "test17b": (
+                ["s3://test_in/a/", "s3://test_in/c/"],
+                ["s3://test_out/b", "s3://test_out/d"],
+            ),
+            # Multiple Folders -> Output: Multiple Folders (Non-Matching number)
+            "test18": (
+                ["s3://test_in/a/", "s3://test_in/c/"],
+                ["s3://test_out/b", "s3://test_out/d", "s3://test_out/e"],
+            ),
+            # Mix of Files and Folders -> Output: 1 File
+            "test20": (["s3://test_in/a", "s3://test_in/c/"], ["s3://test_out/b"]),
+            # Mix of Files and Folders -> Output: Multiple Files and Folders
+            "test21": (
+                ["s3://test_in/a/", "s3://test_in/c"],
+                ["s3://test_out/b", "s3://test_out/d/"],
+            ),
+        }
         return super().setUp()
 
     def test_validate_io_paths(self):
@@ -60,32 +99,8 @@ class BioimgTest(unittest.TestCase):
             print(f"{test_name}:", source, dest)
             validate_io_paths(source, dest)
 
-        io_validation_ni_errors = {
-            "test3": ("s3://test_in/a", ["s3://test_out/b/", "s3://test_out/d/"]),
-        }
-
-        for test_name, io_tuple in io_validation_ni_errors.items():
-            source, dest = io_tuple
-            source = [source] if isinstance(source, str) else source
-            dest = [dest] if isinstance(dest, str) else dest
-            print(f"{test_name}:", source, dest)
-            with self.assertRaises(ValueError):
-                validate_io_paths(source, dest)
-
-        io_validation_value_errors = {
-            # Folder in - single file out
-            "test1": ("s3://test_in/a/", "s3://test_out/b"),
-            "test2": (["s3://test_in/a/"], "s3://test_out/b"),
-            "test3": ("s3://test_in/a/", ["s3://test_out/b"]),
-            "test4": (["s3://test_in/a/"], ["s3://test_out/b"]),
-            # Input list cannot contain dir
-            # One of the input is folder - out is folder
-            "test16": (["s3://test_in/a", "s3://test_in/c/"], "s3://test_out/b/"),
-            # One of the input is folder - out is folder and list
-            "test17": (["s3://test_in/a", "s3://test_in/c/"], ["s3://test_out/b/"]),
-        }
-
-        for test_name, io_tuple in io_validation_value_errors.items():
+        # Non Accepted cases
+        for test_name, io_tuple in self.non_accepted_pairs.items():
             source, dest = io_tuple
             source = [source] if isinstance(source, str) else source
             dest = [dest] if isinstance(dest, str) else dest

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -1,0 +1,120 @@
+import math
+import unittest
+from unittest import mock
+
+from tiledb.cloud.bioimg.helpers import validate_io_paths
+from tiledb.cloud.bioimg.ingestion import build_io_uris_ingestion, _SUPPORTED_EXTENSIONS
+from tiledb.vfs import VFS
+
+
+class BioimgTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.out_path = "out"
+        self.accepted_pairs = {            
+            # One file in one file out
+            "test1": ("s3://test_in/a.tiff", "s3://test_out/b"),
+            # One file in one file out - out 1-elem list
+            "test2": ("s3://test_in/a.tiff", ["s3://test_out/b"]),
+            # One file in one file out - in 1-elem list
+            "test3": (["s3://test_in/a.tiff"], "s3://test_out/b"),
+            # One file in one file out - in & out 1-elem list
+            "test4": (["s3://test_in/a.tiff"], ["s3://test_out/b"]),
+            
+            # One folder in one folder out
+            "test5": ("s3://test_in/a/", "s3://test_out/b/"),
+            # One folder in one file out - in & out 1-elem list
+            "test6": (["s3://test_in/a/"], ["s3://test_out/b/"]),
+            # One folder in one file out - out 1-elem list
+            "test7": ("s3://test_in/a/", ["s3://test_out/b/"]),
+            # One folder in one file out - in 1-elem list
+            "test8": (["s3://test_in/a/"], "s3://test_out/b/"),
+
+            # One file in one folder out
+            "test9": ("s3://test_in/a.tiff", "s3://test_out/b/"),
+            # One file in one folder out - in 1- elem list
+            "test10": (["s3://test_in/a.tiff"], "s3://test_out/b/"),
+            # One file in one folder out - out 1- elem list
+            "test11": ("s3://test_in/a.tiff", ["s3://test_out/b/"]),
+            # One file in one folder out - in & out 1- elem list
+            "test12": (["s3://test_in/a.tiff"], ["s3://test_out/b/"]),
+
+            # Multiple files in one folder out
+            "test13": (["s3://test_in/a.tiff", 
+                       "s3://test_in/c.tiff"], "s3://test_out/b/"),
+            # Multiple files in one folder out
+            "test14": (["s3://test_in/a.tiff", 
+                       "s3://test_in/c.tiff"], ["s3://test_out/b/"]),
+            # Multiple files in multiple files out - equal length
+            # a -> b & c -> d
+            "test15": (["s3://test_in/a.tiff", 
+                       "s3://test_in/c.tiff"], 
+                       ["s3://test_out/b",
+                        "s3://test_out/d"]),
+        }
+
+        return super().setUp()
+
+    def test_validate_io_paths(self):
+
+        # Accepted cases
+        for test_name, io_tuple in self.accepted_pairs.items():
+            source, dest = io_tuple
+            print(f"{test_name}:", source, dest)
+            validate_io_paths(source, dest)
+
+        io_validation_ni_errors = {
+            "test3": ("s3://test_in/a",
+                       ["s3://test_out/b/",
+                        "s3://test_out/d/"]),
+        }
+
+        for test_name, io_tuple in io_validation_ni_errors.items():
+            source, dest = io_tuple
+            print(f"{test_name}:", source, dest)
+            with self.assertRaises(NotImplementedError):
+                validate_io_paths(source, dest)
+
+        io_validation_value_errors = {
+            # Folder in - single file out 
+            "test1": ("s3://test_in/a/",
+                      "s3://test_out/b"),
+            "test2": (["s3://test_in/a/"],
+                      "s3://test_out/b"),
+            "test3": ("s3://test_in/a/",
+                      ["s3://test_out/b"]),
+            "test4": (["s3://test_in/a/"],
+                      ["s3://test_out/b"]),
+            
+            # Input list cannot contain dir
+            # One of the input is folder - out is folder
+            "test16": (["s3://test_in/a",
+                       "s3://test_in/c/"],
+                      "s3://test_out/b/"),
+            # One of the input is folder - out is folder and list
+            "test17": (["s3://test_in/a",
+                       "s3://test_in/c/"],
+                      ["s3://test_out/b/"]),
+            
+        }
+
+        for test_name, io_tuple in io_validation_value_errors.items():
+            source, dest = io_tuple
+            print(f"{test_name}:", source, dest)
+            with self.assertRaises(ValueError):
+                validate_io_paths(source, dest)
+
+    # def test_build_io_uris_ingestion(self):
+    #     out_suffix = "tdb"
+    #     mock_contents = ['s3://test_in/a/x.svs', 's3://test_in/a/y.svs']
+    #     with mock.patch.object(VFS, "ls", return_value=mock_contents):
+    #         out_suffix = "tdb"
+    #         for test_name, pair in self.accepted_pairs.items():
+    #             source, output = pair
+    #             source = [source] if isinstance(source, str) else source
+    #             output = [output] if isinstance(output, str) else output
+                
+    #             paths = build_io_uris_ingestion(source,
+    #                                     output,
+    #                                     out_suffix,
+    #                                     _SUPPORTED_EXTENSIONS)
+    #             print(f"{test_name}: {pair} -> {paths}")


### PR DESCRIPTION
This PR:

- Enables the user to provide a name mapping between the source files to be ingested and the desired final ingested name. This feature can be used also for de-identification cases. The user should be able to provide a list of output files given a equal length source file list where each of the source files will be renamed to the corresponding output item.
- Adds an extra layer of validation useful not only for the programmatic API but also for the 1-click ingestion feature.

### Changes

- Generalization and new semantics for the provided `output` and `input` ingestor argument. If the user want to point to a folder for storing the ingested data, then the path provided should have a trailing `/`. If so the default behaviour is to ingest the source files with the same name in this directory.
- If the `output` arg does not contain a trailing `/` then it is considered as a full target path for the ingested source. In this case the ingested source file should be one at a time, otherwise errors out with a `ValueError`.