### PR TITLE
Rename asset functions, export from tiledb.cloud.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,4 +3,4 @@
 ## Next (YYYY-MM-DD)
 
 - Add a tiledb.cloud.asset module with functions that allow management of
-  assets of any type. The functions are exported from tiledb.cloud (gh-566).
+  assets of any type. This module is exported from tiledb.cloud (gh-566).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,4 +3,4 @@
 ## Next (YYYY-MM-DD)
 
 - Add a tiledb.cloud.asset module with functions that allow management of
-  assets of any type (gh-566).
+  assets of any type. The functions are exported from tiledb.cloud (gh-566).

--- a/src/tiledb/cloud/__init__.py
+++ b/src/tiledb/cloud/__init__.py
@@ -14,6 +14,8 @@ from .array import list_shared_with
 from .array import register_array
 from .array import share_array
 from .array import unshare_array
+from .asset import asset_info
+from .asset import delete_asset
 from .client import Config
 from .client import Ctx
 from .client import list_arrays
@@ -70,6 +72,8 @@ __all__ = (
     "list_shared_arrays",
     "list_shared_groups",
     "list_groups",
+    "asset_info",
+    "delete_asset",
     "login",
     "organization",
     "organizations",

--- a/src/tiledb/cloud/__init__.py
+++ b/src/tiledb/cloud/__init__.py
@@ -1,5 +1,7 @@
 # This file imports specifically to re-export.
 
+from . import array
+from . import asset
 from . import compute
 from . import dag
 from . import file
@@ -14,8 +16,6 @@ from .array import list_shared_with
 from .array import register_array
 from .array import share_array
 from .array import unshare_array
-from .asset import asset_info
-from .asset import delete_asset
 from .client import Config
 from .client import Ctx
 from .client import list_arrays
@@ -51,6 +51,8 @@ ResultFormat = models.ResultFormat
 UDFResultType = ResultFormat
 
 __all__ = (
+    "array",
+    "asset",
     "compute",
     "dag",
     "file",
@@ -72,8 +74,6 @@ __all__ = (
     "list_shared_arrays",
     "list_shared_groups",
     "list_groups",
-    "asset_info",
-    "delete_asset",
     "login",
     "organization",
     "organizations",

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -11,10 +11,10 @@ from .rest_api.models import ArrayInfo  # type: ignore
 from .rest_api.models import GroupInfo  # type: ignore
 
 
-def delete_asset(uri: str, recursive: bool = False) -> None:
+def delete(uri: str, recursive: bool = False) -> None:
     """Deregister the asset and remove its physical groups and arrays from storage.
 
-    :param uri: URI of the asset.
+    :param uri: tiledb URI of the asset.
     :return: None.
     """
     delete_map: Mapping[str, Callable] = {
@@ -26,10 +26,10 @@ def delete_asset(uri: str, recursive: bool = False) -> None:
     return func(uri)
 
 
-def asset_info(uri: str) -> Union[ArrayInfo, GroupInfo]:
+def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """Retrieve information about an asset.
 
-    :param uri: URI of the asset.
+    :param uri: tiledb URI of the asset.
     :return: ArrayInfo or GroupInfo.
     """
     # Note: the URI can be either of the two forms, yes?

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,7 +1,7 @@
 """An asset may be an array or a group."""
 
 from functools import partial
-from typing import Union
+from typing import Callable, Mapping, Union
 
 import tiledb  # type: ignore
 
@@ -11,22 +11,22 @@ from .rest_api.models import ArrayInfo  # type: ignore
 from .rest_api.models import GroupInfo  # type: ignore
 
 
-def delete(uri: str, recursive: bool = False) -> None:
+def delete_asset(uri: str, recursive: bool = False) -> None:
     """Deregister the asset and remove its physical groups and arrays from storage.
 
     :param uri: URI of the asset.
     :return: None.
     """
-    delete_map = {
+    delete_map: Mapping[str, Callable] = {
         "array": array.delete_array,
         "group": partial(groups.delete, recursive=recursive),
     }
-    asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = delete_map[asset_type]
     return func(uri)
 
 
-def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
+def asset_info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """Retrieve information about an asset.
 
     :param uri: URI of the asset.
@@ -34,7 +34,7 @@ def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
-    info_map = {"array": array.info, "group": groups.info}
-    asset_type = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    info_map: Mapping[str, Callable] = {"array": array.info, "group": groups.info}
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = info_map[asset_type]
     return func(uri)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -2,8 +2,7 @@
 
 from unittest import mock
 
-from tiledb.cloud import asset_info  # type: ignore
-from tiledb.cloud import delete_asset  # type: ignore
+from tiledb.cloud import asset  # type: ignore
 from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
 from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 
@@ -12,8 +11,8 @@ from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 @mock.patch("tiledb.cloud.array.delete_array")
 def test_asset_delete_array_dispatch(delete_array, object_type):
     """Dispatch to array.array_delete when URI is an array."""
-    delete_asset("a")
-    # Since delete_asset() doesn't return a value, we assert on the implementation.
+    asset.delete("a")
+    # Since asset.delete() doesn't return a value, we assert on the implementation.
     delete_array.assert_called_once_with("a")
 
 
@@ -21,7 +20,7 @@ def test_asset_delete_array_dispatch(delete_array, object_type):
 @mock.patch("tiledb.cloud.groups.delete")
 def test_asset_delete_group_dispatch(delete_group, object_type):
     """Dispatch to groups.delete when URI is a group."""
-    delete_asset("g")
+    asset.delete("g")
     delete_group.assert_called_once_with("g", recursive=False)
 
 
@@ -29,7 +28,7 @@ def test_asset_delete_group_dispatch(delete_group, object_type):
 @mock.patch("tiledb.cloud.groups.delete")
 def test_asset_delete_group_recursive(delete_group, object_type):
     """Dispatch to groups.delete, recursively, when URI is a group."""
-    delete_asset("g", recursive=True)
+    asset.delete("g", recursive=True)
     delete_group.assert_called_once_with("g", recursive=True)
 
 
@@ -37,7 +36,7 @@ def test_asset_delete_group_recursive(delete_group, object_type):
 @mock.patch("tiledb.cloud.array.info", return_value=ArrayInfo(tiledb_uri="tiledb://a"))
 def test_asset_info_array_dispatch(array_info, object_type):
     """Dispatch to array.info when URI is an array."""
-    info = asset_info("a")
+    info = asset.info("a")
     assert isinstance(info, ArrayInfo)
     assert info.tiledb_uri == "tiledb://a"
 
@@ -46,19 +45,19 @@ def test_asset_info_array_dispatch(array_info, object_type):
 @mock.patch("tiledb.cloud.groups.info", return_value=GroupInfo(tiledb_uri="tiledb://g"))
 def test_asset_info_group_dispatch(group_info, object_type):
     """Dispatch to groups.info when URI is a group."""
-    info = asset_info("g")
+    info = asset.info("g")
     assert isinstance(info, GroupInfo)
     assert info.tiledb_uri == "tiledb://g"
 
 
 def test_public_array_asset_info():
     """Get info about a public production array."""
-    info = asset_info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
+    info = asset.info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
     assert info.name == "documents"
     assert info.type == "sparse"
 
 
 def test_public_group_asset_info():
     """Get info about a public production group."""
-    info = asset_info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
+    info = asset.info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
     assert info.name == "langchain_documentation_huggingface"

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -2,8 +2,8 @@
 
 from unittest import mock
 
-from tiledb.cloud.asset import delete  # type: ignore
-from tiledb.cloud.asset import info  # type: ignore
+from tiledb.cloud import asset_info  # type: ignore
+from tiledb.cloud import delete_asset  # type: ignore
 from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
 from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 
@@ -12,8 +12,8 @@ from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 @mock.patch("tiledb.cloud.array.delete_array")
 def test_asset_delete_array_dispatch(delete_array, object_type):
     """Dispatch to array.array_delete when URI is an array."""
-    delete("a")
-    # Since delete() doesn't return a value, we assert on the implementation.
+    delete_asset("a")
+    # Since delete_asset() doesn't return a value, we assert on the implementation.
     delete_array.assert_called_once_with("a")
 
 
@@ -21,8 +21,7 @@ def test_asset_delete_array_dispatch(delete_array, object_type):
 @mock.patch("tiledb.cloud.groups.delete")
 def test_asset_delete_group_dispatch(delete_group, object_type):
     """Dispatch to groups.delete when URI is a group."""
-    delete("g")
-    # Since delete() doesn't return a value, we assert on the implementation.
+    delete_asset("g")
     delete_group.assert_called_once_with("g", recursive=False)
 
 
@@ -30,8 +29,7 @@ def test_asset_delete_group_dispatch(delete_group, object_type):
 @mock.patch("tiledb.cloud.groups.delete")
 def test_asset_delete_group_recursive(delete_group, object_type):
     """Dispatch to groups.delete, recursively, when URI is a group."""
-    delete("g", recursive=True)
-    # Since delete() doesn't return a value, we assert on the implementation.
+    delete_asset("g", recursive=True)
     delete_group.assert_called_once_with("g", recursive=True)
 
 
@@ -39,28 +37,28 @@ def test_asset_delete_group_recursive(delete_group, object_type):
 @mock.patch("tiledb.cloud.array.info", return_value=ArrayInfo(tiledb_uri="tiledb://a"))
 def test_asset_info_array_dispatch(array_info, object_type):
     """Dispatch to array.info when URI is an array."""
-    asset_info = info("a")
-    assert isinstance(asset_info, ArrayInfo)
-    assert asset_info.tiledb_uri == "tiledb://a"
+    info = asset_info("a")
+    assert isinstance(info, ArrayInfo)
+    assert info.tiledb_uri == "tiledb://a"
 
 
 @mock.patch("tiledb.object_type", return_value="group")
 @mock.patch("tiledb.cloud.groups.info", return_value=GroupInfo(tiledb_uri="tiledb://g"))
 def test_asset_info_group_dispatch(group_info, object_type):
     """Dispatch to groups.info when URI is a group."""
-    asset_info = info("g")
-    assert isinstance(asset_info, GroupInfo)
-    assert asset_info.tiledb_uri == "tiledb://g"
+    info = asset_info("g")
+    assert isinstance(info, GroupInfo)
+    assert info.tiledb_uri == "tiledb://g"
 
 
 def test_public_array_asset_info():
     """Get info about a public production array."""
-    asset_info = info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
-    assert asset_info.name == "documents"
-    assert asset_info.type == "sparse"
+    info = asset_info("tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d")
+    assert info.name == "documents"
+    assert info.type == "sparse"
 
 
 def test_public_group_asset_info():
     """Get info about a public production group."""
-    asset_info = info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
-    assert asset_info.name == "langchain_documentation_huggingface"
+    info = asset_info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
+    assert info.name == "langchain_documentation_huggingface"


### PR DESCRIPTION
Exports asset_info and delete_asset from `tiledb.cloud` alongside array functions.