### PR TITLE
Fixing 1-Click ingestion `access_credentials_name` kwargs

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -23,6 +23,7 @@ def ingest(
     output: Union[Sequence[str], str],
     config: Mapping[str, Any],
     *args: Any,
+    access_credentials_name: str,
     taskgraph_name: Optional[str] = None,
     num_batches: Optional[int] = None,
     threads: Optional[int] = 0,
@@ -298,8 +299,7 @@ def ingest(
         ),
     )
 
-    acn = kwargs.pop("access_credentials_name", None)
-    if not acn:
+    if not access_credentials_name:
         raise ValueError(
             "Ingestion graph requires `access_credentials_name` to be set."
         )
@@ -313,7 +313,7 @@ def ingest(
         _SUPPORTED_EXTENSIONS,
         *args,
         verbose=verbose,
-        access_credentials_name=acn,
+        access_credentials_name=access_credentials_name,
         name=f"{dag_name} input collector",
         result_format="json",
     )
@@ -337,7 +337,7 @@ def ingest(
         image_name=DEFAULT_IMG_NAME,
         max_workers=threads,
         compressor=compressor_serial,
-        access_credentials_name=acn,
+        access_credentials_name=access_credentials_name,
         **kwargs,
     )
 
@@ -347,7 +347,7 @@ def ingest(
             ingest_list_node,
             config=config,
             verbose=verbose,
-            acn=acn,
+            acn=access_credentials_name,
             namespace=namespace,
             name=f"{dag_name} registrator ",
             expand_node_output=ingest_list_node,

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -314,7 +314,7 @@ def as_batch(func: _CT) -> _CT:
 
         name = kwargs.get("name", func.__name__)
         namespace = kwargs.get("namespace", None)
-        acn = kwargs.get("acn", kwargs.get("access_credentials_name", None))
+        acn = kwargs.get("acn", kwargs.pop("access_credentials_name", None))
         kwargs["acn"] = acn  # for backwards compatibility
         resources = kwargs.pop("resources", None)
 


### PR DESCRIPTION
This PR:

- modifies the function signature for ingest so `access_credentials_name` is not a positional argument but a kwarg. 
This way the following line in wrapper:
```python
acn = kwargs.get("acn", kwargs.get("access_credentials_name", None))
```
will be allowed to set it in the `acn` variable and feed it to the `func` as a kwarg argument explicitly. Due to the fact that `access_credentials_name` will not be part of the original `ingest` signature the `_filter_kwargs` will filter it out and won't be given as a duplicate argument in the `graph.submit`. Also with this change the `access_credentials_name` will not be a positional argument anymore and thus we will avoid the error from inside the wrapper.
```bash
TypeError: ingest() missing 1 required positional argument: 'access_credentials_name'
```

**The following PR should be tested in staging using the QA notebook.**