### PR TITLE
File ingestion fixes

### DIFF
--- a/src/tiledb/cloud/file_ingestion/ingestion.py
+++ b/src/tiledb/cloud/file_ingestion/ingestion.py
@@ -161,8 +161,15 @@ def ingest_files_udf(
             array_info = info(array_uri)
             ingested.append(array_info.tiledb_uri)
         except tiledb_cloud_error.TileDBCloudError as exc:
-            if "array already exists at location - Code: 8003" in repr(exc):
+            error_msg = repr(exc)
+            if "array already exists at location - Code: 8003" in error_msg:
                 logger.warning(f"Array '{array_uri}' already exists.")
+                continue
+            elif f"array {array_uri} is not unique" in error_msg:
+                logger.warning(
+                    f"Array URI {array_uri} is not unique. "
+                    f"Skipping {filename} ingestion"
+                )
                 continue
             else:
                 raise exc

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -59,7 +59,8 @@ class TestFiles(unittest.TestCase):
         self.__cleanup_residual_test_arrays(array_uris=self.ingested_array_uris)
         return super().tearDown()
 
-    def __cleanup_residual_test_arrays(self, array_uris: List[str]) -> None:
+    @staticmethod
+    def __cleanup_residual_test_arrays(array_uris: List[str]) -> None:
         """Deletes every array in a list"""
         for array_uri in array_uris:
             try:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -132,7 +132,7 @@ class TestFiles(unittest.TestCase):
         add_arrays_to_group_udf(
             array_uris=ingested_uris,
             namespace=self.namespace,
-            register_name=self.group_name,
+            register_name=self.group_uri,
             config=client.Ctx().config().dict(),
         )
 
@@ -144,11 +144,20 @@ class TestFiles(unittest.TestCase):
             self.assertEqual(array_info.name, fname)
             self.assertEqual(array_info.namespace, self.namespace)
 
-    def test_files_ingestion_udf_into_bad_group_uri_raises(self):
+    def test_add_array_to_group_udf_raises_not_implemented_error(self):
+        with self.assertRaises(NotImplementedError):
+            add_arrays_to_group_udf(
+                array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
+                namespace=self.namespace,
+                register_name="register-group-name",
+                config=client.Ctx().config().dict(),
+            )
+
+    def test_add_array_to_group_udf_raises_bad_namespace_error(self):
         with self.assertRaises(tiledb.TileDBError):
             add_arrays_to_group_udf(
                 array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
                 namespace="very-bad-namespace",
-                register_name="bad-group",
+                register_name=self.group_uri,
                 config=client.Ctx().config().dict(),
             )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -61,7 +61,8 @@ class TestFiles(unittest.TestCase):
                 "test_filename_with_spaces.txt",
             ),
             "test_3": ("test,filename,with,commas.txt", "testfilenamewithcommas.txt"),
-            "test_4": ("test_mixed, file  name.pdf", "test_mixed_file__name.pdf"),
+            "test_4": ("test._m'ixed, file  .name.pdf", "test_mixed_file_name.pdf"),
+            "test_5": ("O'Reilly_-_Python_Cookbook.pdf", "OReilly_Python_Cookbook.pdf"),
         }
 
         for test_name, (fname, sanitized) in subjects.items():


### PR DESCRIPTION
Fixes in the file ingestion process, discovered during testing:
- Improved sanitization of filenames to remove non allowed special characters and spaces.
- Replace `register_name` for `group_uri` of an existing group.
- Fixed a race condition in the tests when using multiple workers to execute them