### PR TITLE
Improve UX when querying annotation VCFs

### DIFF
--- a/src/tiledb/cloud/vcf/query.py
+++ b/src/tiledb/cloud/vcf/query.py
@@ -298,7 +298,8 @@ def build_read_dag(
     if samples is None:
         raise ValueError(
             "`samples` must be provided in order to partition the query. "
-            'If querying a sample-less annotation VCF (like gnomAD or ClinVar), set `samples=""`'
+            "If querying a sample-less annotation VCF (like gnomAD or ClinVar)"
+            "set `samples=''`"
         )
 
     if regions is None and bed_file is None:

--- a/src/tiledb/cloud/vcf/query.py
+++ b/src/tiledb/cloud/vcf/query.py
@@ -294,10 +294,17 @@ def build_read_dag(
 
     logger = setup(config, verbose)
 
-    # Return an empty table if no samples or regions are specified.
-    # This avoids reading the entire array by accident.
-    if samples is None or (regions is None and bed_file is None):
-        return pa.table({})
+    # Validate inputs
+    if samples is None:
+        raise ValueError(
+            "`samples` must be provided in order to partition the query. "
+            'If querying a sample-less annotation VCF (like gnomAD or ClinVar), set `samples=""`'
+        )
+
+    if regions is None and bed_file is None:
+        raise ValueError(
+            "`regions` or `bed_file` must be provided in order to partition the query."
+        )
 
     attrs = attrs or DEFAULT_ATTRS
 
@@ -309,6 +316,8 @@ def build_read_dag(
         (Delayed, DelayedArrayUDF, DelayedMultiArrayUDF, DelayedSQL),
     ):
         samples = samples.compute().values.flatten()
+    elif isinstance(samples, str):
+        samples = [samples]
 
     # Set number of sample partitions
     num_samples = len(samples)


### PR DESCRIPTION
When querying a sample-less annotation VCF file with `tiledb.cloud.vcf.read`, the `samples` parameter must be provided.

Prior to this PR, the samples had to be provided as a list:
```python
samples=[""],
```

This PR allows the samples to also be provided as a string:
```python
samples="",
```

Input validation is also improved with more useful feedback to the user.