### PR TITLE
Graph should not be returned when computed

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -386,7 +386,8 @@ def ingest(
         )
     if compute:
         run_dag(graph, debug=verbose)
-    return graph
+    else:
+        return graph
 
 
 # Wrapper function for batch VCF ingestion


### PR DESCRIPTION
This PR:

- Adds an `else` statement in ingestion function avoiding the need to `pickle` the results of the ingestion function, when the latter is wrapped with `as_batch` and called as `ingest_batch`. The error comes from the fact that the results of a UDF are serialized to return. The DAG returned before the change is not serializable though as it contains  `_thread.lock` object.
- The change does NOT break the API - used by customers -  since the graph is getting is still returned when the `compute` arg is set to `False`. It will only require for the caller of the `ingest_batch` function to set `compute=True` to follow the correct code path.
- Fixes the following error:
```bash
Unexpected error in the UDF environment:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/tdbudf/batch_udf_main.py", line 359, in main
    ret = real_main()
  File "/opt/conda/lib/python3.9/site-packages/tdbudf/batch_udf_main.py", line 351, in real_main
    _serialize(result, result_format, expand_output, stage_part_id)
  File "/opt/conda/lib/python3.9/site-packages/tdbudf/batch_udf_main.py", line 96, in _serialize
    serialized_tgargs = _serialize_to_tgargs(result, result_format)
  File "/opt/conda/lib/python3.9/site-packages/tdbudf/batch_udf_main.py", line 52, in _serialize_to_tgargs
    cloudpickle.dumps(result, protocol=_PICKLE_PROTOCOL)
  File "/opt/conda/lib/python3.9/site-packages/cloudpickle/cloudpickle_fast.py", line 73, in dumps
    cp.dump(obj)
  File "/opt/conda/lib/python3.9/site-packages/cloudpickle/cloudpickle_fast.py", line 632, in dump
    return Pickler.dump(self, obj)
TypeError: cannot pickle '_thread.lock' object
```