### PR TITLE
Add `region` kw argument to `login`.

### DIFF
--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -78,7 +78,8 @@ def login(
     :param token: api token for login
     :param username: username for login
     :param password: password for login
-    :param host: host to login to
+    :param host: host to login to. the tiledb.cloud.regions module contains
+        region-specific host constants.
     :param verify_ssl: Enable strict SSL verification
     :param no_session: don't create a session token on login,
         store instead username/password

--- a/src/tiledb/cloud/region/__init__.py
+++ b/src/tiledb/cloud/region/__init__.py
@@ -1,0 +1,19 @@
+class AWS:
+    """
+    The AWS cloud regions that are currently supported.
+
+    US_EAST_1 = North America, United States (Virginia)
+    US_WEST_1 = North America, United States (California)
+    EU_WEST_1 = Europe, Ireland
+    EU_WEST_2 = Europe, London
+    AP_SOUTHEAST_1 = Asia, Singapore
+    """
+
+    US_EAST_1 = "https://us-east-1.aws.api.tiledb.com"
+    US_WEST_1 = "https://us-west-1.aws.api.tiledb.com"
+    EU_WEST_1 = "https://eu-west-1.aws.api.tiledb.com"
+    EU_WEST_2 = "https://eu-west-2.aws.api.tiledb.com"
+    AP_SOUTHEAST_1 = "https://ap-southeast-1.aws.api.tiledb.com"
+
+
+__all__ = ("AWS",)


### PR DESCRIPTION
As mentioned in [this story](https://app.shortcut.com/tiledb-inc/story/48037/design-improve-support-for-running-task-graphs-in-specific-regions), there are several ways to allow users to specify the region:

1. Modify `tiledb.cloud.client.config.config.host` directly, which is the status quo.
2. Add a `region` keyword argument to classes like `DAG`, `Delayed`, etc.
3. Specify the region as part of logging in (this PR implements a PoC).

The first option is confusing to customers, so we need a better approach. I've been playing with the second approach and find it confusing too: It's easy to forget to pass the `region` argument. Besides, if a user wants to run a task graph in region *A*, odds are that they want all their code to run in region *A*. The third approach strikes me as the safest and least confusing but it feels odd having to specify the region as part of the login function, like so:
```python
tiledb.cloud.login(..., region=tiledb.cloud.AwsRegion.AP_SOUTHEAST_1)
```
Or perhaps we should instead expose a new function, like `tiledb.cloud.set_region()`? Any thoughts on this?