### PR TITLE
Fix reported issues with API doc generation.

### DIFF
--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -118,6 +118,11 @@ quartodoc:
   package: tiledb.cloud
   title: API Reference
 
+  options:
+    include_classes: true
+    include_functions: true
+    include_attributes: true
+
   sections:
     - title: Cloud Services
       desc: Cloud Interaction Services

--- a/src/tiledb/cloud/array.py
+++ b/src/tiledb/cloud/array.py
@@ -25,12 +25,12 @@ split_uri = utils.split_uri
 
 
 class ArrayList:
+    """
+    This class incrementally builds a list of UDFArrayDetails
+    for use in multi array UDFs `list[UDFArrayDetails]`
+    """
+
     def __init__(self):
-        """
-        This class incrementally builds a list of UDFArrayDetails for use in
-        multi array UDFs
-        """
-        """list[UDFArrayDetails]"""
         self.arrayList = []
 
     def add(self, uri=None, ranges=None, buffers=None, layout=None):

--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -620,6 +620,13 @@ _RETRY_CONFIGS = {
 
 
 class Client:
+    """
+    TileDB Client.
+
+    :param pool_threads: Number of threads to use for http requests
+    :param retry_mode: Retry mode ["default", "forceful", "disabled"]
+    """
+
     def __init__(
         self,
         pool_threads: Optional[int] = None,

--- a/src/tiledb/cloud/cloudarray.py
+++ b/src/tiledb/cloud/cloudarray.py
@@ -4,13 +4,14 @@ from tiledb.cloud._results import results
 
 
 class CloudArray(object):
+    """Array cloud interface."""
+
     @functions.signature_of(array.apply_async)
     def apply_async(self, *args, **kwargs) -> results.AsyncResult:
         """
         Apply a user-defined function to this array, asynchronously.
 
-        Params are the same as :func:`array.apply_async`, but this instance
-        provides the URI.
+        Params are the same as `array.apply_async`, but this instance provides the URI.
         """
         return array.apply_async(self.uri, *args, **kwargs)  # pylint: disable=E1101
 
@@ -19,16 +20,17 @@ class CloudArray(object):
         """
         Apply a user-defined function to this array, synchronously.
 
-        Params are the same as :func:`array.apply`, but this instance
-        provides the URI.
+        Params are the same as `array.apply`, but this instance provides the URI.
 
         **Example**
-        >>> import tiledb, tiledb.cloud, numpy
-        >>> def median(df):
-        ...   return numpy.median(df["a"])
-        >>> # Open the array then run the UDF
-        >>> with tiledb.SparseArray("tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.ctx()) as A:
-        ...   A.apply(median, [(0,5), (0,5)], attrs=["a", "b", "c"])
-        2.0
+
+            import tiledb, tiledb.cloud, numpy
+
+            def median(df):
+                return numpy.median(df["a"])
+
+            # Open the array then run the UDF
+            with tiledb.SparseArray("tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.ctx()) as A:
+                A.apply(median, [(0,5), (0,5)], attrs=["a", "b", "c"])
         """  # noqa: E501
         return array.apply(self.uri, *args, **kwargs)  # pylint: disable=E1101

--- a/src/tiledb/cloud/compute/delayed.py
+++ b/src/tiledb/cloud/compute/delayed.py
@@ -14,6 +14,10 @@ from tiledb.cloud.udf import exec as udf_exec
 
 
 class DelayedBase(Node):
+    """
+    Base Delayed interface class
+    """
+
     def __init__(
         self,
         func,
@@ -129,6 +133,12 @@ class DelayedBase(Node):
 
 
 class Delayed(DelayedBase):
+    """
+    Serverless Python function execution as a future.
+
+    Extends [DelayedBase](#tiledb.cloud.compute.delayed.DelayedBase)
+    """
+
     def __init__(self, func_exec, *args, local=False, mode=Mode.REALTIME, **kwargs):
         functions.check_funcable(func_exec=func_exec)
         self.func_exec = func_exec
@@ -152,6 +162,13 @@ class Delayed(DelayedBase):
 
 
 class DelayedSQL(DelayedBase):
+    """
+    Serverless SQL query on a registered Array called with the
+    [Delayed API](#tiledb.cloud.compute.delayed.Delayed)
+
+    Extends [DelayedBase](#tiledb.cloud.compute.delayed.DelayedBase)
+    """
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("name", "SQL query" + _random_suffix())
 
@@ -159,6 +176,13 @@ class DelayedSQL(DelayedBase):
 
 
 class DelayedArrayUDF(DelayedBase):
+    """
+    Serverless Array UDF called with the
+    [Delayed API](#tiledb.cloud.compute.delayed.Delayed)
+
+    Extends [DelayedBase](#tiledb.cloud.compute.delayed.DelayedBase)
+    """
+
     def __init__(self, uri, func_exec, *args, **kwargs):
         functions.check_funcable(func_exec=func_exec)
         self.func_exec = func_exec
@@ -169,6 +193,13 @@ class DelayedArrayUDF(DelayedBase):
 
 
 class DelayedMultiArrayUDF(DelayedBase):
+    """
+    Serverless Multi-Array UDF called with the
+    [Delayed API](#tiledb.cloud.compute.delayed.Delayed)
+
+    Extends [DelayedBase](#tiledb.cloud.compute.delayed.DelayedBase)
+    """
+
     def __init__(
         self,
         func: Union[str, Callable],

--- a/src/tiledb/cloud/dag/mode.py
+++ b/src/tiledb/cloud/dag/mode.py
@@ -2,11 +2,23 @@ import enum
 
 
 class Mode(enum.Enum):
-    """Mode to run in"""
+    """Mode to run a DAG in"""
 
     LOCAL = enum.auto()
+    """Run on local machine (testing purposes)"""
+
     REALTIME = enum.auto()
+    """Designed to return results directly to the client (default).
+    Realtime task graphs are scheduled and executed immediately
+    and are well suited for fast distributed workloads.
+    """
+
     BATCH = enum.auto()
+    """
+    Designed for large, resource intensive asynchronous workloads.
+    Batch task graphs are defined, uploaded, and scheduled for execution
+    and are well suited for ingestion-style workloads.
+    """
 
     def __str__(self):
         return self.name.replace("_", " ").title()


### PR DESCRIPTION
For future reference:
- If a class/method doesn't have a docstring, it will not be picked up by quartodoc.
- In order to include/exclude a class/method from docs, we need to add/remove a relevant docstring.