### PR TITLE
Pop instead of getting resources

### DIFF
--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -316,7 +316,7 @@ def as_batch(func: _CT) -> _CT:
         namespace = kwargs.get("namespace", None)
         acn = kwargs.get("acn", kwargs.get("access_credentials_name", None))
         kwargs["acn"] = acn  # for backwards compatibility
-        resources = kwargs.get("resources", None)
+        resources = kwargs.pop("resources", None)
 
         # Create a new DAG
         graph = dag.DAG(


### PR DESCRIPTION
This PR:

- Changes the following:
```bash
-        resources = kwargs.get("resources", None)
+        resources = kwargs.pop("resources", None)
```
The reason is that with `get` the `kwargs` still keep the argument `resources`. When the arguments are filtered based on the inspect function then if the function signature of the `ingest` API call, contains already the `resources` argument, then we get the following error:
`got multiple values for keyword argument 'resources'`
Since it is not filtered out and thus sent twice to the 
```python
graph.submit(
            func,
            *args,
            name=name,
            access_credentials_name=acn,
            resources=resources,
            **_filter_kwargs(func, kwargs),
        )
```

We will eventually need to correct the behaviour of `filter_kwargs` and `wrapper` so it gives more flexibility to the APIs and don't impose constraints like this one, where the resources should not be part of the function's signature in order for it to work properly.

The same applies for `access_credentials_name`, which we are able to bypass (hack) for now, by setting `acn` instead of `access_credentials_name` at the time of the call.  