### PR TITLE
Add pytest-explicit to skip geospatial tests by default.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -88,7 +88,14 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          pip install --upgrade pip wheel pytest pytest-cov setuptools setuptools-scm
+          pip install --upgrade \
+            pip \
+            wheel \
+            pytest \
+            pytest-cov \
+            pytest-explicit \
+            setuptools \
+            setuptools-scm
 
       - name: Install pinned dependencies
         if: ${{ matrix.dependencies == 'pinned' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,14 @@ repository = "https://github.com/TileDB-Inc/TileDB-Cloud-Py"
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
+[tool.pytest.ini_options]
+explicit-only = ["geospatial"]
+markers = [
+  "geospatial: tests that require the geospatial libraries",
+]
+norecursedirs = ["tiledb/cloud"]
+
+
 [tool.setuptools]
 zip-safe = false
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-; only use tests in the `tests` directory; don't look at generated stuff
-norecursedirs = tiledb/cloud


### PR DESCRIPTION
This change adds the `pytest-explicit` pytest plugin, which allows us to mark certain tests as "explicit-only", i.e., they should only be run when specifically requested to. This will initially be used to mark geospatial tests, which require specific libraries to be installed.

---

This is preparation for https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/507.