### PR TITLE
[PoC] Detach Cloud-Py from OpenAPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=1.2.4",
     "pyarrow>=3.0.0",
     "python-dateutil",
+    "requests>=2.31.0",
     "six>=1.10",
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
@@ -41,9 +42,7 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.pytest.ini_options]
 explicit-only = ["geospatial"]
-markers = [
-  "geospatial: tests that require the geospatial libraries",
-]
+markers = ["geospatial: tests that require the geospatial libraries"]
 norecursedirs = ["tiledb/cloud"]
 
 

--- a/requirements-py3.9.txt
+++ b/requirements-py3.9.txt
@@ -8,6 +8,7 @@ pandas==2.2.0
 pyarrow==15.0.0
 python-dateutil==2.8.2
 pytz==2024.1
+requests==2.31.0
 six==1.16.0
 tblib==1.7.0
 tiledb==0.25.0

--- a/src/tiledb/services/__init__.py
+++ b/src/tiledb/services/__init__.py
@@ -1,0 +1,9 @@
+from . import errors
+from . import http_actions
+
+HOST = "http://localhost"
+
+__all__ = (
+    "errors",
+    "http_actions",
+)

--- a/src/tiledb/services/api_v1/__init__.py
+++ b/src/tiledb/services/api_v1/__init__.py
@@ -1,0 +1,9 @@
+from . import arrays
+from . import groups
+from . import users
+
+__all__ = (
+    "arrays",
+    "groups",
+    "users",
+)

--- a/src/tiledb/services/api_v1/arrays.py
+++ b/src/tiledb/services/api_v1/arrays.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+import requests
+
+from tiledb.cloud import config
+from tiledb.cloud._common import utils
+from tiledb.services import errors
+from tiledb.services.http_actions import AllowedMethods
+from tiledb.services.http_actions import perform_request
+
+HOST = config.config.host
+ARRAYS_V1_URL = f"{HOST}/v1/arrays"
+
+
+def deregister(uri: str, *, request_session: Optional[requests.Session] = None) -> int:
+    """
+    Deregister a TileDB Array.
+
+    :param uri: A TileDB Array URI.
+    :param request_session: A requests.Session, defaults to None
+    :return int: Expected status code
+    """
+    namespace, name = utils.split_uri(uri)
+    try:
+        response = perform_request(
+            method=AllowedMethods.DELETE,
+            url=f"{ARRAYS_V1_URL}/{namespace}/{name}/deregister",
+            request_session=request_session,
+        )
+
+        return response.status_code
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise errors.Unauthorized(
+                "You are not authorized to delete this resource"
+            ) from exc
+        if exc.response.status_code == 404:
+            raise errors.NotFound(f"Array '{uri}' does not exist")
+        raise errors.TileDBCloudError() from exc

--- a/src/tiledb/services/api_v1/groups.py
+++ b/src/tiledb/services/api_v1/groups.py
@@ -1,0 +1,101 @@
+from dataclasses import asdict
+from typing import List, Optional
+
+import requests
+
+from tiledb.cloud import config
+from tiledb.cloud._common import utils
+from tiledb.services import errors
+from tiledb.services.api_v1 import models
+from tiledb.services.http_actions import AllowedMethods
+from tiledb.services.http_actions import perform_request
+
+HOST = config.config.host
+GROUPS_V1_URL = f"{HOST}/v1/groups"
+
+
+def get_group_contents(
+    uri: str,
+    *,
+    page: int = 1,
+    per_page: int = 100,
+    request_session: Optional[requests.Session] = None,
+) -> dict:
+    namespace, name = utils.split_uri(uri)
+    try:
+        response = perform_request(
+            method=AllowedMethods.GET,
+            url=f"{GROUPS_V1_URL}/{namespace}/{name}/contents",
+            params={
+                "page": page,
+                "per_page": per_page,
+            },
+            request_session=request_session,
+        )
+
+        return response.json()
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 400:
+            raise errors.BadRequest(str(exc))
+        if exc.response.status_code == 401:
+            raise errors.Unauthorized(
+                "You are not authorized to delete this resource"
+            ) from exc
+        if exc.response.status_code == 404:
+            raise errors.NotFound(f"Group '{uri}' does not exist")
+        raise errors.TileDBCloudError() from exc
+
+
+def update_info(
+    uri: str,
+    *,
+    description: Optional[str] = None,
+    name: Optional[str] = None,
+    logo: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+) -> int:
+    """
+    Update Group Attributes
+
+    :param uri: URI of the group in the form 'tiledb://<namespace>/<group>'
+    :param description: Group description, defaults to None
+    :param name: Group's name, defaults to None
+    :param logo: Group's logo, defaults to None
+    :param tags: Group tags, defaults to None
+    :return: None
+    """
+    namespace, group_name = utils.split_uri(uri)
+    info = models.groups.GroupUpdateInfo(description, name, logo, tags)
+    info = asdict(
+        info, dict_factory=lambda item: {k: v for (k, v) in item if v is not None}
+    )
+    try:
+        response = perform_request(
+            method=AllowedMethods.PATCH,
+            url=f"{GROUPS_V1_URL}/{namespace}/{group_name}",
+            body=info,
+        )
+        return response.status_code
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 404:
+            raise errors.NotFound(f"Group '{uri}' does not exist") from exc
+        raise errors.TileDBCloudError() from exc
+
+
+def info(uri: str) -> dict:
+    """
+    Fetches metadata for a TileDB Group.
+
+    :param uri: TileDB Group URI.
+    :return dict: Group Metadata
+    """
+    namespace, name = utils.split_uri(uri)
+    try:
+        response = perform_request(
+            method=AllowedMethods.GET, url=f"{GROUPS_V1_URL}/{namespace}/{name}"
+        )
+        return response.json()
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 404:
+            raise errors.NotFound(f"Group '{uri}' does not exist") from exc
+        raise errors.TileDBCloudError() from exc

