### PR TITLE
Fix issue with VCF query using BED file

### DIFF
--- a/src/tiledb/cloud/vcf/query.py
+++ b/src/tiledb/cloud/vcf/query.py
@@ -361,6 +361,7 @@ def build_read_dag(
                     config=config,
                     attrs=attrs,
                     regions=regions,
+                    bed_file=bed_file,
                     region_partition=(region, num_region_partitions),
                     sample_partition=(sample, num_sample_partitions),
                     memory_budget_mb=memory_budget_mb,


### PR DESCRIPTION
Fix an issue where the BED file URI was not being passed all the way to `vcf_query_udf`.