### PR TITLE
Patch rest.py to avoid deprecated urllib3 usage

### DIFF
--- a/src/tiledb/cloud/rest_api/rest.py
+++ b/src/tiledb/cloud/rest_api/rest.py
@@ -44,7 +44,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):

--- a/update_generated.sh
+++ b/update_generated.sh
@@ -187,6 +187,25 @@ index 97319c27..f2307414 100644
 EOF
 }
 
+# Patch rest.py to avoid deprecated urllib3 usage.
+apply_urllib3_patch() {
+  git apply - <<EOF
+diff --git a/src/tiledb/cloud/rest_api/rest.py b/src/tiledb/cloud/rest_api/rest.py
+index 8993ba69..be59d24b 100644
+--- a/src/tiledb/cloud/rest_api/rest.py
++++ b/src/tiledb/cloud/rest_api/rest.py
+@@ -44,7 +44,7 @@ class RESTResponse(io.IOBase):
+
+     def getheader(self, name, default=None):
+         """Returns a given response header."""
+-        return self.urllib3_response.getheader(name, default)
++        return self.urllib3_response.headers.get(name, default)
+
+
+ class RESTClientObject(object):
+EOF
+}
+
 ABSPATH="$(realpath "$1")"
 
 download_generator
@@ -194,4 +213,5 @@ generate_api "${ABSPATH%/}/openapi-v1.yaml" rest_api
 generate_api "${ABSPATH%/}/openapi-v2.yaml" _common.api_v2
 run_format
 apply_json_safe_patch
+apply_urllib3_patch
 cp "$ROOT/generator/openapi_overrides"/* "$TARGET_PATH/_common/api_v2"


### PR DESCRIPTION
urllib3's `Response.getheaders()` is deprecated. With this patch, we can successfully run `python -Werrors -m pytest tests/test_asset.py` (turning warnings into errors).

The `update_generated.sh` script seems to be Linux-only. With some modification to the sed commands (`-i ''` instead of `--in-place`), I could get the script to run on my Mac, but the original json_safe patch no longer applies.

I'll look into tuning up that patch so that it will apply before I ask for review.