### PR TITLE
Add sharing and registration to tiledb.cloud.asset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,4 +3,5 @@
 ## Next (YYYY-MM-DD)
 
 - Add a tiledb.cloud.asset module with functions that allow management of
-  assets of any type. This module is exported from tiledb.cloud (gh-566).
+  assets of any type. This module is exported from tiledb.cloud (gh-566,
+  gh-577).

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -12,10 +12,13 @@ from .rest_api.models import GroupInfo  # type: ignore
 
 
 def delete(uri: str, recursive: bool = False) -> None:
-    """Deregister the asset and remove its physical groups and arrays from storage.
+    """Deregister an asset and remove its objects from storage.
 
-    :param str uri: tiledb URI of the asset.
-    :return: None.
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :param recursive: if True, contents of an asset will be recursively
+        deleted. Default: False.
+    :type recursive: bool
     """
     delete_map: Mapping[str, Callable] = {
         "array": array.delete_array,
@@ -29,7 +32,8 @@ def delete(uri: str, recursive: bool = False) -> None:
 def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """Retrieve information about an asset.
 
-    :param str uri: tiledb URI of the asset.
+    :param uri: tiledb URI of the asset.
+    :type uri: str
     :return: ArrayInfo or GroupInfo.
     """
     # Note: the URI can be either of the two forms, yes?
@@ -40,15 +44,40 @@ def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     return func(uri)
 
 
+def list_shared_with(uri: str) -> None:
+    """List an asset's sharing policies.
+
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :return: a list of ArraySharing or GroupSharing objects.
+    """
+    sharing_map: Mapping[str, Callable] = {
+        "array": array.list_shared_with,
+        "group": groups.list_shared_with,
+    }
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    func = sharing_map[asset_type]
+    return func(uri)
+
+
 def share(
     uri: str, namespace: str, permissions: Union[str, list[str]] = "read"
 ) -> None:
     """Give another namespace permission to access an asset.
 
-    :param str uri: tiledb URI of the asset.
-    :param str namespace: the namespace that the asset is shared with.
-    :param list[str] permissions: 'read', 'write', or ['read', 'write'].
-    :return: None.
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :param namespace: the target namespace.
+    :type namespace: str
+    :param permissions: 'read', 'write', or ['read', 'write'].
+    :type permissions: str or list[str]
+
+    For example, to make an asset readable by all, share it with the
+    "public" namespace:
+
+    >>> from tiledb.cloud import asset
+    >>> asset.share("tiledb://your-namespace/your-asset", "public", "read")
+
     """
     share_map: Mapping[str, Callable] = {
         "array": array.share_array,
@@ -57,3 +86,20 @@ def share(
     asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = share_map[asset_type]
     return func(uri, namespace, permissions)
+
+
+def unshare(uri: str, namespace: str) -> None:
+    """Remove access permissions for another namespace.
+
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :param namespace: the target namespace.
+    :type namespace: str
+
+    For example:
+
+    >>> from tiledb.cloud import asset
+    >>> asset.unshare("tiledb://your-namespace/your-asset", "guest")
+
+    """
+    share(uri, namespace, [])

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -14,7 +14,7 @@ from .rest_api.models import GroupInfo  # type: ignore
 def delete(uri: str, recursive: bool = False) -> None:
     """Deregister the asset and remove its physical groups and arrays from storage.
 
-    :param uri: tiledb URI of the asset.
+    :param str uri: tiledb URI of the asset.
     :return: None.
     """
     delete_map: Mapping[str, Callable] = {
@@ -29,7 +29,7 @@ def delete(uri: str, recursive: bool = False) -> None:
 def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     """Retrieve information about an asset.
 
