### PR TITLE
Support max_workers in Delayed API

### DIFF
--- a/src/tiledb/cloud/compute/delayed.py
+++ b/src/tiledb/cloud/compute/delayed.py
@@ -49,7 +49,10 @@ class DelayedBase(Node):
         self.timeout = timeout
 
     def compute(
-        self, namespace: Optional[str] = None, name: Optional[str] = None
+        self,
+        namespace: Optional[str] = None,
+        name: Optional[str] = None,
+        max_workers: Optional[int] = None,
     ) -> Any:
         """
         Starts execution of all Delayed tasks associated with this node.
@@ -64,7 +67,7 @@ class DelayedBase(Node):
             if self.mode == Mode.LOCAL:
                 mode = Mode.REALTIME
             self.__set_all_parent_nodes_same_dag(
-                DAG(namespace=namespace, name=name, mode=mode)
+                DAG(namespace=namespace, name=name, mode=mode, max_workers=max_workers)
             )
         else:
             if namespace is not None:


### PR DESCRIPTION
The `Delayed` API did not support the `max_workers` parameter.  It should be supported so users can pass this parameter at compute time when the DAG is created.