### PR TITLE
Access credentials part of function signature

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -22,6 +22,7 @@ def ingest(
     source: Union[Sequence[str], str],
     output: Union[Sequence[str], str],
     config: Mapping[str, Any],
+    access_credentials_name: str,
     *args: Any,
     taskgraph_name: Optional[str] = None,
     num_batches: Optional[int] = None,
@@ -44,6 +45,8 @@ def ingest(
     :param output: uri / iterable of uris of input files.
         If the uri points to a directory of files make sure it ends with a trailing '/'
     :param config: dict configuration to pass on tiledb.VFS
+    :param access_credentials_name: Access Credentials Name (ACN) registered
+        in TileDB Cloud (ARN type)
     :param taskgraph_name: Optional name for taskgraph, defaults to None
     :param num_batches: Number of graph nodes to spawn.
         Performs it sequentially if default, defaults to 1
@@ -306,7 +309,7 @@ def ingest(
         _SUPPORTED_EXTENSIONS,
         *args,
         verbose=verbose,
-        access_credentials_name=kwargs.get("access_credentials_name"),
+        access_credentials_name=access_credentials_name,
         name=f"{dag_name} input collector",
         result_format="json",
     )
@@ -330,6 +333,7 @@ def ingest(
         image_name=DEFAULT_IMG_NAME,
         max_workers=threads,
         compressor=compressor_serial,
+        access_credentials_name=access_credentials_name,
         **kwargs,
     )
 
@@ -339,7 +343,7 @@ def ingest(
             ingest_list_node,
             config=config,
             verbose=verbose,
-            acn=kwargs.get("access_credentials_name"),
+            acn=access_credentials_name,
             namespace=namespace,
             name=f"{dag_name} registrator ",
             expand_node_output=ingest_list_node,


### PR DESCRIPTION
This PR:

- Modifies the signature of the bioimg.ingest function to include the `access_credentials_name`. Till now it was given as a `kwarg`. This create an issue combined with the use of the `as_batch` wrapper, which filters out arguments that cannot be inspected in function signature. 

This PR is considered a hotfix for allowing the deployment of one-click ingestion. In the future we either need to modify the `as_batch` function so it accepts `kwargs` and passed them without filtering them out. Or we should design all the relative ingestion functions with that in mind when they are about to be incorporated in the one-click ingestion UI. Currently another another argument `compressor` will be filtered out too, but it is optional and can be fixed in a next PR.
 