### PR TITLE
Add the VCF analysis toolbox module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,21 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 
 dependencies = [
-  "attrs>=21.4.0",
-  "certifi",
-  "cloudpickle>=1.4.1,<3",
-  "importlib-metadata",
-  "packaging",
-  "pandas>=1.2.4",
-  "pyarrow>=3.0.0",
-  "python-dateutil",
-  "six>=1.10",
-  # Not directly used on the client, but some server-side environments have
-  # tblib transitively enabled, so this is needed for unpickling.
-  "tblib~=1.7",
-  "tiledb>=0.15.2",
-  "typing-extensions",
-  "urllib3>=1.26",
+    "attrs>=21.4.0",
+    "certifi",
+    "cloudpickle>=1.4.1,<3",
+    "importlib-metadata",
+    "packaging",
+    "pandas>=1.2.4",
+    "pyarrow>=3.0.0",
+    "python-dateutil",
+    "six>=1.10",
+    # Not directly used on the client, but some server-side environments have
+    # tblib transitively enabled, so this is needed for unpickling.
+    "tblib~=1.7",
+    "tiledb>=0.15.2",
+    "typing-extensions",
+    "urllib3>=1.26",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,21 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 
 dependencies = [
-    "attrs>=21.4.0",
-    "certifi",
-    "cloudpickle>=1.4.1,<3",
-    "importlib-metadata",
-    "packaging",
-    "pandas>=1.2.4",
-    "pyarrow>=3.0.0",
-    "python-dateutil",
-    "six>=1.10",
-    # Not directly used on the client, but some server-side environments have
-    # tblib transitively enabled, so this is needed for unpickling.
-    "tblib~=1.7",
-    "tiledb>=0.15.2",
-    "typing-extensions",
-    "urllib3>=1.26",
+  "attrs>=21.4.0",
+  "certifi",
+  "cloudpickle>=1.4.1,<3",
+  "importlib-metadata",
+  "packaging",
+  "pandas>=1.2.4",
+  "pyarrow>=3.0.0",
+  "python-dateutil",
+  "six>=1.10",
+  # Not directly used on the client, but some server-side environments have
+  # tblib transitively enabled, so this is needed for unpickling.
+  "tblib~=1.7",
+  "tiledb>=0.15.2",
+  "typing-extensions",
+  "urllib3>=1.26",
 ]
 
 [project.optional-dependencies]
@@ -40,9 +40,10 @@ repository = "https://github.com/TileDB-Inc/TileDB-Cloud-Py"
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.pytest.ini_options]
-explicit-only = ["geospatial"]
+explicit-only = ["geospatial", "vcf"]
 markers = [
   "geospatial: tests that require the geospatial libraries",
+  "vcf: VCF tests that run on TileDB Cloud",
 ]
 norecursedirs = ["tiledb/cloud"]
 

--- a/src/tiledb/cloud/vcf/vcf_toolbox/__init__.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/__init__.py
@@ -1,0 +1,14 @@
+import sys
+
+import cloudpickle
+
+from .annotate import annotate
+from .transform import df_transform
+
+__all__ = [
+    "annotate",
+    "df_transform",
+]
+
+# Register the module to be pickled by value
+cloudpickle.register_pickle_by_value(sys.modules[__name__])

--- a/src/tiledb/cloud/vcf/vcf_toolbox/__init__.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/__init__.py
@@ -10,5 +10,9 @@ __all__ = [
     "df_transform",
 ]
 
-# Register the module to be pickled by value
+# Register the module to be pickled by value, so we can use this version of the
+# module in a UDF. Otherwise, the module would be pickled by reference, and we
+# would use the version of module installed in the UDF docker image.
+# This approach enables testing changes to the module before the changes are
+# available in the UDF docker image.
 cloudpickle.register_pickle_by_value(sys.modules[__name__])

--- a/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
@@ -76,8 +76,7 @@ def zygosity(gt: Tuple[int, int]) -> str:
         return str(gt)
 
 