--- a/src/tiledb/services/api_v1/models/__init__.py
+++ b/src/tiledb/services/api_v1/models/__init__.py
@@ -1,0 +1,13 @@
+from tiledb.services.api_v1.models import assets
+from tiledb.services.api_v1.models import groups
+from tiledb.services.api_v1.models import namespaces
+from tiledb.services.api_v1.models import organizations
+from tiledb.services.api_v1.models import users
+
+__all__ = (
+    "assets",
+    "groups",
+    "namespaces",
+    "organizations",
+    "users",
+)

--- a/src/tiledb/services/api_v1/models/assets.py
+++ b/src/tiledb/services/api_v1/models/assets.py
@@ -1,0 +1,36 @@
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class StorageLocation(BaseModel):
+    path: str
+    credentials_name: str
+
+
+class AssetTypes(str, Enum):
+    ARRAY = "array"
+    NOTEBOOK = "notebook"
+    DASHBOARD = "dashboard"
+    USER_DEFINED_FUNCTION = "user_defined_function"
+    ML_MODEL = "ml_model"
+    FILE = "file"
+    REGISTERED_TASK_GRAPH = "registered_task_graph"
+    GROUP = "group"
+    VCF = "vcf"
+    SOMA = "soma"
+    POINTCLOUD = "pointcloud"
+    BIOIMG = "bioimg"
+    GEOMETRY = "geometry"
+    RASTER = "raster"
+    VECTOR_SEARCH = "vector_search"
+
+
+class AssetLocations(BaseModel):
+    arrays: StorageLocation
+    files: StorageLocation
+    groups: StorageLocation
+    ml_models: StorageLocation
+    notebooks: StorageLocation
+    task_graphs: StorageLocation
+    udfs: StorageLocation

--- a/src/tiledb/services/api_v1/models/groups.py
+++ b/src/tiledb/services/api_v1/models/groups.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class GroupUpdateInfo:
+    description: Optional[str]
+    name: Optional[str]
+    logo: Optional[str]
+    tags: Optional[List[str]]

