### PR TITLE
Fix new test partitioning in GitHub Actions runs.

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -129,16 +129,19 @@ jobs:
         # Test pinned dependencies on commit / tag and fresh installs on nightlies
         if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
-          .github/scripts/retry 3 \
-            pytest -sv \
-            --last-failed \
+          pytest -sv \
             --tb short \
             --color yes \
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
             --group ${{ matrix.pytest-split-group }} \
             --store-durations \
             --splitting-algorithm least_duration \
-            --clean-durations
+            --clean-durations \
+          || .github/scripts/retry 2 \
+            pytest -sv \
+            --last-failed \
+            --tb short \
+            --color yes
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 


### PR DESCRIPTION
When adding a new test to the suite, it won't have timing information on its initial run. However, once it runs once, it will have timings, but adding its timings to the existing database may result in the sharding getting changed. This means that if the test fails, the rerun may not include the failing test, as seen in test logs:

https://github.com/TileDB-Inc/TileDB-Cloud-Py/actions/runs/9388190301/job/25852891056#step:11:160

    [pytest-split] Splitting tests with algorithm: least_duration
    [pytest-split] Running group 2/6 (estimated duration: 114.28s)

    collected 245 items / 184 deselected / 61 selected
    run-last-failure: 1 known failures not in selected tests

Instead, we ask pytest to run exclusively the tests that just failed when doing a rerun, and don't re-shard at all.

---

This was part of #576 but I want to commit it on its own to document *why* we did what we did here.