### PR TITLE
An asset module and simple API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Changes
+
+## Next (YYYY-MM-DD)
+
+- Add a tiledb.cloud.asset module with functions that allow management of
+  assets of any type (gh-566).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,22 +29,21 @@ viz-plotly = ["networkx>=2", "plotly>=4", "pydot"]
 all = ["networkx>=2", "plotly>=4", "pydot", "tiledb-plot-widget>=0.1.7"]
 
 dev = ["black", "pytest", "ruff"]
-tests = ["xarray", "pytest-split"]
+tests = ["xarray", "pytest-cov", "pytest-explicit", "pytest-split"]
 
 [project.urls]
 homepage = "https://tiledb.com"
 repository = "https://github.com/TileDB-Inc/TileDB-Cloud-Py"
 
-
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.pytest.ini_options]
+explicit-only = ["geospatial"]
 markers = [
   "geospatial: tests that require the geospatial libraries",
 ]
 norecursedirs = ["tiledb/cloud"]
-
 
 [tool.setuptools]
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ repository = "https://github.com/TileDB-Inc/TileDB-Cloud-Py"
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.pytest.ini_options]
-explicit-only = ["geospatial"]
 markers = [
   "geospatial: tests that require the geospatial libraries",
 ]

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -3,9 +3,12 @@
 from functools import partial
 from typing import Union
 
-import tiledb.cloud  # type: ignore
-from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
-from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
+import tiledb  # type: ignore
+
+from . import array  # type: ignore
+from . import groups  # type: ignore
+from .rest_api.models import ArrayInfo  # type: ignore
+from .rest_api.models import GroupInfo  # type: ignore
 
 
 def delete(uri: str, recursive: bool = False) -> None:
