### PR TITLE
Remove collector node from the SOMA experiment collection mapper

### DIFF
--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -272,10 +272,9 @@ def build_collection_mapper_workflow_graph(
         namespace=namespace,
     )
 
-    node_outputs = {}
-
     for experiment_name, soma_experiment_uri in soma_experiment_uris.items():
-        node_output = grf.submit(
+        logger.debug(f"Processing experiment '{experiment_name}'")
+        grf.submit(
             _function_for_node,
             soma_experiment_uri,
             measurement_name=measurement_name,
@@ -295,20 +294,6 @@ def build_collection_mapper_workflow_graph(
             access_credentials_name=access_credentials_name,
             name=experiment_name,
         )
-        logger.debug("A: node output is a %s" % type(node_output))
-
-        node_outputs[experiment_name] = node_output
-
-    def collect(node_outputs):
-        for node_name, node_output in node_outputs.items():
-            logger.debug("B: node output %s is a %s" % (node_name, type(node_output)))
-        return node_outputs
-
-    grf.submit(
-        collect,
-        node_outputs,
-        name="collector",
-    )
 
     return grf
 

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -114,12 +114,11 @@ def build_collection_mapper_workflow_graph(
     sequence of ``SOMAExperiment`` URIs or a ``SOMACollection``, which is simply
     a collection of SOMAExperiment objects. The caller also passes in query
     terms and a callback lambda which will be called on the ``to_anndata``
-    output of each experiment's query. The top-level collector node will be a
-    dictionary mapping experiment names to the callback lambda's output for each
-    input experiment.
+    output of each experiment's query. The result will be a dictionary mapping
+    experiment names to the callback lambda's output for each input experiment.
 
     For example, if the lambda maps an anndata object to its ``.shape``, then
-    with SOMA experiments ``A`` and ``B``, the collector node might return the
+    with SOMA experiments ``A`` and ``B``, the task graph would return the
     dict ``{"A": (56868, 43050), "B": (23539, 42044)}``.
 
 

--- a/tests/test_soma.py
+++ b/tests/test_soma.py
@@ -102,23 +102,21 @@ class TestSOMAMapper(unittest.TestCase):
         self.assertEqual(
             g.end_results_by_name(),
             {
-                "collector": {
-                    "stack1": [
-                        3,
-                        5,
-                    ],
-                    "stack2": [
-                        3,
-                        4,
-                    ],
-                    "stack3": [
-                        3,
-                        5,
-                    ],
-                    "stack4": [
-                        3,
-                        6,
-                    ],
-                }
+                "stack1": [
+                    3,
+                    5,
+                ],
+                "stack2": [
+                    3,
+                    4,
+                ],
+                "stack3": [
+                    3,
+                    5,
+                ],
+                "stack4": [
+                    3,
+                    6,
+                ],
             },
         )


### PR DESCRIPTION
**Changes:** This removes the final collector node from the task graph created by `soma.build_collection_mapper_workflow()`. 

**Explanation:** The `"collector"` node only iterated over each item in the dictionary to log its name and type, which:

- added an extra deserialization/serialization step
- could lead to OOM errors when processing many large AnnData objects within a single node

**Example:**

```py
import tiledb.cloud
from tiledb.cloud.soma import build_collection_mapper_workflow_graph

graph = build_collection_mapper_workflow_graph(
    soma_collection_uri="tiledb://tiledb-inc/soma-exps-tabula-sapiens-by-tissue",
    measurement_name="RNA",
    X_layer_name="data",
    resource_class="large",
    namespace="TileDB-Inc",
    counts_only=True,
)

graph.compute()
graph.wait()
graph.end_results_by_name()
```

Returns:

```py
{'TS_Vasculature': [16037, 58870],
 'TS_Bone_Marrow': [12297, 58870],
 'TS_Lung': [35682, 58870],
 'TS_Salivary_Gland': [27199, 58870],
 'TS_Lymph_Node': [53275, 58870],
 'TS_Large_Intestine': [13680, 58870],
 'TS_Liver': [5007, 58870],
 'TS_Muscle': [30746, 58870],
 'TS_Bladder': [24583, 58870],
 'TS_Skin': [9424, 58870],
 'TS_Tongue': [15020, 58870],
 'TS_Trachea': [9522, 58870],
 'TS_Mammary': [11375, 58870],
 'TS_Thymus': [33664, 58870],
 'TS_Kidney': [9641, 58870],
 'TS_Spleen': [34004, 58870],
 'TS_Blood': [50115, 58870],
 'TS_Fat': [20263, 58870],
 'TS_Heart': [11505, 58870],
 'TS_Prostate': [16375, 58870],
 'TS_Pancreas': [13497, 58870],
 'TS_Uterus': [7124, 58870],
 'TS_Small_Intestine': [12467, 58870],
 'TS_Eye': [10650, 58870]}
```
