### PR TITLE
Insert expression for DAG retries

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -17,6 +17,7 @@ DEFAULT_IMG_NAME = "3.9-imaging-dev"
 DEFAULT_DAG_NAME = "bioimg-ingestion"
 _SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".ndpi")
 _SUPPORTED_CONVERTERS = ("tiff", "zarr", "osd")
+OOM_EXPRESSION = "asInt(lastRetry.exitCode) != 137"
 
 
 def ingest(
@@ -327,6 +328,9 @@ def ingest(
         retry_strategy=RetryStrategy(
             limit=3,
             retry_policy="Always",
+            # Exclude retries when the last one returns a signal that
+            # container's memory exceeds the memory limit
+            expression=OOM_EXPRESSION,
         ),
     )
 


### PR DESCRIPTION
This PR:

- Adds an `expression` to the DAG retry strategy of bioimg ingestion in accordance with this [prototype]( https://github.com/TileDB-Inc/TileDB-Cloud-REST/blob/81269ec5650d4d37d1eb49b5f69cd41856dc8bf4/internal/taskgraphs/batch/spec/translate.go#L745)
- The expression will not allow retries when the last task will return an OOM exit code for the container running it.
- The test was successful when ran in cloud staging/prod. Unfortunately, there is no way to retrieve the number of retries.

Note: I am not sure if this should work, since this is my first attempt trying sth like that so comments are welcome. After an initial pass I guess I can write some unittests testing that.