-    :param uri: tiledb URI of the asset.
+    :param str uri: tiledb URI of the asset.
     :return: ArrayInfo or GroupInfo.
     """
     # Note: the URI can be either of the two forms, yes?
@@ -38,3 +38,22 @@ def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
     func = info_map[asset_type]
     return func(uri)
+
+
+def share(
+    uri: str, namespace: str, permissions: Union[str, list[str]] = "read"
+) -> None:
+    """Give another namespace permission to access an asset.
+
+    :param str uri: tiledb URI of the asset.
+    :param str namespace: the namespace that the asset is shared with.
+    :param list[str] permissions: 'read', 'write', or ['read', 'write'].
+    :return: None.
+    """
+    share_map: Mapping[str, Callable] = {
+        "array": array.share_array,
+        "group": groups.share_group,
+    }
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    func = share_map[asset_type]
+    return func(uri, namespace, permissions)

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,7 +1,7 @@
 """An asset may be an array or a group."""
 
 from functools import partial
-from typing import Callable, Mapping, Union
+from typing import Callable, Mapping, Optional, Union
 
 import tiledb  # type: ignore
 
@@ -11,7 +11,83 @@ from .rest_api.models import ArrayInfo  # type: ignore
 from .rest_api.models import GroupInfo  # type: ignore
 
 
-def delete(uri: str, recursive: bool = False) -> None:
+def register(
+    storage_uri: str,
+    type: str,
+    *,
+    name: Optional[str] = None,
+    namespace: Optional[str] = None,
+    credentials_name: Optional[str] = None,
+    parent_uri: Optional[str] = None,
+) -> None:
+    """
+    Register stored objects as an asset.
+
+    :param storage_uri: S3, for example, URI of the data to be registered.
+    :type uri: str
+    :param type: The type of asset, "array" or "group".
+    :type type: str
+    :param namespace: The user or organization to register the asset
+        under. If unset will default to the logged-in user's namespace.
+    :type namespace: str
+    :param name: Name of asset.
+    :type name: str
+    :param description: Optional description.
+    :type description: str
+    :param credentials_name: Optional name of access credentials to use.
+        If omitted, the default for namespace will be used.
+    :type credentials_name: str
+    :param parent_uri: Optional parent URI for group type assets.
+    :type parent_uri: str
+
+    For example, to register an array stored on S3 in a bucket named
+    'your-bucket' with a prefix 'prefix' to your own namespace:
+
+    >>> from tiledb.cloud import asset
+    >>> asset.register(
+    ...     "s3://your-bucket/prefix",
+    ...     "array",
+    ...     name="new-array",
+    ... )
+    """
+    if type == "array":
+        array.register_array(
+            storage_uri,
+            namespace=namespace,
+            array_name=name,
+            access_credentials_name=credentials_name,
+        )
+    elif type == "group":
+        groups.register(
+            storage_uri,
+            name=name,
+            namespace=namespace,
+            credentials_name=credentials_name,
+            parent_uri=parent_uri,
+        )
+    else:
+        raise tiledb.TileDBError(f"Invalid asset type '{type}'")
+
+
+def deregister(uri: str, *, recursive: Optional[bool] = False) -> None:
+    """Deregister an asset.
+
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :param recursive: if True, contents of an asset will be recursively
+        deregistered Default: False.
+    :type recursive: bool
+    """
+    deregister_map: Mapping[str, Callable] = {
+        "array": array.deregister_array,
+        "group": partial(groups.deregister, recursive=recursive),
+    }
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    func = deregister_map[asset_type]
+    return func(uri)
+
+
+def delete(uri: str, *, recursive: Optional[bool] = False) -> None:
     """Deregister an asset and remove its objects from storage.
 
     :param uri: tiledb URI of the asset.
@@ -44,6 +120,51 @@ def info(uri: str) -> Union[ArrayInfo, GroupInfo]:
     return func(uri)
 
 
+def update_info(
+    uri: str,
+    *,
+    description: Optional[str] = None,
+    name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    access_credentials_name: Optional[str] = None,
+) -> None:
+    """
+    Update asset info settings.
+
+    :param uri: tiledb URI of the asset.
+    :type uri: str
+    :param description: Asset description, defaults to None
+    :type description: str
+    :param name: Asset name, defaults to None
+    :type name: str
+    :param tags: Asset tags, defaults to None
+    :type tags: list[str]
+
+    For example, to update only the description of an asset, call update_info()
+    with only a 'description' keyword argument:
+
+    >>> from tiledb.cloud import asset
+    >>> asset.update_info(
+    ...     "tiledb://your-namespace/your-asset",
+    ...     description="This is a new description"
+    ... )
+    """
+    # Note: logo not yet supported.
+    asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    if asset_type == "array":
+        return array.update_info(
+            uri,
+            array_name=name,
+            description=description,
+            access_credentials_name=access_credentials_name,
+            tags=tags,
+        )
+    elif asset_type == "group":
+        return groups.update_info(uri, description=description, name=name, tags=tags)
+    else:
+        raise tiledb.TileDBError(f"Invalid asset type '{asset_type}'")
+
+
 def list_shared_with(uri: str) -> None:
     """List an asset's sharing policies.
 
@@ -61,7 +182,7 @@ def list_shared_with(uri: str) -> None:
 
 
 def share(
-    uri: str, namespace: str, permissions: Union[str, list[str]] = "read"
+    uri: str, namespace: str, permissions: Optional[Union[str, list[str]]] = "read"
 ) -> None:
     """Give another namespace permission to access an asset.
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,12 +1,20 @@
 """Tests of the tiledb.cloud.asset module."""
 
+import time
+import unittest
 from unittest import mock
 
 from tiledb.cloud import asset  # type: ignore
