### PR TITLE
Enhance tiledb.cloud.dag module typing and documentation

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -299,7 +299,11 @@ class Node(futures.FutureLike[_T]):
             return self._status is Status.RUNNING
 
     def result(self, timeout: Optional[float] = None) -> _T:
-        """Fetch Node return."""
+        """Fetch Node return.
+
+        :param timeout: Time to wait to fetch result.
+        :return: Results of Node processing.
+        """
 
         if self.mode == Mode.BATCH:
             with self._lifecycle_condition:
@@ -765,7 +769,6 @@ class DAG:
         Add a callback for when DAG status is updated
         :param func: Function to call when DAG status is updated.
             The function will be passed reference to this dag
-        :return:
         """
         if not callable(func):
             raise TypeError("func to add_update_callback must be callable")
@@ -778,7 +781,6 @@ class DAG:
         Add a callback for when DAG is completed
         :param func: Function to call when DAG status is updated.
             The function will be passed reference to this dag
-        :return:
         """
         if not callable(func):
             raise TypeError("func to add_done_callback must be callable")
@@ -837,17 +839,19 @@ class DAG:
         with self._lifecycle_condition:
             return self._done()
 
-    def add_node_obj(self, node):
-        """
-        Add node to DAG
+    def add_node_obj(self, node) -> Node:
+        """Add node to DAG.
+
         :param node: to add to dag
-        :return: node
+        :return: Node instance.
         """
+
         with self._lifecycle_condition:
             return self._add_node_internal(node)
 
     def _add_node_internal(self, node: Node) -> Node:
         """Add node implementation. Must hold lifecycle condition."""
+
         if self._status is not Status.NOT_STARTED:
             raise RuntimeError("Cannot add nodes to a running graph")
         self.nodes[node.id] = node
@@ -859,8 +863,7 @@ class DAG:
         return node
 
     def add_node(self, func_exec, *args, name=None, local_mode=True, **kwargs):
-        """
-        Create and add a node.
+        """Create and add a node.
 
         DEPRECATED. Use `submit_local` instead.
 

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -113,7 +113,7 @@ class Node(futures.FutureLike[_T]):
         Applies only when ``_prewrapped_func`` is used.
         ``True`` if ``_prewrapped_func`` can accept stored parameters.
         ``False`` if it cannot, and all parameters must be serialized.
-    :param **kwargs: dictionary for keyword arguments
+    :param **kwargs: Keyword arguments to pass to UDF.
     """
 
     def __init__(


### PR DESCRIPTION
Add class doc str to `Node` and `DAG` so they're built into API ref: https://tiledb-inc.github.io/TileDB-Cloud-Py/reference/dag.dag.html

Original slack: https://tiledb.slack.com/archives/CB0NNLS6B/p1720713156703479