@@ -15,8 +18,8 @@ def delete(uri: str, recursive: bool = False) -> None:
     :return: None.
     """
     delete_map = {
-        "array": tiledb.cloud.array.delete_array,
-        "group": partial(tiledb.cloud.groups.delete, recursive=recursive),
+        "array": array.delete_array,
+        "group": partial(groups.delete, recursive=recursive),
     }
     asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = delete_map[asset_type]
@@ -31,7 +34,7 @@ def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
-    info_map = {"array": tiledb.cloud.array.info, "group": tiledb.cloud.groups.info}
+    info_map = {"array": array.info, "group": groups.info}
     asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = info_map[asset_type]
     return func(uri)

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,0 +1,17 @@
+"""An asset may be an array or a group."""
+
+import tiledb.cloud  # type: ignore
+
+asset_type_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
+
+
+def info(uri: str) -> object:
+    """Information about an asset.
+
+    :param uri: URI of the asset.
+    :return: object.
+    """
+    # Note: the URI can be either of the two forms, yes?
+    # tiledb://namespace/name or tiledb://namespace/UUID.
+    mod = asset_type_map[tiledb.object_type(uri)]
+    return getattr(mod, "info")(uri)

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -27,7 +27,7 @@ def delete(uri: str, recursive: bool = False) -> None:
 
 
 def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
-    """Information about an asset.
+    """Retrieve information about an asset.
 
     :param uri: URI of the asset.
     :return: ArrayInfo or GroupInfo.

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,8 +1,8 @@
 """An asset may be an array or a group."""
 
-import tiledb.cloud  # type: ignore
+from functools import partial
 
-asset_type_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
+import tiledb.cloud  # type: ignore
 
 
 def info(uri: str) -> object:
@@ -13,6 +13,22 @@ def info(uri: str) -> object:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
+    info_map = {"array": tiledb.cloud.array.info, "group": tiledb.cloud.groups.info}
     ctx = tiledb.cloud.Ctx()
-    mod = asset_type_map[tiledb.object_type(uri, ctx=ctx)]
-    return getattr(mod, "info")(uri)
+    func = info_map[tiledb.object_type(uri, ctx=ctx)]
+    return func(uri)
+
+
+def delete(uri: str, recursive: bool = False) -> None:
+    """Deregister the asset and remove its physical groups and arrays from storage.
+
+    :param uri: URI of the asset.
+    :return: None.
+    """
+    delete_map = {
+        "array": tiledb.cloud.array.delete_array,
+        "group": partial(tiledb.cloud.groups.delete, recursive=recursive),
+    }
+    ctx = tiledb.cloud.Ctx()
+    func = delete_map[tiledb.object_type(uri, ctx=ctx)]
+    return func(uri)

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -13,5 +13,6 @@ def info(uri: str) -> object:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
-    mod = asset_type_map[tiledb.object_type(uri)]
+    ctx = tiledb.cloud.Ctx()
+    mod = asset_type_map[tiledb.object_type(uri, ctx=ctx)]
     return getattr(mod, "info")(uri)

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,22 +1,11 @@
 """An asset may be an array or a group."""
 
 from functools import partial
+from typing import Union
 
 import tiledb.cloud  # type: ignore
-
-
-def info(uri: str) -> object:
-    """Information about an asset.
-
-    :param uri: URI of the asset.
-    :return: object.
-    """
-    # Note: the URI can be either of the two forms, yes?
-    # tiledb://namespace/name or tiledb://namespace/UUID.
-    info_map = {"array": tiledb.cloud.array.info, "group": tiledb.cloud.groups.info}
-    ctx = tiledb.cloud.Ctx()
-    func = info_map[tiledb.object_type(uri, ctx=ctx)]
-    return func(uri)
+from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
+from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 
 
 def delete(uri: str, recursive: bool = False) -> None:
@@ -29,6 +18,20 @@ def delete(uri: str, recursive: bool = False) -> None:
         "array": tiledb.cloud.array.delete_array,
         "group": partial(tiledb.cloud.groups.delete, recursive=recursive),
     }
-    ctx = tiledb.cloud.Ctx()
-    func = delete_map[tiledb.object_type(uri, ctx=ctx)]
+    asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    func = delete_map[asset_type]
+    return func(uri)
+
+
+def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
+    """Information about an asset.
+
+    :param uri: URI of the asset.
+    :return: ArrayInfo or GroupInfo.
+    """
+    # Note: the URI can be either of the two forms, yes?
+    # tiledb://namespace/name or tiledb://namespace/UUID.
+    info_map = {"array": tiledb.cloud.array.info, "group": tiledb.cloud.groups.info}
+    asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    func = info_map[asset_type]
     return func(uri)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,0 +1,36 @@
+"""Tests of the tiledb.cloud.asset module."""
+
+from unittest import mock
+
+import tiledb
+import tiledb.cloud
+
+
+@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.cloud.array.info")
+def test_asset_info_array(array_info, object_type):
+    """Dispatch to array.info when URI is an array."""
+    object_type.return_value = "array"
+    array_info.return_value = {"tiledb_uri": "tiledb://a"}
+
+    def info(uri):
+        asset_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
+        mod = asset_map[tiledb.object_type(uri)]
+        return getattr(mod, "info")(uri)
+
+    assert info("a") == {"tiledb_uri": "tiledb://a"}
+
+
+@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.cloud.groups.info")
+def test_asset_info_group(groups_info, object_type):
+    """Dispatch to groups.info when URI is a group."""
+    object_type.return_value = "group"
+    groups_info.return_value = {"tiledb_uri": "tiledb://g"}
+
+    def info(uri):
+        asset_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
+        mod = asset_map[tiledb.object_type(uri)]
+        return getattr(mod, "info")(uri)
+
+    assert info("g") == {"tiledb_uri": "tiledb://g"}

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -28,17 +28,16 @@ def test_asset_info_group(groups_info, object_type):
 
 
 def test_prod_group_asset_info():
-    """Get info about a production group."""
-    info = asset.info("tiledb://TileDB-Inc/d185ecf1-4572-45f8-81a7-b02e907657dd")
-    assert info.name == "cmu1_small"
-    assert info.group_type == "bioimg"
+    """Get info about a public production group."""
+    info = asset.info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
+    assert info.name == "langchain_documentation_huggingface"
 
 
 def test_prod_array_asset_info():
-    """Get info about a production array."""
-    info = asset.info("tiledb://TileDB-Inc/886afe8c-c055-4569-9644-351d8e72f098")
-    assert info.name == "l_0.tdb"
-    assert info.type == "dense"
+    """Get info about a public production array."""
+    info = asset.info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
+    assert info.name == "documents"
+    assert info.type == "sparse"
 
 
 @mock.patch("tiledb.object_type")

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -2,69 +2,65 @@
 
 from unittest import mock
 
-from tiledb.cloud import asset
+from tiledb.cloud.asset import delete  # type: ignore
+from tiledb.cloud.asset import info  # type: ignore
+from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
+from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 
 
-@mock.patch("tiledb.object_type")
-@mock.patch("tiledb.cloud.array.info")
-def test_asset_info_array(array_info, object_type):
-    """Dispatch to array.info when URI is an array."""
-    object_type.return_value = "array"
-    array_info.return_value = {"tiledb_uri": "tiledb://a"}
-
-    assert asset.info("a") == {"tiledb_uri": "tiledb://a"}
-    array_info.assert_called_once_with("a")
-
-
-@mock.patch("tiledb.object_type")
-@mock.patch("tiledb.cloud.groups.info")
-def test_asset_info_group(groups_info, object_type):
-    """Dispatch to groups.info when URI is a group."""
-    object_type.return_value = "group"
-    groups_info.return_value = {"tiledb_uri": "tiledb://g"}
-
-    assert asset.info("g") == {"tiledb_uri": "tiledb://g"}
-    groups_info.assert_called_once_with("g")
-
-
-def test_prod_group_asset_info():
-    """Get info about a public production group."""
-    info = asset.info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
-    assert info.name == "langchain_documentation_huggingface"
-
-
-def test_prod_array_asset_info():
-    """Get info about a public production array."""
-    info = asset.info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
-    assert info.name == "documents"
-    assert info.type == "sparse"
-
-
-@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.object_type", return_value="array")
 @mock.patch("tiledb.cloud.array.delete_array")
-def test_asset_delete_array(delete_array, object_type):
+def test_asset_delete_array_dispatch(delete_array, object_type):
     """Dispatch to array.array_delete when URI is an array."""
-    object_type.return_value = "array"
-
-    asset.delete("a")
+    delete("a")
+    # Since delete() doesn't return a value, we assert on the implementation.
     delete_array.assert_called_once_with("a")
 
 
-@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.object_type", return_value="group")
 @mock.patch("tiledb.cloud.groups.delete")
-def test_asset_delete_group(delete, object_type):
+def test_asset_delete_group_dispatch(delete_group, object_type):
     """Dispatch to groups.delete when URI is a group."""
-    object_type.return_value = "group"
+    delete("g")
+    # Since delete() doesn't return a value, we assert on the implementation.
+    delete_group.assert_called_once_with("g", recursive=False)
 
-    asset.delete("g")
-    delete.assert_called_once_with("g", recursive=False)
 
-
-@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.object_type", return_value="group")
 @mock.patch("tiledb.cloud.groups.delete")
-def test_asset_delete_group_recursive(delete, object_type):
-    """Dispatch to groups.delete when URI is a group."""
-    object_type.return_value = "group"
+def test_asset_delete_group_recursive(delete_group, object_type):
+    """Dispatch to groups.delete, recursively, when URI is a group."""
+    delete("g", recursive=True)
+    # Since delete() doesn't return a value, we assert on the implementation.
+    delete_group.assert_called_once_with("g", recursive=True)
 
-    asset.delete("g", recursive=True)
-    delete.assert_called_once_with("g", recursive=True)
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch("tiledb.cloud.array.info", return_value=ArrayInfo(tiledb_uri="tiledb://a"))
+def test_asset_info_array_dispatch(array_info, object_type):
+    """Dispatch to array.info when URI is an array."""
+    asset_info = info("a")
+    assert isinstance(asset_info, ArrayInfo)
+    assert asset_info.tiledb_uri == "tiledb://a"
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.info", return_value=GroupInfo(tiledb_uri="tiledb://g"))
+def test_asset_info_group_dispatch(group_info, object_type):
+    """Dispatch to groups.info when URI is a group."""
+    asset_info = info("g")
+    assert isinstance(asset_info, GroupInfo)
+    assert asset_info.tiledb_uri == "tiledb://g"
+
+
+def test_public_array_asset_info():
+    """Get info about a public production array."""
+    asset_info = info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
+    assert asset_info.name == "documents"
+    assert asset_info.type == "sparse"
+
+
+def test_public_group_asset_info():
+    """Get info about a public production group."""
+    asset_info = info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
+    assert asset_info.name == "langchain_documentation_huggingface"

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -2,9 +2,6 @@
 
 from unittest import mock
 
-import tiledb
-import tiledb.cloud
-
 from tiledb.cloud import asset
 
 
@@ -16,6 +13,7 @@ def test_asset_info_array(array_info, object_type):
     array_info.return_value = {"tiledb_uri": "tiledb://a"}
 
     assert asset.info("a") == {"tiledb_uri": "tiledb://a"}
+    array_info.assert_called_once_with("a")
 
 
 @mock.patch("tiledb.object_type")
@@ -26,6 +24,7 @@ def test_asset_info_group(groups_info, object_type):
     groups_info.return_value = {"tiledb_uri": "tiledb://g"}
 
     assert asset.info("g") == {"tiledb_uri": "tiledb://g"}
+    groups_info.assert_called_once_with("g")
 
 
 def test_prod_group_asset_info():
@@ -40,3 +39,33 @@ def test_prod_array_asset_info():
     info = asset.info("tiledb://TileDB-Inc/886afe8c-c055-4569-9644-351d8e72f098")
     assert info.name == "l_0.tdb"
     assert info.type == "dense"
+
+
+@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.cloud.array.delete_array")
+def test_asset_delete_array(delete_array, object_type):
+    """Dispatch to array.array_delete when URI is an array."""
+    object_type.return_value = "array"
+
+    asset.delete("a")
+    delete_array.assert_called_once_with("a")
+
+
+@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.cloud.groups.delete")
+def test_asset_delete_group(delete, object_type):
+    """Dispatch to groups.delete when URI is a group."""
+    object_type.return_value = "group"
+
+    asset.delete("g")
+    delete.assert_called_once_with("g", recursive=False)
+
+
+@mock.patch("tiledb.object_type")
+@mock.patch("tiledb.cloud.groups.delete")
+def test_asset_delete_group_recursive(delete, object_type):
+    """Dispatch to groups.delete when URI is a group."""
+    object_type.return_value = "group"
+
+    asset.delete("g", recursive=True)
+    delete.assert_called_once_with("g", recursive=True)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -5,6 +5,8 @@ from unittest import mock
 import tiledb
 import tiledb.cloud
 
+from tiledb.cloud import asset
+
 
 @mock.patch("tiledb.object_type")
 @mock.patch("tiledb.cloud.array.info")
@@ -13,12 +15,7 @@ def test_asset_info_array(array_info, object_type):
     object_type.return_value = "array"
     array_info.return_value = {"tiledb_uri": "tiledb://a"}
 
-    def info(uri):
-        asset_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
-        mod = asset_map[tiledb.object_type(uri)]
-        return getattr(mod, "info")(uri)
-
-    assert info("a") == {"tiledb_uri": "tiledb://a"}
+    assert asset.info("a") == {"tiledb_uri": "tiledb://a"}
 
 
 @mock.patch("tiledb.object_type")
@@ -28,9 +25,4 @@ def test_asset_info_group(groups_info, object_type):
     object_type.return_value = "group"
     groups_info.return_value = {"tiledb_uri": "tiledb://g"}
 
-    def info(uri):
-        asset_map = {"array": tiledb.cloud.array, "group": tiledb.cloud.groups}
-        mod = asset_map[tiledb.object_type(uri)]
-        return getattr(mod, "info")(uri)
-
-    assert info("g") == {"tiledb_uri": "tiledb://g"}
+    assert asset.info("g") == {"tiledb_uri": "tiledb://g"}

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -26,3 +26,17 @@ def test_asset_info_group(groups_info, object_type):
     groups_info.return_value = {"tiledb_uri": "tiledb://g"}
 
     assert asset.info("g") == {"tiledb_uri": "tiledb://g"}
+
+
+def test_prod_group_asset_info():
+    """Get info about a production group."""
+    info = asset.info("tiledb://TileDB-Inc/d185ecf1-4572-45f8-81a7-b02e907657dd")
+    assert info.name == "cmu1_small"
+    assert info.group_type == "bioimg"
+
+
+def test_prod_array_asset_info():
+    """Get info about a production array."""
+    info = asset.info("tiledb://TileDB-Inc/886afe8c-c055-4569-9644-351d8e72f098")
+    assert info.name == "l_0.tdb"
+    assert info.type == "dense"


### PR DESCRIPTION
To allow abstract asset management and querying.

More methods are useful, but `delete()` and `info()` are the only ones (I think) that currently exist in `tiledb.cloud.array` and `tiledb.cloud.groups` in the same form. Fleshing out `tiledb.cloud.groups` and filling other gaps is work for another PR.