+from tiledb.cloud import client
+from tiledb.cloud import groups
+from tiledb.cloud import rest_api
+from tiledb.cloud._common import testonly
 from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
 from tiledb.cloud.rest_api.models import ArraySharing  # type: ignore
 from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
 from tiledb.cloud.rest_api.models import GroupSharing  # type: ignore
+
+TRIES = 5
 
 
 @mock.patch("tiledb.object_type", return_value="array")
@@ -117,7 +125,7 @@ def test_public_array_sharing():
         "tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d"
     )
     assert len(sharing) == 2
-    assert sharing[0].namespace == "public"
+    assert "public" in set(policy.namespace for policy in sharing)
 
 
 def test_public_group_sharing():
@@ -127,3 +135,129 @@ def test_public_group_sharing():
     )
     assert len(sharing) == 1
     assert sharing[0].namespace == "public"
+
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch("tiledb.cloud.array.update_info")
+def test_asset_update_info_array_dispatch(update_array, object_type):
+    """Dispatch to array.update_info when URI is an array."""
+    asset.update_info("a", description="new description")
+    update_array.assert_called_once_with(
+        "a",
+        array_name=None,
+        description="new description",
+        access_credentials_name=None,
+        tags=None,
+    )
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.update_info")
+def test_asset_update_info_group_dispatch(update_group, object_type):
+    """Dispatch to groups.update_info when URI is a group."""
+    asset.update_info("g", description="new description")
+    update_group.assert_called_once_with(
+        "g", name=None, description="new description", tags=None
+    )
+
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch("tiledb.cloud.array.register_array")
+def test_asset_register_array_dispatch(register_array, object_type):
+    """Dispatch to array.register_array when URI is an array."""
+    asset.register("a", "array", name="foo", credentials_name="bar")
+    register_array.assert_called_once_with(
+        "a", namespace=None, array_name="foo", access_credentials_name="bar"
+    )
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.register")
+def test_asset_register_group_dispatch(register_group, object_type):
+    """Dispatch to groups.register when URI is a group."""
+    asset.register("a", "group", name="foo", credentials_name="bar")
+    register_group.assert_called_once_with(
+        "a", name="foo", namespace=None, credentials_name="bar", parent_uri=None
+    )
+
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch("tiledb.cloud.array.deregister_array")
+def test_asset_deregister_array_dispatch(deregister_array, object_type):
+    """Dispatch to array.deregister_array when URI is an array."""
+    asset.deregister("a")
+    deregister_array.assert_called_once_with("a")
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.deregister")
+def test_asset_deregister_group_dispatch(deregister_group, object_type):
+    """Dispatch to groups.deregister when URI is a group."""
+    asset.deregister("g")
+    deregister_group.assert_called_once_with("g", recursive=False)
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.deregister")
+def test_asset_deregister_group_recursive_dispatch(deregister_group, object_type):
+    """Dispatch to groups.deregister when URI is a group."""
+    asset.deregister("g", recursive=True)
+    deregister_group.assert_called_once_with("g", recursive=True)
+
+
+class RegistrationTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.namespace, storage_path, _ = groups._default_ns_path_cred()
+        self.test_path = storage_path + "/" + testonly.random_name("groups_test")
+
+    def assert_group_exists(self, name):
+        """Asserts that a group exists, and gives it a few tries."""
+        api = client.build(rest_api.GroupsApi)
+        for _ in range(TRIES):
+            try:
+                api.get_group_contents(group_namespace=self.namespace, group_name=name)
+                return
+            except rest_api.ApiException:
+                pass  # try again
+            time.sleep(1)
+        self.fail(f"group {self.namespace}/{name} does not exist")
+
+    def assert_group_not_exists(self, name):
+        """Asserts that a group does not exist, giving it a few tries to go."""
+        api = client.build(rest_api.GroupsApi)
+        for _ in range(TRIES):
+            try:
+                api.get_group_contents(group_namespace=self.namespace, group_name=name)
+            except rest_api.ApiException as apix:
+                if apix.status in (400, 404):
+                    return
+            time.sleep(1)
+        self.fail(f"group {self.namespace}/{name} still exists")
+
+    def test_create_deregister(self):
+        # TODO: This test leaves detritus around.
+        # Once we get true delete functions, clean that up.
+        outer_name = testonly.random_name("outer")
+        outer_storage_name = testonly.random_name(outer_name)
+        outer_storage_path = f"{self.test_path}/{outer_storage_name}"
+        outer_uri = f"tiledb://{self.namespace}/{outer_name}"
+        groups.create(outer_name, storage_uri=outer_storage_path)
+        self.assert_group_exists(outer_name)
+
+        asset.deregister(outer_uri)
+        self.assert_group_not_exists(outer_name)
+
+        asset.register(outer_storage_path, "group", name=outer_name)
+        self.assert_group_exists(outer_name)
+        inner_name = testonly.random_name("inner")
+        groups.create(inner_name, parent_uri=outer_uri)
+        self.assert_group_exists(inner_name)
+        for _ in range(TRIES):
+            try:
+                asset.deregister(outer_uri, recursive=True)
+                break
+            except Exception:
+                time.sleep(2)
+        self.assert_group_not_exists(outer_name)
+        self.assert_group_not_exists(inner_name)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -61,3 +61,19 @@ def test_public_group_asset_info():
     """Get info about a public production group."""
     info = asset.info("tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650")
     assert info.name == "langchain_documentation_huggingface"
