### PR TITLE
Bump pyarrow version to 16.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "importlib-metadata",
     "packaging",
     "pandas>=1.2.4",
-    "pyarrow>=3.0.0",
+    "pyarrow==15.0.0",
     "python-dateutil",
     "six>=1.10",
     # Not directly used on the client, but some server-side environments have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "importlib-metadata",
     "packaging",
     "pandas>=1.2.4",
-    "pyarrow==16.0.0",
+    "pyarrow>=16.0.0",
     "python-dateutil",
     "six>=1.10",
     # Not directly used on the client, but some server-side environments have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "importlib-metadata",
     "packaging",
     "pandas>=1.2.4",
-    "pyarrow==15.0.0",
+    "pyarrow==16.0.0",
     "python-dateutil",
     "six>=1.10",
     # Not directly used on the client, but some server-side environments have

--- a/requirements-geospatial-py3.9.txt
+++ b/requirements-geospatial-py3.9.txt
@@ -6,7 +6,7 @@ fiona==1.10b1
 numpy==1.26.1
 packaging==23.2
 pandas==2.1.1
-pyarrow==14.0.1
+pyarrow==16.0.0
 python-dateutil==2.8.2
 pytz==2023.3.post1
 rasterio==1.4a3

--- a/requirements-py3.9.txt
+++ b/requirements-py3.9.txt
@@ -5,7 +5,7 @@ importlib-metadata==7.0.1
 numpy==1.26.4
 packaging==23.2
 pandas==2.2.0
-pyarrow==15.0.0
+pyarrow==16.0.0
 python-dateutil==2.8.2
 pytz==2024.1
 six==1.16.0


### PR DESCRIPTION
Attempt to resolve the following issue:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

Reported by @jparismorgan and related to `pyarrow` version. 
Related to this [Vector Search PR](https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/434)