### PR TITLE
Deprecate old file methods.

### DIFF
--- a/src/tiledb/cloud/file.py
+++ b/src/tiledb/cloud/file.py
@@ -1,7 +1,5 @@
-from logging import warning
 from typing import Optional, Tuple, Union
 
-from tiledb.cloud.files import utils
 from tiledb.cloud.rest_api import models
 
 
@@ -15,6 +13,9 @@ def create_file(
     async_req: bool = False,
 ) -> models.FileCreated:
     """
+    DEPRECATED METHOD: Will be removed from version 0.12.16.
+    Use `tiledb.cloud.files.utils.create_file instead.
+
     Creates a TileDB file at the specified location
     :param namespace: namespace the create file operation belongs to
     :param name: name to use for registration in TileDB Cloud
@@ -26,20 +27,9 @@ def create_file(
     :param async_req: return future instead of results for async support
     :return: FileCreated details, including file_uuid and output_uri
     """
-    warning(
-        DeprecationWarning(
-            "This method will be deprecated from version 0.12.15 onwards. "
-            "Use `tiledb.cloud.files.utils.create_file` instead."
-        ),
-    )
-    utils.create_file(
-        namespace=namespace,
-        input_uri=input_uri,
-        output_uri=output_uri,
-        name=name,
-        access_credentials_name=access_credentials_name,
-        access_credential_name=access_credential_name,
-        async_req=async_req,
+    raise DeprecationWarning(
+        "This method is deprecated. "
+        "Use `tiledb.cloud.files.utils.create_file instead."
     )
 
 
@@ -50,6 +40,9 @@ def export_file_local(
     async_req: bool = False,
 ) -> models.FileExported:
     """
+    DEPRECATED METHOD: Will be removed from version 0.12.16.
+    Use `tiledb.cloud.files.utils.export_file_local` instead.
+
     Exports a TileDB File back to its original file format
     :param uri: The ``tiledb://...`` URI of the file to export
     :param output_uri: output file uri
@@ -58,14 +51,9 @@ def export_file_local(
     :param async_req: return future instead of results for async support
     :return: FileExported details, including output_uri
     """
-    warning(
-        DeprecationWarning(
-            "This method will be deprecated from version 0.12.15 onwards. "
-            "Use `tiledb.cloud.files.utils.export_file_local` instead."
-        ),
-    )
-    utils.export_file_local(
-        uri=uri, output_uri=output_uri, timestamp=timestamp, async_req=async_req
+    raise DeprecationWarning(
+        "This is deprecated. "
+        "Use `tiledb.cloud.files.utils.export_file_local` instead."
     )
 
 
@@ -75,16 +63,16 @@ def export_file(
     async_req: bool = False,
 ) -> models.FileExported:
     """
+    DEPRECATED METHOD: Will be removed from version 0.12.16.
+    Use `tiledb.cloud.files.utils.export_file` instead.
+
     Exports a TileDB File back to its original file format
     :param uri: The ``tiledb://...`` URI of the file to export
     :param output_uri: output file uri
     :param async_req: return future instead of results for async support
     :return: FileExported details, including output_uri
     """
-    warning(
-        DeprecationWarning(
-            "This method will be deprecated from version 0.12.15 onwards. "
-            "Use `tiledb.cloud.files.utils.export_file` instead."
-        ),
+    raise DeprecationWarning(
+        "This method is deprecated. "
+        "Use `tiledb.cloud.files.utils.export_file` instead."
     )
-    utils.export_file(uri=uri, output_uri=output_uri, async_req=async_req)


### PR DESCRIPTION
Deprecates old `file` methods in favor of `tiledb.cloud.files` methods for version 0.12.15.

Deprecated Methods:
- `tiledb.cloud.file.create_file` use `tiledb.cloud.files.utils.create_file`
- `tiledb.cloud.file.export_file_local` use `tiledb.cloud.files.utils.export_file_local`
- `tiledb.cloud.file.export_file` use `tiledb.cloud.files.utils.export_file`

Preparation for [Releasing version 0.12.15](https://app.shortcut.com/tiledb-inc/story/50684/release-cloud-py-0-12-15-and-update-cloud-images)