### PR TITLE
Make soma an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
   # tblib transitively enabled, so this is needed for unpickling.
   "tblib~=1.7",
   "tiledb>=0.15.2",
-  "tiledbsoma",
   "typing-extensions",
   "urllib3>=1.26",
 ]
@@ -29,9 +28,10 @@ dependencies = [
 viz-tiledb = ["networkx>=2", "pydot", "tiledb-plot-widget>=0.1.7"]
 viz-plotly = ["networkx>=2", "plotly>=4", "pydot"]
 all = ["networkx>=2", "plotly>=4", "pydot", "tiledb-plot-widget>=0.1.7"]
+life-sciences = ["tiledbsoma"]
 
 dev = ["black", "pytest", "ruff"]
-tests = ["xarray", "pytest-cov", "pytest-explicit", "pytest-split"]
+tests = ["xarray", "pytest-cov", "pytest-explicit", "pytest-split", "tiledbsoma"]
 
 [project.urls]
 homepage = "https://tiledb.com"


### PR DESCRIPTION
SOMA was added a dependency for TileDB-Cloud-Py as part of ingestion work. Other libraries we treat as optional to have a middle ground for the amount of dependencies and packages required for a base installation of TileDB-Cloud-Py. SOMA should be moved to optional too.

This also lets tiledb-cloud be installed on windows machines where SOMA doesn't currently offer binaries.