+
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch("tiledb.cloud.array.share_array")
+def test_asset_share_array_dispatch(share_array, object_type):
+    """Dispatch to array.share_array when URI is an array."""
+    asset.share("a", "public", "read")
+    share_array.assert_called_once_with("a", "public", "read")
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.share_group")
+def test_asset_share_group_dispatch(share_group, object_type):
+    """Dispatch to groups.share when URI is a group."""
+    asset.share("g", "public", "read")
+    share_group.assert_called_once_with("g", "public", "read")

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -4,6 +4,8 @@ import time
 import unittest
 from unittest import mock
 
+import pytest
+
 from tiledb.cloud import asset  # type: ignore
 from tiledb.cloud import client
 from tiledb.cloud import groups
@@ -119,6 +121,7 @@ def test_asset_list_shared_with_group_dispatch(group_sharing, object_type):
     assert sharing[0].namespace == "bar"
 
 
+@pytest.mark.xfail(reason="Server error 610")
 def test_public_array_sharing():
     """Get a public production array's sharing policies."""
     sharing = asset.list_shared_with(

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -4,7 +4,9 @@ from unittest import mock
 
 from tiledb.cloud import asset  # type: ignore
 from tiledb.cloud.rest_api.models import ArrayInfo  # type: ignore
+from tiledb.cloud.rest_api.models import ArraySharing  # type: ignore
 from tiledb.cloud.rest_api.models import GroupInfo  # type: ignore
+from tiledb.cloud.rest_api.models import GroupSharing  # type: ignore
 
 
 @mock.patch("tiledb.object_type", return_value="array")
@@ -77,3 +79,33 @@ def test_asset_share_group_dispatch(share_group, object_type):
     """Dispatch to groups.share when URI is a group."""
     asset.share("g", "public", "read")
     share_group.assert_called_once_with("g", "public", "read")
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch("tiledb.cloud.groups.share_group")
+def test_asset_unshare_group_dispatch(share_group, object_type):
+    """Dispatch to groups.share when URI is a group."""
+    asset.unshare("g", "public")
+    share_group.assert_called_once_with("g", "public", [])
+
+
+@mock.patch("tiledb.object_type", return_value="array")
+@mock.patch(
+    "tiledb.cloud.array.list_shared_with", return_value=[ArraySharing(namespace="foo")]
+)
+def test_asset_list_shared_with_array_dispatch(array_sharing, object_type):
+    """Dispatch to array.list_shared_with when URI is an array."""
+    sharing = asset.list_shared_with("a")
+    assert isinstance(sharing[0], ArraySharing)
+    assert sharing[0].namespace == "foo"
+
+
+@mock.patch("tiledb.object_type", return_value="group")
+@mock.patch(
+    "tiledb.cloud.groups.list_shared_with", return_value=[GroupSharing(namespace="bar")]
+)
+def test_asset_list_shared_with_group_dispatch(group_sharing, object_type):
+    """Dispatch to groups.info when URI is a group."""
+    sharing = asset.list_shared_with("g")
+    assert isinstance(sharing[0], GroupSharing)
+    assert sharing[0].namespace == "bar"

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -109,3 +109,21 @@ def test_asset_list_shared_with_group_dispatch(group_sharing, object_type):
     sharing = asset.list_shared_with("g")
     assert isinstance(sharing[0], GroupSharing)
     assert sharing[0].namespace == "bar"
+
+
+def test_public_array_sharing():
+    """Get a public production array's sharing policies."""
+    sharing = asset.list_shared_with(
+        "tiledb://TileDB-Inc/cd89a0d6-c262-4729-9e75-d942879e1d7d"
+    )
+    assert len(sharing) == 2
+    assert sharing[0].namespace == "public"
+
+
+def test_public_group_sharing():
+    """Get a public production group's sharing policies."""
+    sharing = asset.list_shared_with(
+        "tiledb://TileDB-Inc/52165567-040c-4e75-bb89-a3d06017f650"
+    )
+    assert len(sharing) == 1
+    assert sharing[0].namespace == "public"


### PR DESCRIPTION
Starting with share() and tests.