### PR TITLE
Convert boolean recursive params to "true" or "false"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Next (YYYY-MM-DD)
 
+New features:
+
 - Add a tiledb.cloud.asset module with functions that allow management of
   assets of any type. This module is exported from tiledb.cloud (gh-566,
   gh-577).
+
+Bug fixes:
+
+- Ensure that boolean recursive parameters in tiledb.cloud.asset and
+  tiledb.cloud.groups are converted to "true" or "false" before server requests
+  are made (gh-).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,4 +12,4 @@ Bug fixes:
 
 - Ensure that boolean recursive parameters in tiledb.cloud.asset and
   tiledb.cloud.groups are converted to "true" or "false" before server requests
-  are made (gh-).
+  are made (gh-605).

--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -175,7 +175,8 @@ def deregister(
                     )
                 elif m.group:
                     grp: rest_api.GroupInfo = m.group
-                    deregister(grp.tiledb_uri, recursive=recursive)
+                    # Server expects recursive: "true"/"false".
+                    deregister(grp.tiledb_uri, recursive=str(bool(recursive)).lower())
                 else:
                     raise tiledb_cloud_error.TileDBCloudError(
                         "unexpected group member type"
@@ -192,8 +193,11 @@ def delete(uri: str, recursive: bool = False) -> None:
     """
     namespace, group_name = utils.split_uri(uri)
     groups_api = client.build(api_v2.GroupsApi)
+    # Server expects recursive: "true"/"false".
     groups_api.delete_group(
-        group_namespace=namespace, group_name=group_name, recursive=recursive
+        group_namespace=namespace,
+        group_name=group_name,
+        recursive=str(bool(recursive)).lower(),
     )
 
 


### PR DESCRIPTION
The root of the problem is that our API server ignores `recursive="True"` and only expects `recursive="true"`.

I'm converting values of `recursive` before the lowest level, autogenerated client code is called.