### PR TITLE
Fix `vfs.ls` with `access_credentials_name`

### DIFF
--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -174,10 +174,7 @@ def run_ingest_workflow_udf(
     if vfs.is_file(input_uri):
         logging.debug("ENUMERATOR VFS.IS_FILE")
 
-        if dry_run:
-            name = "dry-run-h5ad-file"
-        else:
-            name = "ingest-h5ad-file"
+        name = ("dry-run" if dry_run else "ingest") + "-h5ad-file"
 
         grf = dag.DAG(
             name=name,
@@ -218,7 +215,7 @@ def run_ingest_workflow_udf(
         )
 
         for entry_input_uri in vfs.ls(input_uri):
-            logging.debug(f"ENUMERATOR ENTRY_INPUT_URI={entry_input_uri}")
+            logging.debug("ENUMERATOR ENTRY_INPUT_URI=%r", entry_input_uri)
             base = os.path.basename(entry_input_uri)
             base, _ = os.path.splitext(base)
 
@@ -226,10 +223,10 @@ def run_ingest_workflow_udf(
             if not output_uri.endswith("/"):
                 entry_output_uri += "/"
             entry_output_uri += base
-            logging.debug(f"ENUMERATOR ENTRY_OUTPUT_URI={entry_output_uri}")
+            logging.debug("ENUMERATOR ENTRY_OUTPUT_URI=%r", entry_output_uri)
 
             if pattern is not None and not re.match(pattern, entry_input_uri):
-                logging.debug(f"ENUMERATOR SKIP NO MATCH ON <<{pattern}>>")
+                logging.debug("ENUMERATOR SKIP NO MATCH ON <<%r>>", pattern)
                 continue
 
             node = grf.submit(
@@ -248,12 +245,12 @@ def run_ingest_workflow_udf(
             collector.depends_on(node)
 
     else:
-        raise ValueError(f"input_uri {input_uri!r} is neither file nor directory")
+        raise ValueError("input_uri %r is neither file nor directory", input_uri)
 
     grf.compute()
     grf.wait()
 
-    logging.debug(f"ENUMERATOR EXIT {grf.server_graph_uuid}")
+    logging.debug("ENUMERATOR EXIT server_graph_uuid = %r", grf.server_graph_uuid)
     return grf.server_graph_uuid
 
 

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -143,7 +143,10 @@ def run_ingest_workflow_udf(
     output_uri: str,
     input_uri: str,
     measurement_name: str,
-    carry_along: Dict[str, Optional[str]],  # TODO: COMMENT ME
+    # Some kwargs are eaten by the tiledb.cloud package, and won't reach
+    # our child. In order to propagate these to a _grandchild_ we need to
+    # package these up with different names. We use a dict as a single bag.
+    carry_along: Dict[str, Optional[str]],
     pattern: Optional[str] = None,
     extra_tiledb_config: Optional[Dict[str, object]] = None,
     platform_config: Optional[Dict[str, object]] = None,
@@ -162,9 +165,9 @@ def run_ingest_workflow_udf(
 
     logging.basicConfig(level=logging_level)
     logging.debug("ENUMERATOR ENTER")
-    logging.debug(f"ENUMERATOR INPUT_URI  {input_uri}")
-    logging.debug(f"ENUMERATOR OUTPUT_URI {output_uri}")
-    logging.debug(f"ENUMERATOR DRY_RUN {dry_run}")
+    logging.debug("ENUMERATOR INPUT_URI  %s", input_uri)
+    logging.debug("ENUMERATOR OUTPUT_URI %s", output_uri)
+    logging.debug("ENUMERATOR DRY_RUN    %s", str(dry_run))
 
     vfs = tiledb.VFS(config=extra_tiledb_config)
 
@@ -336,7 +339,7 @@ def ingest_h5ad(
 
     with tiledb.VFS(ctx=soma_ctx.tiledb_ctx).open(input_uri) as input_file:
         if dry_run:
-            logging.info("Dry run for %r to %r", input_uri, output_uri)
+            logging.info("Dry run for %s to %s", input_uri, output_uri)
             return
 
         with _hack_patch_anndata_byval():
@@ -349,7 +352,7 @@ def ingest_h5ad(
             ingest_mode=ingest_mode,
             platform_config=platform_config,
         )
-    logging.info("Successfully wrote data from %r to %r", input_uri, output_uri)
+    logging.info("Successfully wrote data from %s to %s", input_uri, output_uri)
 
 
 # Until we fully get this version of tiledb.cloud deployed server-side, we must

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -248,7 +248,6 @@ def run_ingest_workflow_udf(
         raise ValueError("input_uri %r is neither file nor directory", input_uri)
 
     grf.compute()
-    grf.wait()
 
     logging.debug("ENUMERATOR EXIT server_graph_uuid = %r", grf.server_graph_uuid)
     return grf.server_graph_uuid

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -78,6 +78,10 @@ def run_ingest_workflow(
         dry_run=dry_run,
     )
     grf.compute()
+    # On discussion with the cloud team:
+    # * In batch mode this does add call latency beyond grf.server_graph_uuid
+    # * However, the cloud UI cannot populate a DAG candelabra without us doing so.
+    # This is a necessary choice.
     the_node = next(iter(grf.nodes.values()))
     real_graph_uuid = the_node.result()
     return {


### PR DESCRIPTION
# Overview

When attempting to use the `run_ingest_workflow` function to ingest H5AD files into SOMA, users are expected to provide AWS credentials through the `extra_tiledb_config` argument. This is a departure from other 1-line ingestors, which allow users to provide only an `access_credential_name` (or a `config`) referencing their role-based credential.

The function fails if AWS credentials are not defined in the local environment or passed through the `extra_tiledb_config` argument, even when `access_credential_name` is provided because a `tiledb.VFS` instance is created locally to determine whether the `input_uri` points to a file or directory.

# Why this is

* `run_ingest_workflow` runs on the client
* We need `vfs` in order to:
  * Decide if the input URI is a leaf (`.h5ad`) or not (a prefix)
  * In the latter case, to enumerate over the `.h5ad` leaves at that prefix

# Sample script

```
stamp=$(vdatetime)
prefix="s3://tiledb-johnkerl/s/a/stack-small"
scratch="tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch"
unset AWS_ACCESS_KEY_ID
unset AWS_SECRET_ACCESS_KEY
unset AWS_DEFAULT_REGION
./clingt.py $prefix $scratch/csi-ing-b-prefix-env-no-$stamp
```

`clingt.py`
```
#!/usr/bin/env python

import tiledb.cloud
import tiledb.cloud.soma
import datetime
import sys
import os

input_uri        = "s3://tiledb-johnkerl/s/a/stack-small"
stamp            = datetime.datetime.today().strftime('%Y%m%d-%H%M%S')
output_uri       = f"tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch/csi-{stamp}"
measurement_name = "RNA"
namespace        = "TileDB-Inc"
dry_run          = False

args = sys.argv[1:]

if len(args) >= 1 and args[0] == "-n":
    dry_run = True
    args = args[1:]

if len(args) == 1:
    input_uri  = args[0]
if len(args) == 2:
    input_uri  = args[0]
    output_uri = args[1]

print(input_uri)
print(output_uri)

dikt = tiledb.cloud.soma.run_ingest_workflow(
    output_uri=output_uri,
    input_uri=input_uri,
    measurement_name=measurement_name,
    namespace=namespace,
    access_credentials_name="tiledb-cloud-sandbox-role",
    resources={"cpu": "8", "memory": "32Gi"},
    extra_tiledb_config={"config.logging_level": "5"},
    dry_run=dry_run,
)
print(dikt)
print("https://cloud.tiledb.com/activity/taskgraphs/TileDB-Inc/" + dikt["graph_id"])
```

# Expected behavior

```
$ aws s3 ls s3://tiledb-johnkerl/s/a/stack-small/
2023-08-11 15:37:15      20200 stack1.h5ad
2023-08-11 15:37:15      20200 stack2.h5ad
2023-08-11 15:37:15      20200 stack3.h5ad
2023-08-11 15:37:15      20200 stack4.h5ad
```

Since the prefix provided to `clingt.py` is `s3://tiledb-johnkerl/s/a/stack-small`, I expect one enumerator node to `vfs.ls` that prefix, and four leaves to be launched, one for each `.h5ad` file at that prefix.

# Sample logs

The first one is user-visible, from `clingt.py`, and the second one is linked to from there:

* https://cloud.tiledb.com/compute/logs/taskgraphs/TileDB-Inc/725e8c29-3786-4c57-875e-bca451de5982
* https://cloud.tiledb.com/compute/logs/tasks/aca90987-2a52-47b1-a6a6-5c9d59312d2d

The next one (the enumerator node) can't be found from the ones above. The user has to discover it by searching compute logs :(. The first one is the enumerator (four-point candelabra); the ones after are the four leaves:

* https://cloud.tiledb.com/compute/logs/taskgraphs/TileDB-Inc/77b00b2d-1928-489e-a971-edbccdfa24f6
* https://cloud.tiledb.com/compute/logs/tasks/beaad255-3404-4c84-b8c3-c7d31c529ffe
* https://cloud.tiledb.com/compute/logs/tasks/b4a41857-507a-4506-a38e-c438cd318aaa
* https://cloud.tiledb.com/compute/logs/tasks/2f19b6c5-e112-4118-98b0-f8d4030d061d
* https://cloud.tiledb.com/compute/logs/tasks/2f19b6c5-e112-4118-98b0-f8d4030d061d

# See also

[sc-35137]