### PR TITLE
Add verbose argument to collection mapper

### DIFF
--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -159,18 +159,17 @@ def build_collection_mapper_workflow_graph(
     :param args_dict: Optional additional arguments to be passed to your
         callback.  If provided, this must be a dict from string experiment name,
         to dict of key-value pairs.
+    :param counts_only: If specified, only return obs/var counts, not the
+        result of the provided callback.
 
     TileDB configs:
     :param extra_tiledb_config: Currently unused; reserved for future use.
     :param platform_config: Currently unused; reserved for future use.
 
     Cloud configs:
-
     :param namespace: TileDB namespace in which to run the UDFs.
     :param task_graph_name: Optional name for your task graph, so you can
         find it more easily among other runs.
-    :param counts_only: If specified, only return obs/var counts, not the
-        result of the provided callback.
 
     Real-time vs batch modes:
     :param use_batch_mode: If false (the default), uses real-time UDFs.

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 
 import anndata as ad
@@ -40,7 +39,8 @@ def run_collection_mapper_workflow(
     use_batch_mode: bool = False,
     resource_class: Optional[str] = None,  # only valid for real-time mode
     resources: Optional[Dict[str, object]] = None,  # only valid for batch mode
-    access_credentials_name: Optional[str] = None,  # only valid for batch mode
+    access_credentials_name: Optional[str] = None,  # only valid for batch mode,
+    verbose: bool = False,
 ) -> Dict[str, str]:
     """
     This is an asynchronous entry point, which launches the task graph and returns
@@ -68,6 +68,7 @@ def run_collection_mapper_workflow(
         counts_only=counts_only,
         resources=resources,
         access_credentials_name=access_credentials_name,
+        verbose=verbose,
     )
     grf.compute()
     return {
@@ -103,7 +104,8 @@ def build_collection_mapper_workflow_graph(
     use_batch_mode: bool = False,
     resource_class: Optional[str] = None,  # only valid for real-time mode
     resources: Optional[Dict[str, object]] = None,  # only valid for batch mode
-    access_credentials_name: Optional[str] = None,  # only valid for batch mode
+    access_credentials_name: Optional[str] = None,  # only valid for batch mode,
+    verbose: bool = False,
 ) -> dag.DAG:
     """
     The primary entrypoint for the mapper module. The caller passes in either a
@@ -226,7 +228,8 @@ def build_collection_mapper_workflow_graph(
     # cfg_dict = cfg_dict or {}
     # cfg_dict["rest.use_refactored_array_open"] = True
 
-    logger = get_logger_wrapper(level=logging.INFO)
+    logger = get_logger_wrapper(verbose)
+    logger.debug("tiledbsoma=%s" % tiledbsoma.__version__)
 
     # ----------------------------------------------------------------
     if soma_experiment_uris is None:

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -297,7 +297,7 @@ def build_collection_mapper_workflow_graph(
         )
         logger.debug("A: node output is a %s" % type(node_output))
 
-        node_outputs[soma_experiment_uri] = node_output
+        node_outputs[experiment_name] = node_output
 
     def collect(node_outputs):
         for node_name, node_output in node_outputs.items():

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -66,6 +66,8 @@ def run_collection_mapper_workflow(
         platform_config=platform_config,
         task_graph_name=task_graph_name,
         counts_only=counts_only,
+        use_batch_mode=use_batch_mode,
+        resource_class=resource_class,
         resources=resources,
         access_credentials_name=access_credentials_name,
         verbose=verbose,

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -180,6 +180,9 @@ def build_collection_mapper_workflow_graph(
         Example: ``resources={"cpu": "2", "memory": "8Gi"}``.
     :param access_credentials_name: Only valid when ``use_batch_mode`` is True.
 
+    Other:
+    :param verbose: If True, enable verbose logging. Default: False.
+
     Return value:
     A ``DAG`` object. If you've named this ``dag``, you'll need to call
         ``dag.compute()``, ``dag.wait()``, and ``dag.end_results()``.

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -291,13 +291,13 @@ def build_collection_mapper_workflow_graph(
             access_credentials_name=access_credentials_name,
             name=experiment_name,
         )
-        logger.info("A: node output is a %s" % type(node_output))
+        logger.debug("A: node output is a %s" % type(node_output))
 
         node_outputs[soma_experiment_uri] = node_output
 
     def collect(node_outputs):
         for node_name, node_output in node_outputs.items():
-            logger.info("B: node output %s is a %s" % (node_name, type(node_output)))
+            logger.debug("B: node output %s is a %s" % (node_name, type(node_output)))
         return node_outputs
 
     grf.submit(

--- a/tests/test_soma.py
+++ b/tests/test_soma.py
@@ -103,21 +103,21 @@ class TestSOMAMapper(unittest.TestCase):
             g.end_results_by_name(),
             {
                 "collector": {
-                    "tiledb://unittest/3c0e8956-12d1-463d-87c4-16f644c204c9": [
+                    "stack1": [
                         3,
                         5,
                     ],
-                    "tiledb://unittest/53109d02-4145-4860-9c86-349bb5b8c588": [
-                        3,
-                        6,
-                    ],
-                    "tiledb://unittest/c5cdcdcd-2ce4-4c1d-bed5-b90232568977": [
-                        3,
-                        5,
-                    ],
-                    "tiledb://unittest/a0b92925-a0da-41d4-aa55-f9c3e526ff2d": [
+                    "stack2": [
                         3,
                         4,
+                    ],
+                    "stack3": [
+                        3,
+                        5,
+                    ],
+                    "stack4": [
+                        3,
+                        6,
                     ],
                 }
             },


### PR DESCRIPTION
This adds a `verbose` argument to the SOMA experiment collection mapper.

Like other functions in the package, verbose=False limits logs to INFO level. To decrease the amount of logging shown by default I changed the node type logs to DEBUG.

I also addressed [sc-4490] to key results by soma experiment names, instead of URIs, which will be more user friendly.