### PR TITLE
Pin pydot<3 for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-viz-tiledb = ["networkx>=2", "pydot", "tiledb-plot-widget>=0.1.7"]
-viz-plotly = ["networkx>=2", "plotly>=4", "pydot"]
-all = ["networkx>=2", "plotly>=4", "pydot", "tiledb-plot-widget>=0.1.7"]
+viz-tiledb = ["networkx>=2", "pydot<3", "tiledb-plot-widget>=0.1.7"]
+viz-plotly = ["networkx>=2", "plotly>=4", "pydot<3"]
+all = ["networkx>=2", "plotly>=4", "pydot<3", "tiledb-plot-widget>=0.1.7"]
 life-sciences = ["tiledbsoma"]
 docs = ["quartodoc"]
 dev = ["black", "pytest", "ruff"]


### PR DESCRIPTION
TileDB-Cloud Visualization for Task Graph uses networkx to build the graph representation that is understood by ploty and d3. It turns out networkx requires pydot 2, and the recently (July 15th, 2024) release of pydot 3 has caused incompatibilities.

This PR updates the dependencies to list pydot<3.