### PR TITLE
Update registration name when multiple files present

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -262,10 +262,15 @@ def ingest(
                 if found:
                     logger.info("Dataset already registered at %r.", tiledb_uri)
                 else:
-                    logger.info("Registering dataset %s at %s", dataset_uri, tiledb_uri)
+                    logger.info(
+                        "Registering dataset %s at %s with name %s",
+                        dataset_uri,
+                        tiledb_uri,
+                        register_map[dataset_uri],
+                    )
                     tiledb.cloud.groups.register(
                         dataset_uri,
-                        name=register_name,
+                        name=register_map[dataset_uri],
                         namespace=namespace,
                         credentials_name=acn,
                     )


### PR DESCRIPTION
This PR:

- Fixes a bug that came up during a batch registration. Although the registration name mapping was being constructed, the registration name was not getting updated according to the mapping. 
- The bug was not visible in the cases where even multiple files are getting registered but each task is being given just one io pair from the previous step.