### PR TITLE
Fix soma collection mapper viz

### DIFF
--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -256,7 +256,7 @@ def build_collection_mapper_workflow_graph(
 
     node_outputs = {}
 
-    for _, soma_experiment_uri in soma_experiment_uris.items():
+    for experiment_name, soma_experiment_uri in soma_experiment_uris.items():
         node_output = grf.submit(
             _function_for_node,
             soma_experiment_uri,
@@ -275,7 +275,7 @@ def build_collection_mapper_workflow_graph(
             resource_class=resource_class,
             # Eaten by UDF infra -- won't make it to our callee as kwarg:
             access_credentials_name=access_credentials_name,
-            name=soma_experiment_uri,
+            name=experiment_name,
         )
         logger.info("A: node output is a %s" % type(node_output))
 


### PR DESCRIPTION
Currently, `tiledb.cloud.soma.build_collection_mapper_workflow_graph()` [uses experiment URIs to name task graph nodes](https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/main/src/tiledb/cloud/soma/mapper.py#L278). This was a reasonable choice but it prevents visualizing the graph because [pydot nodes can't contain colons](https://github.com/pydot/pydot/issues/258).

This PR uses experiment names to name the nodes so we can generate the task graph visualization.


<img width="932" alt="Screenshot 2024-06-07 at 12 57 04 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-Py/assets/1067915/711fdaff-6e14-44ea-af82-81657470553e">
