### PR TITLE
Supporting tiledb-bioimg 0.2.10 new tile_scale arg

### DIFF
--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -41,10 +41,18 @@ def is_folder(path: str) -> bool:
     return path.endswith("/")
 
 
-def validate_io_paths(source: Sequence[str], output: Sequence[str]) -> None:
+def validate_io_paths(
+    source: Sequence[str], output: Sequence[str], register: bool
+) -> None:
     if len(source) == 0 or len(output) == 0:
         raise ValueError("Source/Output list must not be empty.")
 
+    if register:
+        if any(o.startswith("tiledb://") for o in output):
+            raise ValueError(
+                "Invalid value of argument 'register'. \
+                             TileDB URIs require register argument to be set to False"
+            )
     if len(source) == 1 and len(output) == 1:
         if is_folder(source[0]) and not is_folder(output[0]):
             raise ValueError("Invalid combination of source and output paths.")

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -50,8 +50,7 @@ def validate_io_paths(
     if for_registration:
         if any(o.startswith("tiledb://") for o in output):
             raise ValueError(
-                "Invalid value of argument 'register'"
-                "TileDB URIs require register argument to be set to False"
+                "Output sequence contains a tiledb URI and this cannot be re-registered."
             )
     if len(source) == 1 and len(output) == 1:
         if is_folder(source[0]) and not is_folder(output[0]):

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -42,16 +42,16 @@ def is_folder(path: str) -> bool:
 
 
 def validate_io_paths(
-    source: Sequence[str], output: Sequence[str], register: bool
+    source: Sequence[str], output: Sequence[str], *, for_registration: bool
 ) -> None:
     if len(source) == 0 or len(output) == 0:
         raise ValueError("Source/Output list must not be empty.")
 
-    if register:
+    if for_registration:
         if any(o.startswith("tiledb://") for o in output):
             raise ValueError(
-                "Invalid value of argument 'register'. \
-                             TileDB URIs require register argument to be set to False"
+                "Invalid value of argument 'register'"
+                "TileDB URIs require register argument to be set to False"
             )
     if len(source) == 1 and len(output) == 1:
         if is_folder(source[0]) and not is_folder(output[0]):

--- a/src/tiledb/cloud/bioimg/helpers.py
+++ b/src/tiledb/cloud/bioimg/helpers.py
@@ -50,7 +50,8 @@ def validate_io_paths(
     if for_registration:
         if any(o.startswith("tiledb://") for o in output):
             raise ValueError(
-                "Output sequence contains a tiledb URI and this cannot be re-registered."
+                "Output sequence contains a tiledb URI"
+                "and this cannot be re-registered."
             )
     if len(source) == 1 and len(output) == 1:
         if is_folder(source[0]) and not is_folder(output[0]):

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -292,7 +292,7 @@ def ingest(
         )
     source = [source] if isinstance(source, str) else source
     output = [output] if isinstance(output, str) else output
-    validate_io_paths(source, output, register)
+    validate_io_paths(source, output, for_registration=register)
 
     # Build the task graph
     dag_name = taskgraph_name or DEFAULT_DAG_NAME

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -36,6 +36,7 @@ def ingest(
     exclude_metadata: bool = False,
     converter: Optional[str] = None,
     output_ext: str = "",
+    tile_scale: int = 1,
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
     """The function ingests microscopy images into TileDB arrays
@@ -48,13 +49,14 @@ def ingest(
     :param taskgraph_name: Optional name for taskgraph, defaults to None
     :param num_batches: Number of graph nodes to spawn.
         Performs it sequentially if default, defaults to 1
-    :param threads: Number of threads for node side multiprocessing, defaults to 8
+    :param threads: Number of threads for node side multiprocessing, defaults to 0
     :param resources: configuration for node specs e.g. {"cpu": "8", "memory": "4Gi"},
         defaults to None
     :param compute: When True the DAG returned will be computed inside the function
     otherwise DAG will only be returned.
     :param register: When True the ingested images are also being registered under the
-        namespace in which were ingested.
+        namespace in which were ingested. Should be False when tiledb uris are given as
+        destination paths, registration node is merged with the ingestion stage.
     :param mode: By default runs Mode.Batch
     :param namespace: The namespace where the DAG will run
     :param verbose: verbose logging, defaults to False
@@ -64,6 +66,8 @@ def ingest(
         when None the default TIFF converter is used. Available converters
         are one of the ("tiff", "zarr", "osd").
     :param output_ext: extension for the output images in tiledb
+    :param tile_scale: The scaling factor applied to each tile during I/O.
+        Larger scale factors will result in less I/O operations.
     :param access_credentials_name: Access Credentials Name (ACN) registered
         in TileDB Cloud (ARN type)
     """
@@ -155,6 +159,7 @@ def ingest(
         config: Mapping[str, Any],
         verbose: bool,
         exclude_metadata: bool,
+        tile_scale: int,
         converter: str = "tiff",
         *args: Any,
         **kwargs,
@@ -201,6 +206,7 @@ def ingest(
                         converter=user_converter,
                         exclude_metadata=exclude_metadata,
                         verbose=verbose,
+                        tile_scale=tile_scale,
                         **kwargs,
                     )
         return io_uris
@@ -286,7 +292,7 @@ def ingest(
         )
     source = [source] if isinstance(source, str) else source
     output = [output] if isinstance(output, str) else output
-    validate_io_paths(source, output)
+    validate_io_paths(source, output, register)
 
     # Build the task graph
     dag_name = taskgraph_name or DEFAULT_DAG_NAME
@@ -342,6 +348,7 @@ def ingest(
         image_name=DEFAULT_IMG_NAME,
         max_workers=threads,
         compressor=compressor_serial,
+        tile_scale=tile_scale,
         access_credentials_name=access_credentials_name,
         **kwargs,
     )

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -19,9 +19,11 @@ class BioimgTest(unittest.TestCase):
                 ["s3://test_out/b", "s3://test_out/d"],
             ),
         }
-        for test_name, (source, dest) in accepted_pairs.items():
-            with self.subTest(f"case: {test_name}"):
-                validate_io_paths(source, dest)
+        register = {"true": True, "false": False}
+        for _, r in register.items():
+            for test_name, (source, dest) in accepted_pairs.items():
+                with self.subTest(f"case: {test_name}"):
+                    validate_io_paths(source, dest, r)
 
         # Non Accepted cases
         non_accepted_pairs = {
@@ -93,7 +95,44 @@ class BioimgTest(unittest.TestCase):
                 ["s3://test_out/b/"],
             ),
         }
-        for test_name, (source, dest) in non_accepted_pairs.items():
+        for _, r in register.items():
+            for test_name, (source, dest) in non_accepted_pairs.items():
+                with self.subTest(f"case: {test_name}"):
+                    with self.assertRaises(ValueError):
+                        validate_io_paths(source, dest, r)
+
+        # Non accepted register with tiledb uri output
+        non_accepted_pairs_registration_true = {
+            # 1 File -> Output: 1 Folder
+            "test24": (
+                ["s3://test_in/a.tiff"],
+                ["tiledb://test_namespace/s3://test_out/b/"],
+            ),
+            # 1 File -> Output: 1 File
+            "test25": (
+                ["s3://test_in/a.tiff"],
+                ["tiledb://test_namespace/s3://test_out/b"],
+            ),
+            # 1 Folder -> Output: 1 Folder
+            "test26": (
+                ["s3://test_in/a/"],
+                ["tiledb://test_namespace/s3://test_out/b/"],
+            ),
+            # Multiple Files -> Output: Multiple Files (Matching number)
+            "test27": (
+                ["s3://test_in/a.tiff", "s3://test_in/c.tiff"],
+                ["s3://test_out/b", "tiledb://test_namespace/s3://test_out/d"],
+            ),
+        }
+
+        # Fail on register=True
+        for test_name, (source, dest) in non_accepted_pairs_registration_true.items():
             with self.subTest(f"case: {test_name}"):
                 with self.assertRaises(ValueError):
-                    validate_io_paths(source, dest)
+                    print(test_name)
+                    validate_io_paths(source, dest, register["true"])
+
+        # Pass on register=False
+        for test_name, (source, dest) in non_accepted_pairs_registration_true.items():
+            with self.subTest(f"case: {test_name}"):
+                validate_io_paths(source, dest, register["false"])

--- a/tests/test_bioimg.py
+++ b/tests/test_bioimg.py
@@ -19,11 +19,10 @@ class BioimgTest(unittest.TestCase):
                 ["s3://test_out/b", "s3://test_out/d"],
             ),
         }
