### PR TITLE
Support ingestion of unzipped VCF files

### DIFF
--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -274,7 +274,9 @@ def process_stream(
 
     vfs = tiledb.VFS(config=config)
 
-    output_fp = vfs.open(output_uri, "wb") if output_uri else None
+    # If output_uri is defined, open the URI with VFS, otherwise open /dev/null.
+    # We need to open something to add to the following context manager.
+    output_fp = vfs.open(output_uri, "wb") if output_uri else open("/dev/null", "wb")
 
     # Including output_fp in the context manager is needed when writing to s3
     with vfs.open(uri) as input_fp, output_fp:

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -276,7 +276,8 @@ def process_stream(
 
     output_fp = vfs.open(output_uri, "wb") if output_uri else None
 
-    with vfs.open(uri) as input_fp:
+    # Including output_fp in the context manager is needed when writing to s3
+    with vfs.open(uri) as input_fp, output_fp:
         with subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -341,9 +342,6 @@ def process_stream(
             # Retrieve results
             stdout = stdout_future.result()
             stderr = stderr_future.result()
-
-            if output_fp:
-                output_fp.close()
 
             return rc, stdout, stderr
 

--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -81,6 +81,7 @@ def install_wheel(
     wheel_uri: str,
     config: Optional[Mapping[str, Any]] = None,
     verbose: bool = False,
+    no_deps: bool = True,
 ):
     """
     THIS IS AN EXPERIMENTAL API. IT MAY CHANGE IN THE FUTURE.
@@ -90,6 +91,7 @@ def install_wheel(
     :param wheel_uri: URI of the wheel file
     :param config: config dictionary, defaults to None
     :param verbose: verbose output, defaults to False
+    :param no_deps: do not install dependencies, defaults to True
     """
 
     with tiledb.scope_ctx(config):
@@ -109,6 +111,8 @@ def install_wheel(
             cmd = [sys.executable, "-m", "pip", "install", "--force-reinstall"]
             if not in_venv:
                 cmd += ["--user"]
+            if no_deps:
+                cmd += ["--no-deps"]
             cmd += [wheel_path]
 
             # Capture stdout/stderr to reduce noise from pip for a successful install.

--- a/src/tiledb/cloud/vcf/__init__.py
+++ b/src/tiledb/cloud/vcf/__init__.py
@@ -6,12 +6,12 @@ from .ingestion import ingest_annotations
 from .ingestion import register_dataset_udf as register_dataset
 from .query import build_read_dag
 from .query import read
-from .utils import bgzip_and_index
 from .utils import create_index_file
 from .utils import find_index
 from .utils import get_record_count
 from .utils import get_sample_name
 from .utils import is_bgzipped
+from .utils import sort_and_bgzip
 
 __all__ = [
     "Contigs",
@@ -22,7 +22,7 @@ __all__ = [
     "build_read_dag",
     "read",
     "read_allele_frequency",
-    "bgzip_and_index",
+    "sort_and_bgzip",
     "create_index_file",
     "find_index",
     "get_sample_name",


### PR DESCRIPTION
Add support for ingesting VCF files that are not bgzipped. Any raw VCF files will be sorted, bgzipped, and indexed as part of the ingestion process.

A temporary copy of the bgzipped VCF file is stored on the UDF node or in a `tmp` subdirectory of the VCF dataset being created. This behavior is controlled by the `use_remote_tmp` parameter.

`use_remote_tmp=False` is the default and preferred for small VCF files, to avoid the overhead of writing the bgzipped VCF to remote storage.

**Note**: this PR includes unrelated UX improvements to the experimental wheel upload and install code.