--- a/src/tiledb/services/api_v1/models/namespaces.py
+++ b/src/tiledb/services/api_v1/models/namespaces.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class NamespaceActions(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    CREATE = "create"
+    DELETE = "delete"
+    EDIT = "edit"
+    READ_ARRAY_LOGS = "read_array_logs"
+    READ_JOB_LOGS = "read_job_logs"
+    READ_OBJECT_LOGS = "read_object_logs"
+    RUN_JOB = "run_job"
+    DELETE_ORGANIZATION = "delete_organization"
+    EDIT_ORGANIZATION = "edit_organization"
+    EDIT_BILLING = "edit_billing"

--- a/src/tiledb/services/api_v1/models/organizations.py
+++ b/src/tiledb/services/api_v1/models/organizations.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel
+
+from tiledb.services.api_v1.models.namespaces import NamespaceActions
+
+
+class OrganizationRoles(str, Enum):
+    OWNER = "owner"
+    ADMIN = "admin"
+    READ_WRITE = "read_write"
+    READ_ONLY = "read_only"
+
+
+class OrganizationUser(BaseModel):
+    user_id: str
+    organization_id: str
+    username: str
+    organization_name: str
+    role: OrganizationRoles
+    allowed_actions: List[NamespaceActions]

--- a/src/tiledb/services/api_v1/models/users.py
+++ b/src/tiledb/services/api_v1/models/users.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    id: str
+    username: str
+    name: str
+    email: str
+    is_valid_email: bool
+    stripe_connect: bool
+    company: str
+    logo: str
+    timezone: str
+    organizations: List[dict]
+    allowed_actions: List[str]
+    enabled_features: List[str]
+    unpaid_subscription: bool
+    default_s3_path: str
+    default_s3_path_credentials_name: str
+    asset_locations: Optional[dict] = None
+    default_namespace_charged: str
+    default_region: str

--- a/src/tiledb/services/api_v1/users.py
+++ b/src/tiledb/services/api_v1/users.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+import requests
+
+from tiledb.cloud import config
+from tiledb.services import errors
+from tiledb.services.api_v1.models.users import User
+from tiledb.services.http_actions import AllowedMethods
+from tiledb.services.http_actions import perform_request
+
+HOST = config.config.host
+USER_V1_URL = f"{HOST}/v1/user"
+USERS_V1_URL = f"{HOST}/v1/users"
+
+
+def get_user(request_session: Optional[requests.Session] = None) -> User:
+    try:
+        response = perform_request(
+            method=AllowedMethods.GET,
+            url=USER_V1_URL,
+            request_session=request_session,
+        )
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise errors.Unauthorized(
+                "You are not authorized to access this resource"
+            ) from exc
+        raise errors.TileDBCloudError() from exc
+
+    return User.model_validate(response.json())
+
+
+def get_user_with_username(
+    username: str, request_session: Optional[requests.Session] = None
+) -> User:
+    try:
+        response = perform_request(
+            method=AllowedMethods.GET,
+            url=f"{USERS_V1_URL}/{username}",
+            request_session=request_session,
+        )
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise errors.Unauthorized(
+                "You are not authorized to access this resource"
+            ) from exc
+        if exc.response.status_code == 404:
+            raise errors.NotFound(f"User with Username '{username}' not found") from exc
+        raise errors.TileDBCloudError() from exc
+
+    return User.model_validate(response.json())

--- a/src/tiledb/services/api_v2/__init__.py
+++ b/src/tiledb/services/api_v2/__init__.py
@@ -1,0 +1,3 @@
+from . import groups
+
+__all__ = ("groups",)

--- a/src/tiledb/services/api_v2/groups.py
+++ b/src/tiledb/services/api_v2/groups.py
@@ -1,0 +1,297 @@
+import posixpath
+import urllib.parse
+from typing import Optional, Tuple
+
+import requests
+
+import tiledb.cloud.tiledb_cloud_error as tce
+from tiledb.cloud import config
+from tiledb.cloud._common import utils
+from tiledb.services import errors
+from tiledb.services.api_v1 import arrays as v1_arrays
+from tiledb.services.api_v1 import groups as v1_groups
+from tiledb.services.api_v1 import users as v1_users
+from tiledb.services.http_actions import AllowedMethods
+from tiledb.services.http_actions import perform_request
+
+HOST = config.config.host
+GROUPS_V2_URL = f"{HOST}/v2/groups"
+
+
+# ============================
+#      Auxiliary Methods
+# ============================
+def _add_to(
+    *,
+    namespace: str,
+    name: str,
+    parent_uri: str,
+    credentials_name: str,
+    request_session: Optional[requests.Session] = None,
+) -> dict:
+    parent_ns, parent_name = utils.split_uri(parent_uri)
+    return update_group_contents(
+        group_namespace=parent_ns,
+        group_name=parent_name,
+        group_update_contents={
+            "group_changes": {
+                "members_to_add": [
+                    {
+                        "name": name,
+                        "uri": f"tiledb://{namespace}/{name}",
+                        "type": "GROUP",
+                    }
+                ]
+            }
+        },
+        credentials_name=credentials_name,
+        request_session=request_session,
+    )
+
+
+def _default_ns_path_cred(
+    namespace: Optional[str] = None,
+    request_session: Optional[requests.Session] = None,
+) -> Tuple[str, str, str]:
+    if namespace:
+        user = v1_users.get_user_with_username(namespace, request_session)
+        # TODO: Missing `get_organization` in case of error.
+    else:
+        user = v1_users.get_user()
+        namespace = user.username
+        assert namespace
+
+    return (
+        namespace,
+        f"{user.default_s3_path}/groups",
+        user.default_s3_path_credentials_name,
+    )
+
+
+# ============================
+#         API Methods
+# ============================
+def create(
+    name: str,
+    *,
+    namespace: Optional[str] = None,
+    parent_uri: Optional[str] = None,
+    storage_uri: Optional[str] = None,
+    credentials_name: Optional[str] = None,
+) -> int:
+    """Creates a new TileDB Cloud group.
+
+    :param name: The name of the group to create.
+    :param namespace: The namespace to create the group in.
+        If not provided, the current logged-in user will be used.
+    :param parent_uri: The parent URI to add the group to, if desired.
+    :param storage_uri: The backend URI where the group will be stored.
+        If not provided, uses the namespace's default storage path for groups.
+    :param credentials_name: The name of the storage credential to use for
+        creating the group. If not provided, uses the namespace's default
+        credential for groups.
+    :return int: Expected status code
+    """
+    with requests.session() as session:
+        if not (namespace and storage_uri and credentials_name):
+            namespace, default_path, default_cred = _default_ns_path_cred(
+                namespace, session
+            )
+            storage_uri = storage_uri or (default_path + "/" + name)
+            credentials_name = credentials_name or default_cred
+
+        try:
+            response = perform_request(
+                method=AllowedMethods.POST,
+                url=f"{GROUPS_V2_URL}/{namespace}",
+                acn=credentials_name,
+                body={
+                    "group_details": {
+                        "name": name,
+                        "uri": storage_uri,
+                    }
+                },
+                request_session=session,
+            )
+
+            if parent_uri:
+                _add_to(
+                    namespace=namespace,
+                    name=name,
+                    parent_uri=parent_uri,
+                    credentials_name=credentials_name,
+                    request_session=session,
+                )
+
+            return response.status_code
+        except requests.HTTPError as exc:
+            raise errors.TileDBCloudError() from exc
+
+
+def delete(uri: str, *, recursive: bool = False) -> int:
+    """
+    Deletes a TileDB Group given it's URI.
+
+    :param uri: TileDB Group URI.
+    :param recursive: Flag to delete the Group's contents,
+        defaults to False
+    :return int: Expected Status Code.
+    """
+    namespace, name = utils.split_uri(uri)
+    try:
+        response = perform_request(
+            method=AllowedMethods.DELETE,
+            url=f"{GROUPS_V2_URL}/{namespace}/{name}/delete",
+            params={"recursive": recursive},
+        )
+
+        return response.status_code
+    except requests.HTTPError as exc:
+        raise errors.TileDBCloudError() from exc
+
+
+def update_group_contents(
+    group_namespace: str,
+    group_name: str,
+    group_update_contents: dict,
+    credentials_name: str,
+    request_session: Optional[requests.Session] = None,
+) -> Tuple[int, Optional[dict]]:
+    try:
+        response = perform_request(
+            method=AllowedMethods.PATCH,
+            url=f"{GROUPS_V2_URL}/{group_namespace}/{group_name}",
+            acn=credentials_name,
+            body=group_update_contents,
+            request_session=request_session,
+        )
+
+        return response.status_code, response.json()
+    except requests.HTTPError as exc:
+        raise errors.TileDBCloudError() from exc
+    except requests.JSONDecodeError:
+        # Status 204 case
+        return response.status_code, None
+
+
+def register(
+    storage_uri: str,
+    *,
+    name: Optional[str] = None,
+    namespace: Optional[str] = None,
+    parent_uri: Optional[str] = None,
+    credentials_name: Optional[str] = None,
+) -> int:
+    """
+    Registers a pre-existing group.
+
+    :param storage_uri: The backend URI where the Group is stored.
+    :param name: The name to register the Group as, defaults to None
+    :param namespace: The namespace to register the group in.
+        If not provided, the current logged-in user will be used.
+    :param parent_uri: The parent URI to add the group to, if desired.
+    :param credentials_name: The name of the storage credential to use for
+        creating the group. If not provided, uses the namespace's default
+        credential for groups.
+    :return int: Expected status code
+    """
+    if not name:
+        # Extract the basename from the storage URI and use it for the name.
+        parsed_uri = urllib.parse.urlparse(storage_uri)
+        name = posixpath.basename(parsed_uri.path)
+
+    with requests.session() as session:
+        if not (namespace and credentials_name):
+            namespace, _, default_cred = _default_ns_path_cred(namespace, session)
+            credentials_name = credentials_name or default_cred
+
+        try:
+            response = perform_request(
+                method=AllowedMethods.PUT,
+                url=f"{GROUPS_V2_URL}/{namespace}",
+                acn=credentials_name,
+                body={
+                    "group_details": {
+                        "name": name,
+                        "uri": storage_uri,
+                        "access_credentials_name": credentials_name,
+                        "parent": parent_uri,
+                    }
+                },
+                request_session=session,
+            )
+
+            if parent_uri:
+                _add_to(
+                    namespace=namespace,
+                    name=name,
+                    parent_uri=parent_uri,
+                    credentials_name=credentials_name,
+                    request_session=session,
+                )
+
+            return response.status_code
+        except requests.HTTPError as exc:
+            raise errors.TileDBCloudError() from exc
+
+
+def deregister(
+    uri: str,
+    *,
+    recursive: bool = False,
+    credentials_name: Optional[str] = None,
+    request_session: Optional[requests.Session] = None,
+) -> int:
+    """
+    De-registers the given group from TileDB Cloud.
+
+    :param uri: The URI of the group to deregister.
+    :param recursive: If true, deregister the group recursively by de-registering
+        all of the elements of the group (and all elements of those groups,
+        recursively) before de-registering the group itself.
+    :param credentials_name: The name of the storage credential to use for
+        de-registering the group. If not provided, uses the namespace's default
+        credential for groups.
+    :return int: Expected status code
+    """
+    namespace, name = utils.split_uri(uri)
+    session = request_session or requests.session()
+
+    if not credentials_name:
+        _, _, credentials_name = _default_ns_path_cred(namespace, session)
+
+    if recursive:
+        group_contents = v1_groups.get_group_contents(uri, request_session=session)
+        pm = group_contents.get("pagination_metadata", {})
+        while pm.get("total_items", 0) > 0:
+            for member in group_contents.get("entries", []):
+                if member.get("array", None):
+                    array = member["array"]
+                    try:
+                        v1_arrays.deregister(uri=array["uri"], request_session=session)
+                    except Exception:
+                        # TODO: Add some logging
+                        continue
+                elif member.get("group", None):
+                    group = member["group"]
+                    deregister(
+                        uri=group["tiledb_uri"], recursive=True, request_session=session
+                    )
+                else:
+                    raise tce.TileDBCloudError("unexpected group member type")
+
+    try:
+        response = perform_request(
+            method=AllowedMethods.DELETE,
+            url=f"{GROUPS_V2_URL}/{namespace}/{name}",
+            acn=credentials_name,
+            # TODO: [DISCUSSION] Since v2 expects a "recursive" param,
+            #       it must be able to do the recursive de-registering
+            #       instead of doing it manually as we do above.
+            params={"recursive": recursive},
+            request_session=session,
+        )
+
+        return response.status_code
+    except requests.HTTPError as exc:
+        raise errors.TileDBCloudError() from exc

--- a/src/tiledb/services/errors.py
+++ b/src/tiledb/services/errors.py
@@ -1,0 +1,56 @@
+from tiledb import TileDBError
+
+
+class TileDBCloudError(TileDBError):
+    """Generic base TileDB Cloud API exception class."""
+
+    code = 500
+
+    def __init__(self, message=None, code=None) -> None:
+        super().__init__()
+
+        if code:
+            self.code = code
+        self.message = message or "Internal Server Error"
+
+    def __str__(self):
+        return f"[{self.message}] - Code: {self.code}"
+
+
+class BadRequest(TileDBCloudError):
+    """Custom Exception to be raised if a request sends wrong or malformed payload."""
+
+    code = 400
+
+
+class Unauthorized(TileDBCloudError):
+    """Custom Exception to be raised if a request user is not authenticated."""
+
+    code = 401
+
+
+class NotFound(TileDBCloudError):
+    """Custom Exception to be raised if a resource was not found."""
+
+    code = 404
+
+
+class MethodNotAllowed(TileDBCloudError):
+    """
+    Custom Exception to be raised if a request method
+    is not allowed by the endpoint service.
+    """
+
+    code = 405
+
+
+class ResourceConflict(TileDBCloudError):
+    """Custom Exception to be raised if a resource's state is not the expected."""
+
+    code = 409
+
+
+class Unavailable(TileDBCloudError):
+    """Custom Exception to be raised if a service was unavailable."""
+
+    pass

--- a/src/tiledb/services/http_actions.py
+++ b/src/tiledb/services/http_actions.py
@@ -1,0 +1,138 @@
+from enum import Enum
+from typing import Any, Dict, Optional
+
+import requests
+
+from tiledb.cloud import config
+from tiledb.services import errors
+
+
+class AllowedMethods(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
+
+def _prepare_headers(
+    *, acn: Optional[str] = None, extra_headers: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-TILEDB-REST-API-KEY": config.config.api_key["X-TILEDB-REST-API-KEY"],
+    }
+
+    if acn:
+        headers["X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME"] = acn
+    if extra_headers:
+        headers.update(extra_headers)
+
+    return headers
+
+
+def perform_request(
+    method: AllowedMethods,
+    url: str,
+    *,
+    # Common
+    acn: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    # GET
+    params: Optional[Dict[str, Any]] = None,
+    # POST
+    body: Optional[Dict[str, Any]] = None,
+    # Session
+    request_session: Optional[requests.Session] = None,
+) -> requests.Response:
+    """
+    Performs a request of a given Allowed Action to the provided endpoint.
+
+    :param method: An AllowedMethod from:
+        ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    :param url: Endpoint's url.
+    :param acn: Cloud Access Credentials Name, defaults to None.
+    :param headers: Request headers, defaults to None
+    :param params: Request path parameters, defaults to None.
+    :param body: Request body dictionary, defaults to None.
+    :param request_session: A requests.Session instance, defaults to None
+    :raises errors.Unavailable: In case of Connection or Timeout errors.
+    :return requests.Response: The endpoint response
+    """
+
+    headers = _prepare_headers(acn=acn, extra_headers=headers)
+    try:
+        actor = request_session or requests
+        response = actor.request(
+            method=method.value, url=url, params=params, json=body, headers=headers
+        )
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        raise errors.Unavailable("Endpoint '{}' is unavailable".format(url)) from exc
+
+    response.raise_for_status()
+    return response
+
+
+def perform_post_request(
+    url: str,
+    body: Dict[str, Any],
+    *,
+    acn: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    request_session: Optional[requests.Session] = None,
+) -> requests.Response:
+    """
+    Performs a PATCH request to the provided endpoint.
+
+    :param url: Endpoint's url.
+    :param body: Request body dictionary.
+    :param acn: Cloud Access Credentials Name, defaults to None.
+    :param headers: Request headers, defaults to None
+    :param request_session: A requests.Session instance, defaults to None
+    :raises errors.Unavailable: In case of Connection or Timeout errors.
+    :return requests.Response: The endpoint response
+    """
+    headers = _prepare_headers(acn=acn, **headers)
+    try:
+        if request_session:
+            response = request_session.post(url, json=body, headers=headers)
+        else:
+            response = requests.post(url, json=body, headers=headers)
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        raise errors.Unavailable("Endpoint '{}' is unavailable".format(url)) from exc
+
+    response.raise_for_status()
+    return response
+
+
+def perform_patch_request(
+    url: str,
+    body: Dict[str, Any],
+    *,
+    acn: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    request_session: Optional[requests.Session] = None,
+) -> requests.Response:
+    """
+    Performs a PATCH request to the provided endpoint.
+
+    :param url: Endpoint's url.
+    :param body: Request body dictionary.
+    :param acn: Cloud Access Credentials Name, defaults to None.
+    :param headers: Request headers, defaults to None
+    :param request_session: A requests.Session instance, defaults to None
+    :raises errors.Unavailable: In case of Connection or Timeout errors.
+    :return requests.Response: The endpoint response
+    """
+    headers = _prepare_headers(acn=acn, **headers)
+    try:
+        if request_session:
+            response = request_session.patch(url, json=body, headers=headers)
+        else:
+            response = requests.patch(url, json=body, headers=headers)
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        raise errors.Unavailable("Endpoint '{}' is unavailable".format(url)) from exc
+
+    response.raise_for_status()
+    return response

--- a/src/tiledb/services/invitations.py
+++ b/src/tiledb/services/invitations.py
@@ -1,0 +1,187 @@
+from typing import Sequence
+
+import requests
+
+from tiledb.cloud import client
+from tiledb.cloud import rest_api
+from tiledb.cloud import tiledb_cloud_error
+from tiledb.cloud._common import utils
+from tiledb.cloud.rest_api.models.invitation_array_share_email import (
+    InvitationArrayShareEmail,
+)
+from tiledb.cloud.rest_api.models.invitation_group_share_email import (
+    InvitationGroupShareEmail,
+)
+from tiledb.cloud.rest_api.models.invitation_organization_join_email import (
+    InvitationOrganizationJoinEmail,
+)
+
+# from tiledb.services import HOST
+from tiledb.services import errors
+from tiledb.services.http_actions import perform_fetch_request
+from tiledb.services.http_actions import perform_post_request
+
+INVITATIONS_V1_URL = "/v1/invitations/"
+
+
+def accept_invitation(invitation_id: str) -> dict:
+    """
+    Accept an invitation.
+
+    :param invitation_id: the ID of invitation about to be accepted.
+    :return dict: API Response JSON
+    """
+    try:
+        response = perform_post_request(url=f"{INVITATIONS_V1_URL}/{invitation_id}")
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 404:
+            raise errors.NotFound(
+                f"Invitation with ID '{invitation_id}' does not exist"
+            ) from exc
+        raise errors.TileDBCloudError() from exc
+
+    return response.json()
+
+
+def fetch_invitations(**filters) -> dict:
+    """
+    Fetches a paginated list of invitations.
+
+    :param str organization: name or ID of organization to filter
+    :param str array: name/uri of array that is url-encoded to filter
+    :param str group: name or ID of group to filter
+    :param int start: start time for tasks to filter by
+    :param int end: end time for tasks to filter by
+    :param int page: pagination offset
+    :param int per_page: pagination limit
+    :param str type: invitation type, "ARRAY_SHARE", "JOIN_ORGANIZATION"
+    :param str status: Filter to only return "PENDING", "ACCEPTED"
+    :param str orderby: sort by which field valid values include
+                        timestamp, array_name, organization_name
+    :return dict: Invitations and pagination metadata.
+    """
+    try:
+        response = perform_fetch_request(
+            url=f"{INVITATIONS_V1_URL}",
+            params={k: v for k, v in filters.items() if v is not None},
+        )
+    except requests.requests.HTTPError as exc:
+        raise errors.TileDBCloudError() from exc
+
+    return response.json()
+
+
+def invite_to_organization(
+    organization: str, *, recipients: Sequence[str], role: str
+) -> None:
+    """
+    Sends email to multiple recipients with joining information
+    regarding an organization.
+
+    :param organization: name or UUID of organization.
+    :param recipients: list of recipient emails/usernames.
+    :param role: role assigned to the recipient.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    email_invite = InvitationOrganizationJoinEmail(role, recipients)
+    try:
+        return invitation_api.join_organization(organization, email_invite)
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)
+
+
+def cancel_invite_to_organization(organization: str, *, invitation_id: str) -> None:
+    """
+    Cancels join organization invitation.
+
+    :param organization: name or UUID of organization.
+    :param invitation_id: the ID of invitation about to be canceled.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    try:
+        return invitation_api.cancel_join_organization(invitation_id, organization)
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)
+
+
+def invite_to_array(
+    uri: str, *, recipients: Sequence[str], actions: Sequence[str]
+) -> None:
+    """
+    Share array by email invite.
+
+    :param uri: URI of array in the form 'tiledb://<namespace>/<array>'
+    :param recipients: list of recipient emails/usernames.
+    :param actions: list of ArrayActions allowed to the recipient.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    namespace, uri = utils.split_uri(uri)
+    email_invite = InvitationArrayShareEmail(actions, recipients)
+    try:
+        return invitation_api.share_array_by_invite(namespace, uri, email_invite)
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)
+
+
+def cancel_invite_to_array(uri: str, *, invitation_id: str) -> None:
+    """
+    Cancels array sharing invitation.
+
+    :param uri: URI of array in the form 'tiledb://<namespace>/<array>'
+    :param invitation_id: the ID of invitation about to be canceled.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    namespace, uri = utils.split_uri(uri)
+    try:
+        return invitation_api.cancel_share_array_by_invite(
+            namespace, invitation_id, uri
+        )
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)
+
+
+def invite_to_group(
+    uri: str,
+    *,
+    recipients: Sequence[str],
+    array_actions: Sequence[str],
+    group_actions: Sequence[str],
+) -> None:
+    """
+    Sends email to multiple recipients with sharing information regarding a group.
+
+    :param uri: URI of group in the form 'tiledb://<namespace>/<group>'
+    :param recipients: list of recipient emails/usernames.
+    :param array_actions: list of ArrayActions allowed to the recipient.
+    :param group_actions: list of GroupActions allowed to the recipient.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    namespace, uri = utils.split_uri(uri)
+    email_invite = InvitationGroupShareEmail(array_actions, group_actions, recipients)
+    try:
+        return invitation_api.share_group_by_invite(namespace, uri, email_invite)
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)
+
+
+def cancel_invite_to_group(uri: str, *, invitation_id: str) -> None:
+    """
+    Cancels group sharing invitation.
+
+    :param uri: URI of group in the form 'tiledb://<namespace>/<group>'
+    :param invitation_id: the ID of invitation about to be canceled.
+    :return: None
+    """
+    invitation_api = client.build(rest_api.InvitationApi)
+    namespace, uri = utils.split_uri(uri)
+    try:
+        return invitation_api.cancel_share_group_by_invite(
+            namespace, invitation_id, uri
+        )
+    except rest_api.ApiException as exc:
+        raise tiledb_cloud_error.check_exc(exc)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,11 +14,11 @@ import tiledb
 import tiledb.cloud
 from tiledb.cloud import array
 from tiledb.cloud import client
-from tiledb.cloud import groups
 from tiledb.cloud import tasks
 from tiledb.cloud import tiledb_cloud_error
 from tiledb.cloud._common import json_safe
 from tiledb.cloud._common import testonly
+from tiledb.services.api_v1 import groups as v1_groups
 
 
 class BasicTests(unittest.TestCase):
@@ -36,7 +36,7 @@ class BasicTests(unittest.TestCase):
 
     def test_info(self):
         self.assertIsNotNone(array.info("tiledb://TileDB-Inc/quickstart_sparse"))
-        self.assertIsNotNone(groups.info("tiledb://TileDB-Inc/TileDB_101"))
+        self.assertIsNotNone(v1_groups.info("tiledb://TileDB-Inc/TileDB_101"))
 
     def test_list_shared_with(self):
         self.needsUnittestUser()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -6,13 +6,14 @@ from typing import List
 
 import tiledb
 from tiledb.cloud import client
-from tiledb.cloud import groups
 from tiledb.cloud._common import testonly
 from tiledb.cloud.array import delete_array
 from tiledb.cloud.array import info
 from tiledb.cloud.file import ingestion as file_ingestion
 from tiledb.cloud.file import udfs as file_udfs
 from tiledb.cloud.file import utils as file_utils
+from tiledb.services.api_v1 import groups as v1_groups
+from tiledb.services.api_v2 import groups as v2_groups
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -159,7 +160,7 @@ class TestFileIngestion(unittest.TestCase):
             f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
         ]
 
-        cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
+        cls.namespace, cls.storage_path, cls.acn = v2_groups._default_ns_path_cred()
         cls.namespace = cls.namespace.rstrip("/")
         cls.storage_path = cls.storage_path.rstrip("/")
         cls.destination = (
@@ -169,7 +170,7 @@ class TestFileIngestion(unittest.TestCase):
         cls.group_name = testonly.random_name("file_ingestion_test_group")
         cls.group_uri = f"tiledb://{cls.namespace}/{cls.group_name}"
         cls.group_destination = f"{cls.storage_path}/{cls.group_name}"
-        groups.create(cls.group_name, storage_uri=cls.group_destination)
+        v2_groups.create(cls.group_name, storage_uri=cls.group_destination)
 
         return super().setUpClass()
 
@@ -181,7 +182,7 @@ class TestFileIngestion(unittest.TestCase):
                 f"tiledb://{cls.namespace}/{fname}" for fname in cls.input_file_names
             ]
         )
-        groups.deregister(cls.group_uri)
+        v2_groups.deregister(cls.group_uri, recursive=True)
         return super().tearDownClass()
 
     def setUp(self) -> None:
@@ -235,7 +236,7 @@ class TestFileIngestion(unittest.TestCase):
             verbose=True,
         )
 
-        group_info = groups.info(self.group_uri)
+        group_info = v1_groups.info(self.group_uri)
         self.assertEqual(group_info.asset_count, len(self.test_file_uris))
 
         for fname in self.input_file_names:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,10 +1,10 @@
 import time
 import unittest
 
-from tiledb.cloud import client
-from tiledb.cloud import groups
-from tiledb.cloud import rest_api
 from tiledb.cloud._common import testonly
+from tiledb.services import errors
+from tiledb.services.api_v1 import groups as v1_groups
+from tiledb.services.api_v2 import groups as v2_groups
 
 TRIES = 5
 
@@ -12,54 +12,49 @@ TRIES = 5
 class GroupsTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.namespace, storage_path, _ = groups._default_ns_path_cred()
+        self.namespace, storage_path, _ = v2_groups._default_ns_path_cred()
         self.test_path = storage_path + "/" + testonly.random_name("groups_test")
 
     def assert_group_exists(self, name):
         """Asserts that a group exists, and gives it a few tries."""
-        api = client.build(rest_api.GroupsApi)
         for _ in range(TRIES):
             try:
-                api.get_group_contents(group_namespace=self.namespace, group_name=name)
+                v1_groups.get_group_contents(uri=f"tiledb://{self.namespace}/{name}")
                 return
-            except rest_api.ApiException:
+            except errors.TileDBCloudError:
                 pass  # try again
             time.sleep(1)
         self.fail(f"group {self.namespace}/{name} does not exist")
 
     def assert_group_not_exists(self, name):
         """Asserts that a group does not exist, giving it a few tries to go."""
-        api = client.build(rest_api.GroupsApi)
         for _ in range(TRIES):
             try:
-                api.get_group_contents(group_namespace=self.namespace, group_name=name)
-            except rest_api.ApiException as apix:
-                if apix.status in (400, 404):
-                    return
+                v1_groups.get_group_contents(uri=f"tiledb://{self.namespace}/{name}")
+            except (errors.BadRequest, errors.NotFound):
+                return
             time.sleep(1)
         self.fail(f"group {self.namespace}/{name} still exists")
 
     def test_create_deregister(self):
-        # TODO: This test leaves detritus around.
-        # Once we get true delete functions, clean that up.
         outer_name = testonly.random_name("outer")
         outer_storage_name = testonly.random_name(outer_name)
         outer_storage_path = f"{self.test_path}/{outer_storage_name}"
         outer_uri = f"tiledb://{self.namespace}/{outer_name}"
-        groups.create(outer_name, storage_uri=outer_storage_path)
+        v2_groups.create(outer_name, storage_uri=outer_storage_path)
         self.assert_group_exists(outer_name)
 
-        groups.deregister(outer_uri)
+        v2_groups.deregister(outer_uri)
         self.assert_group_not_exists(outer_name)
 
-        groups.register(outer_storage_path, name=outer_name)
+        v2_groups.register(outer_storage_path, name=outer_name)
         self.assert_group_exists(outer_name)
         inner_name = testonly.random_name("inner")
-        groups.create(inner_name, parent_uri=outer_uri)
+        v2_groups.create(inner_name, parent_uri=outer_uri)
         self.assert_group_exists(inner_name)
         for _ in range(TRIES):
             try:
-                groups.deregister(outer_uri, recursive=True)
+                v2_groups.deregister(outer_uri, recursive=True)
                 break
             except Exception:
                 time.sleep(2)
@@ -71,19 +66,22 @@ class GroupsTest(unittest.TestCase):
         group_storage_name = testonly.random_name(group_name)
         group_storage_path = f"{self.test_path}/{group_storage_name}"
         group_uri = f"tiledb://{self.namespace}/{group_name}"
-        groups.create(group_name, storage_uri=group_storage_path)
+        v2_groups.create(group_name, storage_uri=group_storage_path)
         self.assert_group_exists(group_name)
 
         description = "this is a test description"
         logo = "testLogo"
         tags = ["tag", "othertag"]
-        groups.update_info(group_uri, description=description, logo=logo, tags=tags)
-        group_info = groups.info(group_uri)
+        status_code = v1_groups.update_info(
+            group_uri, description=description, logo=logo, tags=tags
+        )
+        self.assertEqual(status_code, 204)
 
-        self.assertEqual(group_info.description, description)
-        self.assertEqual(group_info.logo, logo)
-        self.assertCountEqual(group_info.tags, tags)
+        group_info = v1_groups.info(group_uri)
+        self.assertEqual(group_info.get("description", None), description)
+        self.assertEqual(group_info.get("logo", None), logo)
+        self.assertCountEqual(group_info.get("tags", []), tags)
 
         # Cleanup
-        groups.deregister(group_uri)
+        v2_groups.deregister(group_uri)
         self.assert_group_not_exists(group_name)


### PR DESCRIPTION
# What it does:
- Adds the scaffolding of a solution to move away from OpenAPI for REST API integration.
- Moves v1 and v2 actions into services.
    - Major moves: Groups, Invitations.
    - Minor moves: Users, Arrays.

# Discussions:
1. Move away from OpenAPI based Config.
2. Needs request/response models for I/O validation.
     - Consider using [pydantic](https://docs.pydantic.dev/latest/) (also applies to the Config discussion)
     - Models will act as the "contract" between REST server and Cloud-Py
3. Add your consideration/suggestions etc. (also an internal discussion can be held in the ticket and/or the Notion Document)
 