### PR TITLE
Remove `dataset_type` from registered array metadata for geospatial ingest.

### DIFF
--- a/src/tiledb/cloud/geospatial/ingestion.py
+++ b/src/tiledb/cloud/geospatial/ingestion.py
@@ -962,6 +962,13 @@ def register_dataset_udf(
                 access_credentials_name=acn,
             )
 
+            # FIXME: This removes `dataset_type` metadata field for internal UI reasons
+            with tiledb.open(dataset_uri, mode="w") as array:
+                try:
+                    del array.meta["dataset_type"]
+                except KeyError:
+                    pass
+
 
 def build_file_list_udf(
     *,
@@ -1510,51 +1517,52 @@ def ingest_datasets(
 # Wrapper function for batch dataset ingestion
 ingest = as_batch(ingest_datasets)
 
-# if __name__ == "__main__":
-#     import datetime
-
-#     date_mark = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-#     # date_mark = "1"
-#     ingest_datasets(
-#         dataset_uri=f"s3://tiledb-norman/deleteme/lidar/ma/2024-03-05/test-{date_mark}",
-#         dataset_type=DatasetType.POINTCLOUD,
-#         acn="norman-cloud-sandbox-role",
-#         namespace="norman",
-#         register_name="test_lidar_ma",
-#         search_uri="s3://tiledb-norman/deleteme/files/geospatial/lidar/MA_CentralEastern_2021_B21/",
-#         stats=False,
-#         verbose=True,
-#         trace=True,
-#         pattern="*.laz",
-#     )
-
 if __name__ == "__main__":
     import datetime
 
-    from tiledb.cloud.utilities import serialize_filter
-
     date_mark = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     # date_mark = "1"
-
-    tile_size = 1024
-    pixels_per_fragment = (tile_size**2) * 100  # 100 tiles per fragment
-    batch_size = 8
-    zstd_filter = tiledb.ZstdFilter(level=7)
-
     ingest_datasets(
-        dataset_uri=f"s3://tiledb-norman/deleteme/raster/raster_test/2024-03-08/test-{date_mark}",
-        dataset_type=DatasetType.RASTER,
-        batch_size=batch_size,
-        tile_size=tile_size,
-        pixels_per_fragment=pixels_per_fragment,
-        nodata=0,
-        compression_filter=serialize_filter(zstd_filter),
-        acn="norman-cloud-sandbox-role",
-        namespace="norman",
-        register_name="test_landcover_small",
-        search_uri="s3://tiledb-norman/deleteme/raster_test/small/",
+        dataset_uri="s3://john.moutafis-test/pointcloud-test-4",
+        dataset_type=DatasetType.POINTCLOUD,
+        acn="my_quicktest_role",
+        namespace="john-moutafis",
+        register_name="test-lidar-4",
+        search_uri="s3://tiledb-norman/deleteme/files/geospatial/lidar/MA_CentralEastern_2021_B21/",
         stats=False,
+        # max_files=3,
         verbose=True,
         trace=True,
-        pattern="*.tif",
+        pattern="*.laz",
     )
+
+# if __name__ == "__main__":
+#     import datetime
+
+#     from tiledb.cloud.utilities import serialize_filter
+
+#     date_mark = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+#     # date_mark = "1"
+
+#     tile_size = 1024
+#     pixels_per_fragment = (tile_size**2) * 100  # 100 tiles per fragment
+#     batch_size = 8
+#     zstd_filter = tiledb.ZstdFilter(level=7)
+
+#     ingest_datasets(
+#         dataset_uri=f"s3://tiledb-norman/deleteme/raster/raster_test/2024-03-08/test-{date_mark}",
+#         dataset_type=DatasetType.RASTER,
+#         batch_size=batch_size,
+#         tile_size=tile_size,
+#         pixels_per_fragment=pixels_per_fragment,
+#         nodata=0,
+#         compression_filter=serialize_filter(zstd_filter),
+#         acn="norman-cloud-sandbox-role",
+#         namespace="norman",
+#         register_name="test_landcover_small",
+#         search_uri="s3://tiledb-norman/deleteme/raster_test/small/",
+#         stats=False,
+#         verbose=True,
+#         trace=True,
+#         pattern="*.tif",
+#     )

--- a/src/tiledb/cloud/geospatial/ingestion.py
+++ b/src/tiledb/cloud/geospatial/ingestion.py
@@ -1420,6 +1420,7 @@ def remove_dataset_type_from_array_meta(
     """
     Removes `dataset_type` meta if the ingested result is an array.
     FIXME: This exists to fix an internal UI issue until formally fixed.
+    FIXME: Related ticket -> sc-48098
 
     :param dataset_uri: dataset URI
     :param verbose: verbose logging, defaults to False
@@ -1427,13 +1428,17 @@ def remove_dataset_type_from_array_meta(
     logger = get_logger_wrapper(verbose)
     if tiledb.object_type(dataset_uri) == "array":
         logger.info(
-            "Ingested result is an array. " "Removing dataset_type from metadata..."
+            "Removing non-standard dataset_type from ingested array metadata: "
+            "dataset_uri=%r",
+            dataset_uri,
         )
         with tiledb.open(dataset_uri, mode="w") as array:
             try:
                 del array.meta["dataset_type"]
             except KeyError as exc:
-                logger.debug(f"Failed: {str(exc)}")
+                logger.info(
+                    f"sc-48098: Failed to remove `dataset_type` key: {str(exc)}"
+                )
 
 
 def ingest_datasets(


### PR DESCRIPTION
Removes the `dataset_type` metadata field to enable the UI to read PointClouds and Rasters as arrays or groups.