### PR TITLE
Adding supported extension for ndpi files

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -14,7 +14,7 @@ from tiledb.cloud.utilities._common import run_dag
 DEFAULT_RESOURCES = {"cpu": "8", "memory": "4Gi"}
 DEFAULT_IMG_NAME = "3.9-imaging-dev"
 DEFAULT_DAG_NAME = "bioimg-ingestion"
-_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs")
+_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".ndpi")
 _SUPPORTED_CONVERTERS = ("tiff", "zarr", "osd")
 
 


### PR DESCRIPTION
This PR:

- Extends ingestion support for `.ndpi` images via cloud ingestor.

**Important**. This PR heavily **depends** on the deployment of a new TileDB-Py version, which will include https://github.com/TileDB-Inc/TileDB-Py/pull/1915