### PR TITLE
Enable renaming in bioimg exporter

### DIFF
--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -78,17 +78,14 @@ def export(
 
         def create_output_path(input_file: str, output: str) -> str:
             # Check if output is dir
-            if output.endswith("/"):
-                filename = os.path.splitext(os.path.basename(input_file))[0]
-                output_filename = (
-                    filename + f".{output_ext}" if output_ext else filename
-                )
-                return os.path.join(output, output_filename)
-            else:
+            if not output.endswith("/"):
                 # The output is considered a target file
                 return output
+            filename = os.path.splitext(os.path.basename(input_file))[0]
+            output_filename = f"{filename}.{output_ext}" if output_ext else filename
+            return os.path.join(output, output_filename)
 
-        def iter_paths(source: Sequence, output: Sequence[str]) -> Iterator[Tuple]:
+        def iter_paths(source: Sequence[str], output: Sequence[str]) -> Iterator[Tuple]:
             if len(output) != 1:
                 for s, o in zip(source, output):
                     if tiledb.object_type(s) == "group":
@@ -127,14 +124,14 @@ def export(
         uri_pairs = build_io_uris_exportation(source, output, out_ext, logger)
         # If the user didn't specify a number of batches, run every import
         # as its own task.
-        logger.debug(f"Input batches:{uri_pairs}")
-        logger.debug(f"The io pairs for ingestion: {uri_pairs}")
+        logger.debug("Input batches: %s", uri_pairs)
+        logger.debug("The io pairs for ingestion: %s:", uri_pairs)
         my_num_batches = num_batches or len(uri_pairs)
         # If they specified too many batches, don't create empty tasks.
         my_num_batches = min(len(uri_pairs), my_num_batches)
-        logger.debug(f"Number of batches:{my_num_batches}")
+        logger.debug("Number of batches: %s", my_num_batches)
         split_batches = [uri_pairs[n::my_num_batches] for n in range(my_num_batches)]
-        logger.debug(f"Split batches:{split_batches}")
+        logger.debug("Split batches: %s", split_batches)
         return split_batches
 
     def export_tiff_udf(

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -101,7 +101,9 @@ def export(
                         # Folder for exploration
                         contents = vfs.ls(s)
                         # Explore folders only at depth 1
-                        filtered_contents = [c for c in contents if not vfs.is_dir(c)]
+                        filtered_contents = [
+                            c for c in contents if tiledb.object_type(c) == "group"
+                        ]
                         yield from iter_paths(filtered_contents, output)
                     else:
                         logger.debug("Pair %s and %s", s, output[0])
@@ -129,9 +131,9 @@ def export(
         my_num_batches = num_batches or len(uri_pairs)
         # If they specified too many batches, don't create empty tasks.
         my_num_batches = min(len(uri_pairs), my_num_batches)
-        logger.debug("Number of batches: %s", my_num_batches)
+        logger.debug("Number of batches: %r", my_num_batches)
         split_batches = [uri_pairs[n::my_num_batches] for n in range(my_num_batches)]
-        logger.debug("Split batches: %s", split_batches)
+        logger.debug("Split batches: %r", split_batches)
         return split_batches
 
     def export_tiff_udf(

--- a/src/tiledb/cloud/bioimg/exportation.py
+++ b/src/tiledb/cloud/bioimg/exportation.py
@@ -55,7 +55,10 @@ def export(
     :param output_ext: extension for the output images in tiledb
 
     """
-
+    if not access_credentials_name:
+        raise ValueError(
+            "Ingestion graph requires `access_credentials_name` to be set."
+        )
     logger = get_logger_wrapper(verbose)
     logger.debug("Exporting files: %s", source)
     max_workers = None if num_batches else 20  # Default picked heuristically.
@@ -187,11 +190,6 @@ def export(
             retry_policy="Always",
         ),
     )
-
-    if not access_credentials_name:
-        raise ValueError(
-            "Ingestion graph requires `access_credentials_name` to be set."
-        )
 
     # The lister doesn't need many resources.
     input_list_node = graph.submit(


### PR DESCRIPTION
This PR:

- Replicates the logic of `bioimg.ingest` for allowing renaming of files during exportation.
- Adds `access_credentials_name` as a keyword argument and not as arbitrary
- Adds the `verbose` argument and activates a logger for internal UDFs
- Updates the name of `export_udf` to `export_batch` using the `as_batch`