### PR TITLE
Change name for wrapper function

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -357,4 +357,4 @@ def ingest(
 
 
 # Wrapper function for batch VCF ingestion
-ingest = as_batch(ingest)
+ingest_wrappper = as_batch(ingest)

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -357,4 +357,4 @@ def ingest(
 
 
 # Wrapper function for batch VCF ingestion
-ingest_wrappper = as_batch(ingest)
+ingest_batch = as_batch(ingest)


### PR DESCRIPTION
This PR:


- Decouples the wrapper function for internal usage to the external API of ingest. 