### PR TITLE
Modify upload_wheel to use tiledb:// URIs

### DIFF
--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -1,11 +1,19 @@
+"""Install and access Python packages via wheel path or from PyPI."""
+
 import os
 import subprocess
 import sys
 import tempfile
 from site import USER_SITE
 from typing import Any, Mapping, Optional
+from dataclasses import dataclass
 
 import tiledb
+
+from tiledb.cloud.utilities import get_logger
+
+logger = get_logger()
+logger.propagate = False
 
 
 def upload_wheel(
@@ -13,7 +21,8 @@ def upload_wheel(
     wheel_path: str,
     dest_uri: str,
     config: Optional[Mapping[str, Any]] = None,
-):
+    overwrite: bool = False,
+) -> None:
     """
     THIS IS AN EXPERIMENTAL API. IT MAY CHANGE IN THE FUTURE.
 
@@ -37,6 +46,7 @@ def upload_wheel(
     :param wheel_path: path to the local wheel file
     :param dest_uri: URI where the wheel filestore will be created or updated
     :param config: config dictionary, defaults to None
+    :param overwrite: whether to overwrite a registered wheel if one exists.
     """
 
     # Replace '+' characters, which are not allowed in TileDB URL encoded URIs.
@@ -49,13 +59,75 @@ def upload_wheel(
         object_type = tiledb.object_type(dest_uri)
         if object_type is None:
             tiledb.Array.create(dest_uri, tiledb.ArraySchema.from_file(wheel_path))
-            print(f"Created filestore at '{dest_uri}'")
+            logger.info(f"Created filestore at '{dest_uri}'")
         elif object_type == "group":
             raise ValueError(f"A TileDB group exists at '{dest_uri}'")
+        elif object_type == "array" and not overwrite:
+            raise ValueError(
+                f"Wheel already exists at URI: {dest_uri}, toggle 'overwrite'"
+                " to overwrite existing wheel."
+            )
 
         # Copy the wheel to the array
         tiledb.Filestore.copy_from(dest_uri, wheel_path)
-        print(f"Uploaded '{wheel_path}' to '{dest_uri}'")
+        logger.info(f"Uploaded '{wheel_path}' to '{dest_uri}'")
+
+
+@dataclass
+class PipInstall:
+    """Pip installer."""
+
+    wheel: str
+    """Wheel URI or alternatively library name."""
+    in_venv: bool
+    """Whether in an active env."""
+    no_deps: bool = True
+    """Whether to install dependencies."""
+    runtime: str = sys.executable
+    """Path to python runtime exec."""
+
+    @property
+    def wheel_ext(self) -> bool:
+        """Does self.wheel have proper wheel extension?"""
+
+        parsed = os.path.splitext(self.wheel)
+        if parsed[-1] in (".whl", ".wheel"):
+            return True
+        else:
+            return False
+    
+    def install(self, wheel: str) -> subprocess.CompletedProcess:
+        """Install wheel.
+        
+        :param wheel: URI to registered wheel or name of library to install 
+            from PyPI.
+        """
+
+        cmd = [
+            self.runtime,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+        ]
+
+        if not self.in_venv:
+            cmd += ["--user"]
+        if self.no_deps:
+            cmd += ["--no-deps"]
+
+        cmd += [wheel]
+
+        # Capture stdout/stderr to reduce noise from pip for a successful install.
+        # (subprocess.check_output always displays stderr)
+        res = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        return res
 
 
 def install_wheel(
@@ -63,7 +135,7 @@ def install_wheel(
     config: Optional[Mapping[str, Any]] = None,
     verbose: bool = False,
     no_deps: bool = True,
-):
+) -> None:
     """
     THIS IS AN EXPERIMENTAL API. IT MAY CHANGE IN THE FUTURE.
 
@@ -75,44 +147,37 @@ def install_wheel(
     :param no_deps: do not install dependencies, defaults to True
     """
 
-    with tiledb.scope_ctx(config):
-        # Get the original wheel file name from metadata.
-        with tiledb.open(wheel_uri) as A:
-            wheel_file = A.meta["original_file_name"] + "." + A.meta["file_extension"]
+    installer = PipInstall(
+        wheel=wheel_uri,
+        in_venv=sys.prefix != sys.base_prefix,
+        no_deps=no_deps,
+    )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Copy the wheel to a temporary directory
-            wheel_path = os.path.join(tmpdir, wheel_file)
+    if installer.wheel_ext:
+        with tiledb.scope_ctx(config):
+            # Get the original wheel file name from metadata.
+            with tiledb.open(wheel_uri) as A:
+                wheel_file = A.meta["original_file_name"] + "." + A.meta["file_extension"]
 
-            tiledb.Filestore.copy_to(wheel_uri, wheel_path)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Copy the wheel to a temporary directory
+                wheel_path = os.path.join(tmpdir, wheel_file)
 
-            # Install the wheel in a venv or user site
-            in_venv = sys.prefix != sys.base_prefix
+                tiledb.Filestore.copy_to(wheel_uri, wheel_path)
+                res = installer.install(wheel=wheel_path)
 
-            cmd = [sys.executable, "-m", "pip", "install", "--force-reinstall"]
-            if not in_venv:
-                cmd += ["--user"]
-            if no_deps:
-                cmd += ["--no-deps"]
-            cmd += [wheel_path]
+    # attempt to install from PyPI, assume library name given
+    else:
+        res = installer.install(wheel=wheel_uri)
 
-            # Capture stdout/stderr to reduce noise from pip for a successful install.
-            # (subprocess.check_output always displays stderr)
-            res = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
+    if res.returncode != 0:
+        logger.info(f"Failed to install wheel '{wheel_uri}'")
+        print(res.stdout)
+        print(res.stderr)
+    elif verbose:
+        print(res.stdout)
+        print(res.stderr)
 
-            if res.returncode != 0:
-                print(f"Failed to install wheel '{wheel_path}'")
-                print(res.stdout)
-                print(res.stderr)
-            elif verbose:
-                print(res.stdout)
-                print(res.stderr)
-
-            # Modify sys.path if the wheel was installed with --user
-            if not in_venv and USER_SITE not in sys.path:
-                sys.path.insert(0, USER_SITE)
+    # Modify sys.path if the wheel was installed with --user
+    if not installer.in_venv and USER_SITE not in sys.path:
+        sys.path.insert(0, USER_SITE)

--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -4,12 +4,11 @@ import os
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from site import USER_SITE
 from typing import Any, Mapping, Optional
-from dataclasses import dataclass
 
 import tiledb
-
 from tiledb.cloud.utilities import get_logger
 
 logger = get_logger()
@@ -95,11 +94,11 @@ class PipInstall:
             return True
         else:
             return False
-    
+
     def install(self, wheel: str) -> subprocess.CompletedProcess:
         """Install wheel.
-        
-        :param wheel: URI to registered wheel or name of library to install 
+
+        :param wheel: URI to registered wheel or name of library to install
             from PyPI.
         """
 
@@ -157,7 +156,9 @@ def install_wheel(
         with tiledb.scope_ctx(config):
             # Get the original wheel file name from metadata.
             with tiledb.open(wheel_uri) as A:
-                wheel_file = A.meta["original_file_name"] + "." + A.meta["file_extension"]
+                wheel_file = (
+                    A.meta["original_file_name"] + "." + A.meta["file_extension"]
+                )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 # Copy the wheel to a temporary directory


### PR DESCRIPTION
Modify upload_wheel to use tiledb://...s3://... URIs to create, register, and update the wheel filestore. This avoids the need for s3 credentials.

Thanks to @spencerseale for the suggestion and prototyping.