### PR TITLE
Fix Tasks API mismatch between client and server for array parameter

### DIFF
--- a/src/tiledb/cloud/tasks.py
+++ b/src/tiledb/cloud/tasks.py
@@ -82,7 +82,8 @@ def tasks(
         raise Exception("status must be one of ['FAILED', 'RUNNING', 'COMPLETED']")
 
     if array is not None:
-        (namespace, array) = utils.split_uri(array)
+        # API expects array as URI. Extracting namespace only for usage.
+        namespace, _ = utils.split_uri(array)
 
     try:
         args = {"async_req": async_req}


### PR DESCRIPTION
The server expects `array` to be a TileDB URI, but in the `tasks.tasks` method, if the `array` param was present, it was overwritten by the array name isntead, causing an error response:
`TileDBCloudError: unable to determine array namespace/name from URI (expected "tiledb://<namespace>/<name>"): quickstart_sparse - Code: 24`
 