### PR TITLE
Add cloud regions to documentation.

### DIFF
--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -73,6 +73,10 @@ website:
             href: reference/dag.status.qmd
           - text: "`visualization`"
             href: reference/dag.visualization.qmd
+      - section: Region
+        contents:
+          - text: "`region`"
+            href: reference/region.qmd
       - section: Files
         contents:
           - text: "`indexing`"
@@ -158,6 +162,11 @@ quartodoc:
         - dag.mode
         - dag.status
         - dag.visualization
+
+    - title: region
+      desc: Cloud regions
+      contents:
+        - region
 
     - title: files
       desc: File API.

--- a/src/tiledb/cloud/region/__init__.py
+++ b/src/tiledb/cloud/region/__init__.py
@@ -2,10 +2,10 @@ class AWS:
     """
     The AWS cloud regions that are currently supported.
 
-    US_EAST_1 = North America, United States (Virginia)
-    US_WEST_2 = North America, United States (Oregon)
-    EU_WEST_1 = Europe, Ireland
-    EU_WEST_2 = Europe, London
+    US_EAST_1 = North America, United States (Virginia)  
+    US_WEST_2 = North America, United States (Oregon)  
+    EU_WEST_1 = Europe, Ireland  
+    EU_WEST_2 = Europe, London  
     AP_SOUTHEAST_1 = Asia, Singapore
     """
 

--- a/src/tiledb/cloud/region/__init__.py
+++ b/src/tiledb/cloud/region/__init__.py
@@ -2,10 +2,14 @@ class AWS:
     """
     The AWS cloud regions that are currently supported.
 
-    US_EAST_1 = North America, United States (Virginia)  
-    US_WEST_2 = North America, United States (Oregon)  
-    EU_WEST_1 = Europe, Ireland  
-    EU_WEST_2 = Europe, London  
+    US_EAST_1 = North America, United States (Virginia)
+
+    US_WEST_2 = North America, United States (Oregon)
+
+    EU_WEST_1 = Europe, Ireland
+
+    EU_WEST_2 = Europe, London
+
     AP_SOUTHEAST_1 = Asia, Singapore
     """
 


### PR DESCRIPTION
In addition, this PR enforces newlines after the region strings, which makes the documentation easier to read. Here's what the documentation page looks like:

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/ede771ad-3e55-4d23-870f-94e5a7005a98">