### PR TITLE
Put urllib3.BaseHTTPResponse annotation in quotes.

### DIFF
--- a/src/tiledb/cloud/_common/utils.py
+++ b/src/tiledb/cloud/_common/utils.py
@@ -92,7 +92,7 @@ def ephemeral_thread(func: _CT, name: Optional[str] = None) -> _CT:
     return wrapper  # type: ignore[return-value]
 
 
-def release_connection(resp: urllib3.BaseHTTPResponse) -> None:
+def release_connection(resp: "urllib3.BaseHTTPResponse") -> None:
     """Release the backing connection of this HTTPResponse to the pool.
 
     When a call is made with ``preload_content=False``, the response body is not


### PR DESCRIPTION
The latest release of tiledb-cloud on PyPI has an import exception when used with old versions of urllib3, which don’t include the BaseHTTPResponse class. We only use that in an annotation, and it’s the only thing from recent urllib3 that we use, so by putting it in quotes, we can avoid evaluating it and triggering the error.