-        register = {"true": True, "false": False}
-        for _, r in register.items():
+        for register in (True, False):
             for test_name, (source, dest) in accepted_pairs.items():
                 with self.subTest(f"case: {test_name}"):
-                    validate_io_paths(source, dest, r)
+                    validate_io_paths(source, dest, for_registration=register)
 
         # Non Accepted cases
         non_accepted_pairs = {
@@ -95,11 +94,11 @@ class BioimgTest(unittest.TestCase):
                 ["s3://test_out/b/"],
             ),
         }
-        for _, r in register.items():
+        for register in (True, False):
             for test_name, (source, dest) in non_accepted_pairs.items():
                 with self.subTest(f"case: {test_name}"):
                     with self.assertRaises(ValueError):
-                        validate_io_paths(source, dest, r)
+                        validate_io_paths(source, dest, for_registration=register)
 
         # Non accepted register with tiledb uri output
         non_accepted_pairs_registration_true = {
@@ -130,9 +129,9 @@ class BioimgTest(unittest.TestCase):
             with self.subTest(f"case: {test_name}"):
                 with self.assertRaises(ValueError):
                     print(test_name)
-                    validate_io_paths(source, dest, register["true"])
+                    validate_io_paths(source, dest, for_registration=True)
 
         # Pass on register=False
         for test_name, (source, dest) in non_accepted_pairs_registration_true.items():
             with self.subTest(f"case: {test_name}"):
-                validate_io_paths(source, dest, register["false"])
+                validate_io_paths(source, dest, for_registration=False)


### PR DESCRIPTION
This PR:

- Introduces a new argument to the bioimg ingestor for supporting the tiledb-bioimg [0.2.10](https://github.com/TileDB-Inc/TileDB-BioImaging/releases/tag/v0.2.10). The latter will allow a more efficient way to ingest + register using TileDB URI directly at the ingestion stage. 
- This change requires the update of TileDB-Bioimg package to UDF docker images and JupyterHub from 0.2.9 to 0.2.10.