-@df_transform
-def annotate(
+def _annotate(
     vcf_df: pd.DataFrame,
     *,
     ann_uri: str,
@@ -223,3 +222,6 @@ def annotate(
     log_event("total annotation time", t_start)
 
     return vcf_df
+
+
+annotate = df_transform(_annotate)

--- a/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
@@ -1,0 +1,180 @@
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pandas as pd
+
+import tiledb
+from tiledb.cloud.utilities import get_logger
+from tiledb.cloud.utilities import max_memory_usage
+
+from .transform import df_transform
+
+
+def split_region(region):
+    if not isinstance(region, str) or ":" not in region or "-" not in region:
+        raise ValueError("Region must be in the format 'contig:start-end'")
+    contig, range = region.split(":")
+    start, end = range.split("-")
+    return contig, slice(int(start), int(end))
+
+
+def split_regions(regions):
+    if isinstance(regions, str):
+        regions = [regions]
+
+    contig = None
+    ranges = []
+    for region in regions:
+        c, r = split_region(region)
+        if contig is None:
+            contig = c
+        elif contig != c:
+            raise ValueError("All regions must be in the same contig")
+        ranges.append(r)
+
+    return contig, ranges
+
+
+def zygosity(x):
+    if tuple(x) == tuple([0, 0]):
+        return "HOM_REF"
+    if tuple(x) == tuple([".", "."]):
+        return "UNKNOWN"
+    # check for any tuple where any element is 0
+    elif len(tuple(x)) == 2 and (tuple(x)[0] == 0 or tuple(x)[1] == 0):
+        return "HET"
+    elif tuple(x)[0] != 0 and tuple(x)[1] != 0:
+        return "HOM_ALT"
+    elif len(tuple(x)) == 1 and tuple(x)[0] != 0:
+        return "HEMI"
+    else:
+        return str(x)
+
+
+@df_transform
+def annotate(
+    vcf_df,
+    *,
+    ann_uri,
+    ann_attrs,
+    ann_regions,
+    vcf_filter=None,
+    add_zygosity=False,
+    reorder=["sample_name", "contig", "pos_start", "ref", "alt"],
+    rename={"sample_name": "sample", "contig": "chrom", "pos_start": "pos"},
+    verbose=False,
+):
+    """
+    Annotate a VCF DataFrame with annotations from a TileDB array.
+
+    Parameters
+    ----------
+    vcf_df
+        The input VCF DataFrame, passed in automatically by `tiledb.cloud.vcf.query`.
+    ann_uri
+        The URI of the annotation array.
+    ann_attrs
+        The attributes to query.
+    ann_regions
+        The regions to query. All regions must be in the same chromosome/contig.
+    vcf_filter, optional
+        A pandas filter to apply to the VCF DataFrame before annotation, by default None
+    add_zygosity, optional
+        Add a zygosity column to the DataFrame, by default False
+    reorder, optional
+        List of columns to reorder, by default
+            ["sample_name", "contig", "pos_start", "ref", "alt"]
+    rename, optional
+        Dict of columns to rename, by default
+            {"sample_name": "sample", "contig": "chrom", "pos_start": "pos"}
+    verbose, optional
+        Enable verbose logging, by default False
+
+    Returns
+    -------
+        The annotated VCF DataFrame.
+    """
+
+    if isinstance(ann_attrs, str):
+        ann_attrs = [ann_attrs]
+
+    # Add attributes required for join
+    for attr in ["ref", "alt"]:
+        if attr not in ann_attrs:
+            ann_attrs.append(attr)
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logger = get_logger(level)
+
+    def log_event(message, t_prev=None):
+        if t_prev:
+            message += f" {time.time() - t_prev:.3f} sec"
+        logger.debug(message)
+        return time.time()
+
+    t_prev = log_event("start annotation")
+    t_start = t_prev
+    mem_start = max_memory_usage()
+
+    # Split regions
+    contig, regions = split_regions(ann_regions)
+
+    # Start annotation query
+    def read_ann():
+        with tiledb.open(ann_uri) as A:
+            df = A.query(attrs=ann_attrs).df[contig, regions]
+        return df
+
+    executor = ThreadPoolExecutor(1)
+    ann_future = executor.submit(read_ann)
+
+    # Filter the VCF data
+    if vcf_filter:
+        vcf_df = vcf_df.query(vcf_filter).reset_index(drop=True)
+        t_prev = log_event("filter", t_prev)
+
+    # Return if the filtered VCF data is empty
+    if len(vcf_df) == 0:
+        return vcf_df
+
+    # Split alleles into ref and alt
+    vcf_df["ref"] = vcf_df["alleles"].str[0]
+    vcf_df["alt"] = vcf_df["alleles"].apply(lambda x: ",".join(x[1:]))
+    vcf_df = vcf_df.drop("alleles", axis=1)
+    t_prev = log_event("split ref/alt", t_prev)
+
+    # Add zygosity
+    if add_zygosity:
+        vcf_df["zygosity"] = vcf_df["fmt_GT"].apply(zygosity)
+        t_prev = log_event("add zygosity", t_prev)
+
+    # Wait for annotation query
+    ann_df = ann_future.result()
+    t_prev = log_event("wait on annotation query", t_prev)
+
+    # Merge VCF and annotations
+    vcf_df = pd.merge(
+        ann_df,
+        vcf_df,
+        how="inner",
+        left_on=["contig", "pos_start", "ref", "alt"],
+        right_on=["contig", "pos_start", "ref", "alt"],
+    )
+    t_prev = log_event("join", t_prev)
+
+    # Reorder columns
+    if reorder:
+        ordered_columns = reorder + [c for c in vcf_df.columns if c not in reorder]
+        vcf_df = vcf_df[ordered_columns]
+
+    # Rename columns
+    if rename:
+        vcf_df = vcf_df.rename(columns=rename)
+
+    annotation_mem_gib = (max_memory_usage() - mem_start) / (1 << 30)
+    logger.debug(f"annotation memory usage: {annotation_mem_gib:.3f} GiB")
+    logger.debug(f"max memory usage: {max_memory_usage() / (1<<30):.3f} GiB")
+    log_event("total annotation time", t_start)
+
+    return vcf_df

--- a/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
@@ -78,7 +78,7 @@ def zygosity(gt: Tuple[int, int]) -> str:
 
 @df_transform
 def annotate(
-    vcf_df: str,
+    vcf_df: pd.DataFrame,
     *,
     ann_uri: str,
     ann_regions: Union[str, Sequence[str]],
@@ -98,14 +98,14 @@ def annotate(
         "pos_start": "pos",
     },
     verbose: bool = False,
-):
+) -> pd.DataFrame:
     """
     Annotate a VCF DataFrame with annotations from a TileDB array.
 
     Parameters
     ----------
     vcf_df
-        The input VCF DataFrame, passed in automatically by `tiledb.cloud.vcf.query`.
+        The input VCF DataFrame.
     ann_uri
         The URI of the annotation array.
     ann_regions

--- a/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
@@ -1,0 +1,61 @@
+import functools
+
+import pyarrow as pa
+
+
+def _df_transform_result(table: pa.Table, fn) -> pa.Table:
+    # Return if the table is empty
+    if table.num_rows == 0:
+        return table
+
+    # Store the original schema
+    original_schema = table.schema
+
+    # Convert arrow table to pandas
+    df = table.to_pandas()
+
+    # Run user-defined transform function
+    df = fn(df)
+
+    # Convert the DataFrame back to a table
+    result = pa.Table.from_pandas(df)
+
+    # Cast the columns to the original data types because pandas may change the
+    # column type for partitions where the results are all null.
+    for field in original_schema:
+        if field.name in result.column_names:
+            result = result.set_column(
+                result.column_names.index(field.name),
+                field.name,
+                pa.array(result.column(field.name).to_pandas(), type=field.type),
+            )
+
+    return result
+
+
+def df_transform(fn):
+    """
+    A function decorator that allows users to create a user-defined function to
+    transform a pandas dataframe. The decorated function can be passed directly
+    to the `transform_result` parameter of the `tiledb.cloud.vcf.query` function.
+
+    Parameters
+    ----------
+    fn
+        The user-defined function that takes a pandas dataframe as input and
+        returns a pandas dataframe.
+
+    Returns
+    -------
+        A function than can be passed to the `transform_result` parameter of the
+        `tiledb.cloud.vcf.query` function.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return functools.partial(
+            _df_transform_result,
+            fn=functools.partial(fn, *args, **kwargs),
+        )
+
+    return wrapper

--- a/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
@@ -1,9 +1,19 @@
 import functools
+from typing import Callable, TypeVar
 
 import pyarrow as pa
 
 
 def _df_transform_result(table: pa.Table, fn) -> pa.Table:
+    """
+    Transform the pyarrow table using a user-defined function that operates on
+    a pandas dataframe.
+
+    :param table: pyarrow table
+    :param fn: user-defined function to transform the pandas dataframe
+    :return: pyarrow table
+    """
+
     # Return if the table is empty
     if table.num_rows == 0:
         return table
@@ -33,7 +43,10 @@ def _df_transform_result(table: pa.Table, fn) -> pa.Table:
     return result
 
 
-def df_transform(fn):
+_CT = TypeVar("_CT", bound=Callable)
+
+
+def df_transform(fn: _CT) -> _CT:
     """
     A function decorator that allows users to create a user-defined function to
     transform a pandas dataframe. The decorated function can be passed directly

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -4,8 +4,50 @@ import tiledb.cloud.vcf as vcf
 import tiledb.cloud.vcf.vcf_toolbox as vtb
 
 
+@vtb.df_transform
+def filter_vcf(df, *, filter=None):
+    return df.query(filter)
+
+
 @pytest.mark.vcf
-def test_vcf_annotation():
+def test_vcf_transform():
+    vcf_uri = "tiledb://TileDB-Inc/vcf-1kg-dragen-v376"
+
+    regions = [
+        "chr21:26973732-27213386",  # APP (Amyloid Beta Precursor Protein)
+    ]
+
+    # VCF attributes to read
+    vcf_attrs = [
+        "sample_name",
+        "contig",
+        "pos_start",
+        "alleles",
+        "fmt_DP",
+        "fmt_GQ",
+        "fmt_GT",
+    ]
+
+    # Filter to apply to VCF data
+    filter = "fmt_DP > 20 and fmt_GQ > 25"
+
+    # Run the VCF query with the transform function
+    vcf_table = vcf.read(
+        dataset_uri=vcf_uri,
+        attrs=vcf_attrs,
+        regions=regions,
+        samples="NA12878",
+        transform_result=filter_vcf(filter=filter),
+    )
+
+    assert vcf_table.num_rows == 336
+
+
+@pytest.mark.vcf
+@pytest.mark.parametrize(
+    "split_multiallelic,expected_rows", [(False, 336), (True, 340)]
+)
+def test_vcf_annotation(split_multiallelic, expected_rows):
     vcf_uri = "tiledb://TileDB-Inc/vcf-1kg-dragen-v376"
 
     regions = [
@@ -50,6 +92,7 @@ def test_vcf_annotation():
         ann_regions=regions,
         vcf_filter=vcf_filter,
         add_zygosity=add_zygosity,
+        split_multiallelic=split_multiallelic,
     )
 
     # Run the VCF query with annotation
@@ -61,4 +104,4 @@ def test_vcf_annotation():
         transform_result=transform_result,
     )
 
-    assert vcf_table.num_rows == 557
+    assert vcf_table.num_rows == expected_rows

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -41,13 +41,20 @@ def test_vcf_transform():
     )
 
     assert vcf_table.num_rows == 336
+    assert vcf_table.num_columns == 8
 
 
 @pytest.mark.vcf
 @pytest.mark.parametrize(
-    "split_multiallelic,expected_rows", [(False, 336), (True, 340)]
+    "split_multiallelic,attr_list,expected_rows,expected_columns",
+    [(False, True, 336, 13), (True, False, 340, 51)],
 )
-def test_vcf_annotation(split_multiallelic, expected_rows):
+def test_vcf_annotation(
+    split_multiallelic,
+    attr_list,
+    expected_rows,
+    expected_columns,
+):
     vcf_uri = "tiledb://TileDB-Inc/vcf-1kg-dragen-v376"
 
     regions = [
@@ -75,15 +82,7 @@ def test_vcf_annotation(split_multiallelic, expected_rows):
     ann_uri = "tiledb://tiledb-genomics-dev/vep_20230726_6"
 
     # Annotation attributes to read
-    ann_attrs = [
-        "SYMBOL",
-        "Gene",
-        "Feature",
-        "VARIANT_CLASS",
-        "Consequence",
-        "Codons",
-        "Amino_acids",
-    ]
+    ann_attrs = ["Gene", "Feature", "VARIANT_CLASS"] if attr_list else None
 
     # Configure the annotation transform function
     transform_result = vtb.annotate(
@@ -105,3 +104,4 @@ def test_vcf_annotation(split_multiallelic, expected_rows):
     )
 
     assert vcf_table.num_rows == expected_rows
+    assert vcf_table.num_columns == expected_columns

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,0 +1,64 @@
+import pytest
+
+import tiledb.cloud.vcf as vcf
+import tiledb.cloud.vcf.vcf_toolbox as vtb
+
+
+@pytest.mark.vcf
+def test_vcf_annotation():
+    vcf_uri = "tiledb://TileDB-Inc/vcf-1kg-dragen-v376"
+
+    regions = [
+        "chr21:26973732-27213386",  # APP (Amyloid Beta Precursor Protein)
+    ]
+
+    # VCF attributes to read
+    vcf_attrs = [
+        "sample_name",
+        "contig",
+        "pos_start",
+        "alleles",
+        "fmt_DP",
+        "fmt_GQ",
+        "fmt_GT",
+    ]
+
+    # Filter to apply to VCF data
+    vcf_filter = "fmt_DP > 20 and fmt_GQ > 25"
+
+    # Add a zygosity column based on fmt_GT
+    add_zygosity = True
+
+    # Annotation array URI
+    ann_uri = "tiledb://tiledb-genomics-dev/vep_20230726_6"
+
+    # Annotation attributes to read
+    ann_attrs = [
+        "SYMBOL",
+        "Gene",
+        "Feature",
+        "VARIANT_CLASS",
+        "Consequence",
+        "Codons",
+        "Amino_acids",
+    ]
+
+    # Configure the annotation transform function
+    transform_result = vtb.annotate(
+        ann_uri=ann_uri,
+        ann_attrs=ann_attrs,
+        ann_regions=regions,
+        vcf_filter=vcf_filter,
+        add_zygosity=add_zygosity,
+    )
+
+    # Run the VCF query with annotation
+    vcf_table = vcf.read(
+        dataset_uri=vcf_uri,
+        attrs=vcf_attrs,
+        regions=regions,
+        samples="NA12878",
+        transform_result=transform_result,
+    )
+
+    assert vcf_table.num_rows == 557


### PR DESCRIPTION
The `vcf_toolbox` module provides useful VCF analysis capabilities, initially including the `df_transform` decorator and the `annotate` transform function.

## `df_transform` decorator
The `df_transform` function decorator streamlines the creation of transform functions that modify the VCF query results. A `df_transform` decorated function takes a pandas dataframe and optional kwargs as input and returns a pandas dataframe, as shown in this example.

```python
import tiledb.cloud.vcf as vcf
import tiledb.cloud.vcf.vcf_toolbox as vtb

@vtb.df_transform
def filter_vcf(df, *, filter=None):
    return df.query(filter)

# VCF attributes to read
attrs = [
    "sample_name",
    "contig",
    "pos_start",
    "alleles",
    "fmt_DP",
    "fmt_GQ",
    "fmt_GT",
]

# Filter to apply to VCF data
filter = "fmt_DP > 20 and fmt_GQ > 25"

# Run the VCF query with the transform function
df = vcf.read(
    dataset_uri="tiledb://TileDB-Inc/vcf-1kg-dragen-v376",
    attrs=attrs,
    regions="chr21:26973732-27213386",
    samples="NA12878",
    transform_result=filter_vcf(filter=filter),
).to_pandas()
```

## `annotate` transform function
The `annotate` transform function makes it easy to add annotations from sources like VEP or SnpEff to VCF query results.

```python
import tiledb.cloud.vcf as vcf
import tiledb.cloud.vcf.vcf_toolbox as vtb

regions = "chr21:26973732-27213386"

# Run the VCF query with annotation
df = vcf.read(
    dataset_uri="tiledb://TileDB-Inc/vcf-1kg-dragen-v376",
    regions=regions,
    samples="NA12878",
    transform_result=vtb.annotate(
        ann_uri="tiledb://tiledb-genomics-dev/vep_20230726_6",
        ann_regions=regions,
    ),
).to_pandas()
```