### PR TITLE
Add DAG._find_leaf_nodes helper

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1139,6 +1139,13 @@ class DAG:
 
         return roots
 
+    def _find_leaf_nodes(self):
+        """
+        Find all leaf nodes
+        :return: list of leaf nodes
+        """
+        return [n for n in self.nodes.values() if not n.children]
+
     def compute(self):
         """
         Start the DAG by executing root nodes


### PR DESCRIPTION
This function is helpful for returning the leaves for the DAG. Its effectively the opposite of `_find_root_nodes`. It can be helpful for users that want to add a new node(s) that depend on the current leaves.