### PR TITLE
File ingestion and indexing chained graph.

### DIFF
--- a/src/tiledb/cloud/files/indexing.py
+++ b/src/tiledb/cloud/files/indexing.py
@@ -258,8 +258,6 @@ def ingest_files(
         Suffixes must include the dot, e.g. ".txt"
     :param max_files: Maximum number of files to include.
     :param text_splitter_kwargs: Arguments for the splitter class.
-    # SentenceTransformersEmbedding params.
-    :param model_name_or_path: Huggingface SentenceTransformer model name or path
     # Index update params.
     :param index_timestamp: Timestamp to add index updates at.
     :param workers: If `embeddings_generation_mode=BATCH` this is the number of
@@ -306,6 +304,7 @@ def ingest_files(
         write of centroids.
     :param partial_index_resources: Resources to request when performing the
         computation of partial indexing.
+    :return str: The resulting TaskGraph's server UUID.
     """
 
     from tiledb.cloud.utilities import run_dag
@@ -393,7 +392,11 @@ def ingest_files(
     )
 
     ingest_files_node.depends_on(create_index_node)
+
+    # Start the indexing process
+    ## graph is waited by default using `run_dag`
     run_dag(graph, debug=verbose)
+    return str(graph.server_graph_uuid)
 
 
 index = as_batch(ingest_files)

--- a/src/tiledb/cloud/files/ingestion.py
+++ b/src/tiledb/cloud/files/ingestion.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import tiledb
 import tiledb.cloud
@@ -10,8 +10,11 @@ from tiledb.cloud.array import info
 from tiledb.cloud.dag.mode import Mode
 from tiledb.cloud.files import udfs as file_udfs
 from tiledb.cloud.files import utils as file_utils
+from tiledb.cloud.files.indexing import IndexTypes
+from tiledb.cloud.files.indexing import ingest_files as index_files
 from tiledb.cloud.utilities import as_batch
 from tiledb.cloud.utilities import get_logger_wrapper
+from tiledb.cloud.utilities import run_dag
 
 DEFAULT_FILE_INGESTION_NAME = "file-ingestion"
 
@@ -162,7 +165,7 @@ def ingest_files(
     :param ingest_resources: Configuration for node specs,
         defaults to {"cpu": "1", "memory": "2Gi"}
     :param verbose: Verbose logging, defaults to False
-    :return str: The resulting TaskGraph's server UUID as string.
+    :return str: The resulting TaskGraph's server UUID.
     """
     # Argument Validation
     if not search_uri:
@@ -281,8 +284,249 @@ def ingest_files(
         ).depends_on(ingested)
 
     # Start the ingestion process
-    graph.compute()
+    ## graph is waited by default using `run_dag`
+    run_dag(graph, debug=verbose)
     return str(graph.server_graph_uuid)
 
 
 ingest = as_batch(ingest_files)
+
+
+# ====================================
+#         Ingest and Index
+# ====================================
+def ingest_and_index(
+    dataset_uri: str,
+    search_uri: str,
+    index_uri: str,
+    *,
+    # Configuration params
+    acn: Optional[str] = None,
+    config: Optional[dict] = None,
+    namespace: Optional[str] = None,
+    # Common params
+    environment_variables: Optional[Mapping[str, str]] = None,
+    pattern: Optional[str] = None,
+    ignore: Optional[str] = None,
+    max_files: Optional[int] = None,
+    trace_id: Optional[str] = None,
+    wait: bool = False,
+    verbose: bool = False,
+    # Ingest params
+    group_uri: Optional[str] = None,
+    batch_size: Optional[int] = file_udfs.DEFAULT_BATCH_SIZE,
+    taskgraph_name: Optional[str] = None,
+    ingest_resources: Optional[Mapping[str, Any]] = dag.MIN_BATCH_RESOURCES,
+    # Index creation params
+    index_type: IndexTypes = IndexTypes.IVF_FLAT,
+    index_creation_kwargs: Optional[Dict] = None,
+    index_dag_resources: Optional[Mapping[str, Any]] = dag.MIN_BATCH_RESOURCES,
+    # DirectoryTextReader params
+    text_splitter: str = "RecursiveCharacterTextSplitter",
+    text_splitter_kwargs: Optional[Dict] = None,
+    suffixes: Optional[Sequence[str]] = None,
+    # Embedding params
+    embedding_class: str = "LangChainEmbedding",
+    embedding_kwargs: Optional[Dict] = None,
+    openai_key: Optional[str] = None,
+    # Index update params
+    index_timestamp: Optional[int] = None,
+    workers: int = -1,
+    worker_resources: Optional[Dict] = None,
+    worker_image: Optional[str] = None,
+    extra_worker_modules: Optional[List[str]] = None,
+    driver_resources: Optional[Dict] = None,
+    driver_image: Optional[str] = None,
+    extra_driver_modules: Optional[List[str]] = None,
+    max_tasks_per_stage: int = -1,
+    embeddings_generation_mode: dag.Mode = dag.Mode.BATCH,
+    embeddings_generation_driver_mode: dag.Mode = dag.Mode.BATCH,
+    vector_indexing_mode: dag.Mode = dag.Mode.BATCH,
+    index_update_kwargs: Optional[Dict] = None,
+    ## Vector Search BATCH Embedding Resources
+    threads: str = "16",
+    index_resources: Optional[Dict] = None,
+    consolidate_partition_resources: Optional[Dict] = None,
+    copy_centroids_resources: Optional[Dict] = None,
+    random_sample_resources: Optional[Dict] = None,
+    kmeans_resources: Optional[Dict] = None,
+    compute_new_centroids_resources: Optional[Dict] = None,
+    assign_points_and_partial_new_centroids_resources: Optional[Dict] = None,
+    write_centroids_resources: Optional[Dict] = None,
+    partial_index_resources: Optional[Dict] = None,
+) -> str:
+    """
+     Ingest files into a dataset and index them afterwards.
+
+     :param dataset_uri: The dataset URI
+     :param search_uri: URI or an iterable of URIs of input files.
+     :param index_uri: URI of the vector index to load files to.
+     # Configuration params
+     :param acn: Access Credentials Name (ACN) registered in TileDB Cloud (ARN type),
+         defaults to None
+     :param config: Config dictionary, defaults to None
+     :param namespace: TileDB-Cloud namespace, defaults to None
+     # Common params
+     :param environment_variables: Environment variables to use during ingestion.
+     :param pattern: UNIX shell style pattern to filter files in the search,
+         defaults to None
+     :param ignore: UNIX shell style pattern to filter files out of the search,
+         defaults to None
+     :param max_files: maximum number of File URIs to read/find,
+         defaults to None (no limit)
+     :param trace_id: trace ID for logging, defaults to None.
+     :param wait: wait for completion, defaults to False (non-blocking)
+     :param verbose: Verbose logging, defaults to False
+     # Ingest params
+     :param group_uri: A TileDB Group URI, defaults to None.
+     :param batch_size: Batch size for file ingestion, defaults to 100.
+     :param taskgraph_name: Optional name for taskgraph, defaults to None.
+     :param ingest_resources: Configuration for node specs,
+         defaults to {"cpu": "1", "memory": "2Gi"}
+     # Index creation params
+     :param index_type: Vector search index type ("FLAT", "IVF_FLAT").
+     :param index_creation_kwargs: Arguments to be passed to the index creation
+         method.
+     :param index_dag_resources: Index creation Node Specs configuration.
+     # DirectoryTextReader params.
+     :param text_splitter: Text splitter class,
+         defaults to "RecursiveCharacterTextSplitter"
+     :param text_splitter_kwargs: Arguments for the splitter class.
+     :param suffixes: Provide to keep only files with these suffixes
+         Useful when wanting to keep files with different suffixes
+         Suffixes must include the dot, e.g. ".txt"
+     # Embedding params
+     :param embedding_class: Embedding class, defaults to "LangChainEmbedding"
+     :param embedding_kwargs: Arguments of the embedding class, defaults to None
+     :param openai_key: OpenAI key, defaults to None
+    # Index update params.
+     :param index_timestamp: Timestamp to add index updates at.
+     :param workers: If `embeddings_generation_mode=BATCH` this is the number of
+         distributed workers to be used.
+     :param worker_resources: If `embeddings_generation_mode=BATCH` this can be used
+         to specify the worker resources.
+     :param worker_image: If `embeddings_generation_mode=BATCH` this can be used
+         to specify the worker Docker image.
+     :param extra_worker_modules: If `embeddings_generation_mode=BATCH` this can be
+         used to install extra pip package to the image.
+     :param driver_resources: If `embeddings_generation_driver_mode=BATCH` this can
+         be used to specify the driver resources.
+     :param driver_image: If `embeddings_generation_driver_mode=BATCH` this can be
+         used to specify the driver Docker image.
+     :param extra_driver_modules: If `embeddings_generation_driver_mode=BATCH` this
+         can be used to install extra pip package to the image.
+     :param max_tasks_per_stage: Number of maximum udf tasks per computation stage.
+     :param embeddings_generation_mode: TaskGraph execution mode for embeddings
+         generation.
+     :param embeddings_generation_driver_mode: TaskGraph execution mode for the
+         ingestion driver.
+     :param vector_indexing_mode: TaskGraph execution mode for the vector indexing.
+     :param index_update_kwargs: Extra arguments to pass to the index update job.
+         These can be any of the documented tiledb.vector_search.ingest method with the
+         exception of BATCH Embedding Resources (see next params):
+         https://tiledb-inc.github.io/TileDB-Vector-Search/documentation/reference/ingestion.html#tiledb.vector_search.ingestion.ingest
+         Also `files_per_partition: int` can be included (defaults to -1)
+     ## Vector Search BATCH Embedding Resources
+     ## These are only applicable if indexing update is executed in BATCH mode.
+     :param threads: Threads to be used in the Nodes, defaults to 16.
+     :param ingest_resources: Resources to request when performing vector ingestion.
+     :param consolidate_partition_resources: Resources to request when performing
+         consolidation of a partition.
+     :param copy_centroids_resources: Resources to request when performing copy
+         of centroids from input array to output array.
+     :param random_sample_resources: Resources to request when performing random
+         sample selection.
+     :param kmeans_resources: Resources to request when performing kmeans task.
+     :param compute_new_centroids_resources: Resources to request when performing
+         centroid computation.
+     :param assign_points_and_partial_new_centroids_resources: Resources to request
+         when performing the computation of partial centroids.
+     :param write_centroids_resources: Resources to request when performing the
+         write of centroids.
+     :param partial_index_resources: Resources to request when performing the
+         computation of partial indexing.
+
+     :return str: The resulting TaskGraph's server UUID.
+    """
+    # Graph Setup
+    taskgraph_name = taskgraph_name or "files-ingest-and-index"
+    graph = dag.DAG(
+        name=taskgraph_name,
+        namespace=namespace,
+        mode=Mode.BATCH,
+    )
+
+    # Step 1: File ingestion graph
+    ingestion = graph.submit(
+        ingest_files,
+        dataset_uri,
+        search_uri=search_uri,
+        pattern=pattern,
+        ignore=ignore,
+        max_files=max_files,
+        batch_size=batch_size,
+        acn=acn,
+        config=config,
+        namespace=namespace,
+        group_uri=group_uri,
+        taskgraph_name=f"initiated from: ({taskgraph_name})",
+        ingest_resources=ingest_resources,
+        verbose=verbose,
+    )
+
+    # Step 2: File indexing graph
+    indexing = graph.submit(
+        index_files,
+        # Search in the ingested files' uri
+        search_uri=dataset_uri,
+        index_uri=index_uri,
+        acn=acn,
+        config=config,
+        environment_variables=environment_variables,
+        namespace=namespace,
+        verbose=verbose,
+        trace_id=trace_id,
+        index_type=index_type,
+        index_creation_kwargs=index_creation_kwargs,
+        index_dag_resources=index_dag_resources,
+        include=pattern,
+        exclude=ignore,
+        suffixes=suffixes,
+        max_files=max_files,
+        text_splitter=text_splitter,
+        text_splitter_kwargs=text_splitter_kwargs,
+        embedding_class=embedding_class,
+        embedding_kwargs=embedding_kwargs,
+        openai_key=openai_key,
+        index_timestamp=index_timestamp,
+        workers=workers,
+        worker_resources=worker_resources,
+        worker_image=worker_image,
+        extra_worker_modules=extra_worker_modules,
+        driver_resources=driver_resources,
+        driver_image=driver_image,
+        extra_driver_modules=extra_driver_modules,
+        max_tasks_per_stage=max_tasks_per_stage,
+        embeddings_generation_mode=embeddings_generation_mode,
+        embeddings_generation_driver_mode=embeddings_generation_driver_mode,
+        vector_indexing_mode=vector_indexing_mode,
+        index_update_kwargs=index_update_kwargs,
+        threads=threads,
+        ingest_resources=index_resources,
+        consolidate_partition_resources=consolidate_partition_resources,
+        copy_centroids_resources=copy_centroids_resources,
+        random_sample_resources=random_sample_resources,
+        kmeans_resources=kmeans_resources,
+        compute_new_centroids_resources=compute_new_centroids_resources,
+        assign_points_and_partial_new_centroids_resources=assign_points_and_partial_new_centroids_resources,
+        write_centroids_resources=write_centroids_resources,
+        partial_index_resources=partial_index_resources,
+    )
+    indexing.depends_on(ingestion)
+
+    # Start the ingestion and indexing process
+    run_dag(graph, wait=wait, debug=verbose)
+    return str(graph.server_graph_uuid)
+
+
+ingest_and_index = as_batch(ingest_and_index)


### PR DESCRIPTION
Implements a method that chains file ingestion with file indexing graphs.

- Spawns an ingestion graph that is awaited by the indexing graph.
- Utilizes the existing ingestion and indexing methods.
- Has the same defaults that both the respective methods provide.