### PR TITLE
Fix VCF multiallelic split of info_TILEDB_IAF

### DIFF
--- a/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/annotate.py
@@ -173,7 +173,7 @@ def _annotate(
         # Split multiallelic variants
         explode_cols = ["alt"]
 
-        if "af" in vcf_df:
+        if "info_TILEDB_IAF" in vcf_df:
             explode_cols.append(alt_af)
 
         vcf_df = vcf_df.explode(explode_cols)


### PR DESCRIPTION
Correctly split `info_TILEDB_IAF` in the VCF `annotate` transform function.