### PR TITLE
Suppress file ingestion/indexing tests until #595 is merged.

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,13 +5,20 @@ import tempfile
 import unittest
 from typing import List
 
+import tiledb
+import tiledb.cloud
 from tiledb.cloud import array
 from tiledb.cloud import client
+from tiledb.cloud import groups
 from tiledb.cloud._common import testonly
 from tiledb.cloud._common import utils
 from tiledb.cloud.array import delete_array
+from tiledb.cloud.array import info
+from tiledb.cloud.files import indexing as file_indexing
+from tiledb.cloud.files import ingestion as file_ingestion
 from tiledb.cloud.files import udfs as file_udfs
 from tiledb.cloud.files import utils as file_utils
+from tiledb.cloud.utilities import get_logger_wrapper
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -186,194 +193,195 @@ class UploadTest(unittest.TestCase):
 
 # FIXME: Will be fixed with #595 implementation
 # Disable until then.
-# class TestFileIngestion(unittest.TestCase):
-#     @classmethod
-#     def setUpClass(cls) -> None:
-#         """
-#         Setup test files, group and destinations once before the file tests start.
-#         """
-#         cls.input_file_location = (
-#             "s3://tiledb-unittest/groups/file_ingestion_test_files"
-#         )
-#         # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
-#         # in the "cls.input_file_location"
-#         cls.input_file_names = [f"input_file_{i}.pdf" for i in range(5)]
-#         cls.test_file_uris = [
-#             f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
-#         ]
-#         # Files with name "group_input_file_<n[0, 4]>.pdf" have already been placed
-#         # in the "cls.input_file_location"
-#         cls.group_input_file_names = [f"group_input_file_{i}.pdf" for i in range(5)]
-#         cls.group_test_file_uris = [
-#             f"{cls.input_file_location}/{fname}"
-#             for fname in cls.group_input_file_names
-#         ]
+@unittest.skip("Skip until fixed VFS access")
+class TestFileIngestion(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Setup test files, group and destinations once before the file tests start.
+        """
+        cls.input_file_location = (
+            "s3://tiledb-unittest/groups/file_ingestion_test_files"
+        )
+        # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
+        # in the "cls.input_file_location"
+        cls.input_file_names = [f"input_file_{i}.pdf" for i in range(5)]
+        cls.test_file_uris = [
+            f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
+        ]
+        # Files with name "group_input_file_<n[0, 4]>.pdf" have already been placed
+        # in the "cls.input_file_location"
+        cls.group_input_file_names = [f"group_input_file_{i}.pdf" for i in range(5)]
+        cls.group_test_file_uris = [
+            f"{cls.input_file_location}/{fname}" for fname in cls.group_input_file_names
+        ]
 
-#         cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
-#         cls.namespace = cls.namespace.rstrip("/")
-#         cls.storage_path = cls.storage_path.rstrip("/")
-#         cls.destination = f"{cls.storage_path}/{testonly.random_name('file_test')}"
+        cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
+        cls.namespace = cls.namespace.rstrip("/")
+        cls.storage_path = cls.storage_path.rstrip("/")
+        cls.destination = f"{cls.storage_path}/{testonly.random_name('file_test')}"
 
-#         cls.group_name = testonly.random_name("file_ingestion_test_group")
-#         cls.group_uri = f"tiledb://{cls.namespace}/{cls.group_name}"
-#         cls.group_destination = f"{cls.storage_path}/{cls.group_name}"
-#         groups.create(cls.group_name, storage_uri=cls.group_destination)
+        cls.group_name = testonly.random_name("file_ingestion_test_group")
+        cls.group_uri = f"tiledb://{cls.namespace}/{cls.group_name}"
+        cls.group_destination = f"{cls.storage_path}/{cls.group_name}"
+        groups.create(cls.group_name, storage_uri=cls.group_destination)
 
-#         cls.cleanup_these_uris = []
-#         return super().setUpClass()
+        cls.cleanup_these_uris = []
+        return super().setUpClass()
 
-#     @classmethod
-#     def tearDownClass(cls) -> None:
-#         """Cleanup after the tests have run"""
-#         cls.cleanup_these_uris += [
-#             f"tiledb://{cls.namespace}/{gifn}" for gifn in cls.group_input_file_names
-#         ]
-#         cls.cleanup_these_uris += [
-#             f"tiledb://{cls.namespace}/{ifn}" for ifn in cls.input_file_names
-#         ]
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Cleanup after the tests have run"""
+        cls.cleanup_these_uris += [
+            f"tiledb://{cls.namespace}/{gifn}" for gifn in cls.group_input_file_names
+        ]
+        cls.cleanup_these_uris += [
+            f"tiledb://{cls.namespace}/{ifn}" for ifn in cls.input_file_names
+        ]
 
-#         _cleanup_residual_test_arrays(array_uris=cls.cleanup_these_uris)
-#         groups.delete(cls.group_uri, recursive=True)
-#         return super().tearDownClass()
+        _cleanup_residual_test_arrays(array_uris=cls.cleanup_these_uris)
+        groups.delete(cls.group_uri, recursive=True)
+        return super().tearDownClass()
 
-#     def test_files_ingestion_udf(self):
-#         ingested_array_uris = file_ingestion.ingest_files_udf(
-#             dataset_uri=self.destination,
-#             file_uris=self.test_file_uris,
-#             acn=self.acn,
-#             namespace=self.namespace,
-#         )
+    def test_files_ingestion_udf(self):
+        ingested_array_uris = file_ingestion.ingest_files_udf(
+            dataset_uri=self.destination,
+            file_uris=self.test_file_uris,
+            acn=self.acn,
+            namespace=self.namespace,
+        )
 
-#         for uri in ingested_array_uris:
-#             array_info = info(uri)
-#             self.assertTrue(array_info.name in self.input_file_names)
-#             self.assertEqual(array_info.namespace, self.namespace)
-#         # Clean up
-#         _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
+        for uri in ingested_array_uris:
+            array_info = info(uri)
+            self.assertTrue(array_info.name in self.input_file_names)
+            self.assertEqual(array_info.namespace, self.namespace)
+        # Clean up
+        _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
 
-#     def test_files_ingestion_udf_into_group(self):
-#         ingested_array_uris = file_ingestion.ingest_files_udf(
-#             dataset_uri=self.group_destination,
-#             file_uris=self.group_test_file_uris,
-#             acn=self.acn,
-#             namespace=self.namespace,
-#         )
+    def test_files_ingestion_udf_into_group(self):
+        ingested_array_uris = file_ingestion.ingest_files_udf(
+            dataset_uri=self.group_destination,
+            file_uris=self.group_test_file_uris,
+            acn=self.acn,
+            namespace=self.namespace,
+        )
 
-#         file_ingestion.add_arrays_to_group_udf(
-#             array_uris=ingested_array_uris,
-#             group_uri=self.group_uri,
-#             config=client.Ctx().config().dict(),
-#             verbose=True,
-#         )
+        file_ingestion.add_arrays_to_group_udf(
+            array_uris=ingested_array_uris,
+            group_uri=self.group_uri,
+            config=client.Ctx().config().dict(),
+            verbose=True,
+        )
 
-#         groups.info(self.group_uri)
-#         # FIXME: Uncomment when CI has vfs access.
-#         # self.assertEqual(group_info.asset_count, len(self.group_test_file_uris))
+        groups.info(self.group_uri)
+        # FIXME: Uncomment when CI has vfs access.
+        # self.assertEqual(group_info.asset_count, len(self.group_test_file_uris))
 
-#         for uri in ingested_array_uris:
-#             array_info = info(uri)
-#             self.assertTrue(array_info.name in self.group_input_file_names)
-#             self.assertEqual(array_info.namespace, self.namespace)
+        for uri in ingested_array_uris:
+            array_info = info(uri)
+            self.assertTrue(array_info.name in self.group_input_file_names)
+            self.assertEqual(array_info.namespace, self.namespace)
 
-#         # Clean up
-#         _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
-#         _cleanup_residual_test_arrays(
-#             array_uris=[
-#                 f"tiledb://{self.namespace}/{iau}" for iau in ingested_array_uris
-#             ]
-#         )
+        # Clean up
+        _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
+        _cleanup_residual_test_arrays(
+            array_uris=[
+                f"tiledb://{self.namespace}/{iau}" for iau in ingested_array_uris
+            ]
+        )
 
-#     def test_add_array_to_group_udf_raises_bad_namespace_error(self):
-#         with self.assertRaises(tiledb.TileDBError):
-#             file_ingestion.add_arrays_to_group_udf(
-#                 array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
-#                 group_uri=f"tiledb://very-bad-namespace/{self.group_name}",
-#                 config=client.Ctx().config().dict(),
-#                 verbose=True,
-#             )
+    def test_add_array_to_group_udf_raises_bad_namespace_error(self):
+        with self.assertRaises(tiledb.TileDBError):
+            file_ingestion.add_arrays_to_group_udf(
+                array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
+                group_uri=f"tiledb://very-bad-namespace/{self.group_name}",
+                config=client.Ctx().config().dict(),
+                verbose=True,
+            )
 
-#     def test_add_array_to_group_udf_non_existing_group_raises_value_error(self):
-#         with self.assertRaises(ValueError):
-#             file_ingestion.add_arrays_to_group_udf(
-#                 array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
-#                 group_uri=f"tiledb://{self.namespace}/non-existing-group",
-#                 config=client.Ctx().config().dict(),
-#                 verbose=True,
-#             )
+    def test_add_array_to_group_udf_non_existing_group_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            file_ingestion.add_arrays_to_group_udf(
+                array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
+                group_uri=f"tiledb://{self.namespace}/non-existing-group",
+                config=client.Ctx().config().dict(),
+                verbose=True,
+            )
 
 
-# class TestFileIndexing(unittest.TestCase):
-#     @classmethod
-#     def setUpClass(cls) -> None:
-#         """
-#         Setup test files, group and destinations once before the file tests start.
-#         """
-#         cls.input_file_location = "s3://tiledb-unittest/groups/file_indexing_test_files"
-#         # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
-#         # in the "cls.input_file_location"
-#         cls.input_file_names = [f"file_to_index_{i}.pdf" for i in range(5)]
-#         cls.test_file_uris = [
-#             f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
-#         ]
+@unittest.skip("Skip until fixed VFS access")
+class TestFileIndexing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Setup test files, group and destinations once before the file tests start.
+        """
+        cls.input_file_location = "s3://tiledb-unittest/groups/file_indexing_test_files"
+        # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
+        # in the "cls.input_file_location"
+        cls.input_file_names = [f"file_to_index_{i}.pdf" for i in range(5)]
+        cls.test_file_uris = [
+            f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
+        ]
 
-#         cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
-#         cls.namespace = cls.namespace.rstrip("/")
-#         cls.storage_path = cls.storage_path.rstrip("/")
-#         cls.destination = (
-#             f"{cls.storage_path}/{testonly.random_name('file-indexing-test')}"
-#         )
+        cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
+        cls.namespace = cls.namespace.rstrip("/")
+        cls.storage_path = cls.storage_path.rstrip("/")
+        cls.destination = (
+            f"{cls.storage_path}/{testonly.random_name('file-indexing-test')}"
+        )
 
-#         # Ingest test files for testing
-#         cls.ingested_array_uris = file_ingestion.ingest_files_udf(
-#             dataset_uri=cls.destination,
-#             file_uris=cls.test_file_uris,
-#             acn=cls.acn,
-#             namespace=cls.namespace,
-#         )
+        # Ingest test files for testing
+        cls.ingested_array_uris = file_ingestion.ingest_files_udf(
+            dataset_uri=cls.destination,
+            file_uris=cls.test_file_uris,
+            acn=cls.acn,
+            namespace=cls.namespace,
+        )
 
-#         return super().setUpClass()
+        return super().setUpClass()
 
-#     @classmethod
-#     def tearDownClass(cls) -> None:
-#         """Remove index testing residuals"""
-#         _cleanup_residual_test_arrays(array_uris=cls.ingested_array_uris)
-#         return super().tearDownClass()
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Remove index testing residuals"""
+        _cleanup_residual_test_arrays(array_uris=cls.ingested_array_uris)
+        return super().tearDownClass()
 
-#     def tearDown(self) -> None:
-#         """Cleanup indexing arrays between tests"""
-#         groups.delete(self.created_index_uri, recursive=True)
-#         # FIXME: Not a nice way to cleanup vector search residuals:
-#         _cleanup_residual_test_arrays(
-#             array_uris=[
-#                 f"tiledb://{self.namespace}/object_metadata",
-#                 f"tiledb://{self.namespace}/updates",
-#                 f"tiledb://{self.namespace}/shuffled_vectors",
-#                 f"tiledb://{self.namespace}/shuffled_vector_ids",
-#                 f"tiledb://{self.namespace}/partition_indexes",
-#                 f"tiledb://{self.namespace}/partition_centroids",
-#             ]
-#         )
-#         return super().tearDown()
+    def tearDown(self) -> None:
+        """Cleanup indexing arrays between tests"""
+        groups.delete(self.created_index_uri, recursive=True)
+        # FIXME: Not a nice way to cleanup vector search residuals:
+        _cleanup_residual_test_arrays(
+            array_uris=[
+                f"tiledb://{self.namespace}/object_metadata",
+                f"tiledb://{self.namespace}/updates",
+                f"tiledb://{self.namespace}/shuffled_vectors",
+                f"tiledb://{self.namespace}/shuffled_vector_ids",
+                f"tiledb://{self.namespace}/partition_indexes",
+                f"tiledb://{self.namespace}/partition_centroids",
+            ]
+        )
+        return super().tearDown()
 
-#     @unittest.skip("Extremely slow execution times in the CI/CD client")
-#     def test_create_and_update_dataset_udf(self):
-#         with self.assertLogs(get_logger_wrapper()) as lg:
-#             # Create a vector search group with 1 file
-#             self.created_index_uri = file_indexing.create_dataset_udf(
-#                 search_uri=self.input_file_location,
-#                 index_uri=f"tiledb://{self.namespace}/{self.destination}",
-#                 config=client.Ctx().config().dict(),
-#                 max_files=3,
-#             )
-#             self.assertTrue("Creating dataset" in lg.output[0])
+    @unittest.skip("Extremely slow execution times in the CI/CD client")
+    def test_create_and_update_dataset_udf(self):
+        with self.assertLogs(get_logger_wrapper()) as lg:
+            # Create a vector search group with 1 file
+            self.created_index_uri = file_indexing.create_dataset_udf(
+                search_uri=self.input_file_location,
+                index_uri=f"tiledb://{self.namespace}/{self.destination}",
+                config=client.Ctx().config().dict(),
+                max_files=3,
+            )
+            self.assertTrue("Creating dataset" in lg.output[0])
 
-#             # Update the group with all the available files
-#             file_indexing.create_dataset_udf(
-#                 search_uri=self.input_file_location,
-#                 index_uri=self.created_index_uri,
-#                 config=client.Ctx().config().dict(),
-#             )
-#             self.assertTrue("Updating reader" in lg.output[1])
-#             index_group_info = groups.info(self.created_index_uri)
-#             self.assertIsNotNone(index_group_info)
-#             self.assertEqual(index_group_info.asset_count, 6)
+            # Update the group with all the available files
+            file_indexing.create_dataset_udf(
+                search_uri=self.input_file_location,
+                index_uri=self.created_index_uri,
+                config=client.Ctx().config().dict(),
+            )
+            self.assertTrue("Updating reader" in lg.output[1])
+            index_group_info = groups.info(self.created_index_uri)
+            self.assertIsNotNone(index_group_info)
+            self.assertEqual(index_group_info.asset_count, 6)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,19 +5,13 @@ import tempfile
 import unittest
 from typing import List
 
-import tiledb
 from tiledb.cloud import array
 from tiledb.cloud import client
-from tiledb.cloud import groups
 from tiledb.cloud._common import testonly
 from tiledb.cloud._common import utils
 from tiledb.cloud.array import delete_array
-from tiledb.cloud.array import info
-from tiledb.cloud.files import indexing as file_indexing
-from tiledb.cloud.files import ingestion as file_ingestion
 from tiledb.cloud.files import udfs as file_udfs
 from tiledb.cloud.files import utils as file_utils
-from tiledb.cloud.utilities import get_logger_wrapper
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -190,177 +184,196 @@ class UploadTest(unittest.TestCase):
             array.delete_array(uri)
 
 
-class TestFileIngestion(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Setup test files, group and destinations once before the file tests start."""
-        cls.input_file_location = (
-            "s3://tiledb-unittest/groups/file_ingestion_test_files"
-        )
-        # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
-        # in the "cls.input_file_location"
-        cls.input_file_names = [f"input_file_{i}.pdf" for i in range(5)]
-        cls.test_file_uris = [
-            f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
-        ]
-        # Files with name "group_input_file_<n[0, 4]>.pdf" have already been placed
-        # in the "cls.input_file_location"
-        cls.group_input_file_names = [f"group_input_file_{i}.pdf" for i in range(5)]
-        cls.group_test_file_uris = [
-            f"{cls.input_file_location}/{fname}" for fname in cls.group_input_file_names
-        ]
+# FIXME: Will be fixed with #595 implementation
+# Disable until then.
+# class TestFileIngestion(unittest.TestCase):
+#     @classmethod
+#     def setUpClass(cls) -> None:
+#         """
+#         Setup test files, group and destinations once before the file tests start.
+#         """
+#         cls.input_file_location = (
+#             "s3://tiledb-unittest/groups/file_ingestion_test_files"
+#         )
+#         # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
+#         # in the "cls.input_file_location"
+#         cls.input_file_names = [f"input_file_{i}.pdf" for i in range(5)]
+#         cls.test_file_uris = [
+#             f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
+#         ]
+#         # Files with name "group_input_file_<n[0, 4]>.pdf" have already been placed
+#         # in the "cls.input_file_location"
+#         cls.group_input_file_names = [f"group_input_file_{i}.pdf" for i in range(5)]
+#         cls.group_test_file_uris = [
+#             f"{cls.input_file_location}/{fname}"
+#             for fname in cls.group_input_file_names
+#         ]
 
-        cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
-        cls.namespace = cls.namespace.rstrip("/")
-        cls.storage_path = cls.storage_path.rstrip("/")
-        cls.destination = f"{cls.storage_path}/{testonly.random_name('file_test')}"
+#         cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
+#         cls.namespace = cls.namespace.rstrip("/")
+#         cls.storage_path = cls.storage_path.rstrip("/")
+#         cls.destination = f"{cls.storage_path}/{testonly.random_name('file_test')}"
 
-        cls.group_name = testonly.random_name("file_ingestion_test_group")
-        cls.group_uri = f"tiledb://{cls.namespace}/{cls.group_name}"
-        cls.group_destination = f"{cls.storage_path}/{cls.group_name}"
-        groups.create(cls.group_name, storage_uri=cls.group_destination)
+#         cls.group_name = testonly.random_name("file_ingestion_test_group")
+#         cls.group_uri = f"tiledb://{cls.namespace}/{cls.group_name}"
+#         cls.group_destination = f"{cls.storage_path}/{cls.group_name}"
+#         groups.create(cls.group_name, storage_uri=cls.group_destination)
 
-        cls.cleanup_these_uris = []
-        return super().setUpClass()
+#         cls.cleanup_these_uris = []
+#         return super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Cleanup after the tests have run"""
-        _cleanup_residual_test_arrays(array_uris=cls.cleanup_these_uris)
-        groups.delete(cls.group_uri, recursive=True)
-        return super().tearDownClass()
+#     @classmethod
+#     def tearDownClass(cls) -> None:
+#         """Cleanup after the tests have run"""
+#         cls.cleanup_these_uris += [
+#             f"tiledb://{cls.namespace}/{gifn}" for gifn in cls.group_input_file_names
+#         ]
+#         cls.cleanup_these_uris += [
+#             f"tiledb://{cls.namespace}/{ifn}" for ifn in cls.input_file_names
+#         ]
 
-    def test_files_ingestion_udf(self):
-        ingested_array_uris = file_ingestion.ingest_files_udf(
-            dataset_uri=self.destination,
-            file_uris=self.test_file_uris,
-            acn=self.acn,
-            namespace=self.namespace,
-        )
+#         _cleanup_residual_test_arrays(array_uris=cls.cleanup_these_uris)
+#         groups.delete(cls.group_uri, recursive=True)
+#         return super().tearDownClass()
 
-        for uri in ingested_array_uris:
-            array_info = info(uri)
-            self.assertTrue(array_info.name in self.input_file_names)
-            self.assertEqual(array_info.namespace, self.namespace)
-        # Clean up
-        _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
+#     def test_files_ingestion_udf(self):
+#         ingested_array_uris = file_ingestion.ingest_files_udf(
+#             dataset_uri=self.destination,
+#             file_uris=self.test_file_uris,
+#             acn=self.acn,
+#             namespace=self.namespace,
+#         )
 
-    def test_files_ingestion_udf_into_group(self):
-        ingested_array_uris = file_ingestion.ingest_files_udf(
-            dataset_uri=self.group_destination,
-            file_uris=self.group_test_file_uris,
-            acn=self.acn,
-            namespace=self.namespace,
-        )
+#         for uri in ingested_array_uris:
+#             array_info = info(uri)
+#             self.assertTrue(array_info.name in self.input_file_names)
+#             self.assertEqual(array_info.namespace, self.namespace)
+#         # Clean up
+#         _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
 
-        file_ingestion.add_arrays_to_group_udf(
-            array_uris=ingested_array_uris,
-            group_uri=self.group_uri,
-            config=client.Ctx().config().dict(),
-            verbose=True,
-        )
+#     def test_files_ingestion_udf_into_group(self):
+#         ingested_array_uris = file_ingestion.ingest_files_udf(
+#             dataset_uri=self.group_destination,
+#             file_uris=self.group_test_file_uris,
+#             acn=self.acn,
+#             namespace=self.namespace,
+#         )
 
-        groups.info(self.group_uri)
-        # FIXME: Uncomment when CI has vfs access.
-        # self.assertEqual(group_info.asset_count, len(self.group_test_file_uris))
+#         file_ingestion.add_arrays_to_group_udf(
+#             array_uris=ingested_array_uris,
+#             group_uri=self.group_uri,
+#             config=client.Ctx().config().dict(),
+#             verbose=True,
+#         )
 
-        for uri in ingested_array_uris:
-            array_info = info(uri)
-            self.assertTrue(array_info.name in self.group_input_file_names)
-            self.assertEqual(array_info.namespace, self.namespace)
+#         groups.info(self.group_uri)
+#         # FIXME: Uncomment when CI has vfs access.
+#         # self.assertEqual(group_info.asset_count, len(self.group_test_file_uris))
 
-        # Clean up
-        _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
+#         for uri in ingested_array_uris:
+#             array_info = info(uri)
+#             self.assertTrue(array_info.name in self.group_input_file_names)
+#             self.assertEqual(array_info.namespace, self.namespace)
 
-    def test_add_array_to_group_udf_raises_bad_namespace_error(self):
-        with self.assertRaises(tiledb.TileDBError):
-            file_ingestion.add_arrays_to_group_udf(
-                array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
-                group_uri=f"tiledb://very-bad-namespace/{self.group_name}",
-                config=client.Ctx().config().dict(),
-                verbose=True,
-            )
+#         # Clean up
+#         _cleanup_residual_test_arrays(array_uris=ingested_array_uris)
+#         _cleanup_residual_test_arrays(
+#             array_uris=[
+#                 f"tiledb://{self.namespace}/{iau}" for iau in ingested_array_uris
+#             ]
+#         )
 
-    def test_add_array_to_group_udf_non_existing_group_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            file_ingestion.add_arrays_to_group_udf(
-                array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
-                group_uri=f"tiledb://{self.namespace}/non-existing-group",
-                config=client.Ctx().config().dict(),
-                verbose=True,
-            )
+#     def test_add_array_to_group_udf_raises_bad_namespace_error(self):
+#         with self.assertRaises(tiledb.TileDBError):
+#             file_ingestion.add_arrays_to_group_udf(
+#                 array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
+#                 group_uri=f"tiledb://very-bad-namespace/{self.group_name}",
+#                 config=client.Ctx().config().dict(),
+#                 verbose=True,
+#             )
+
+#     def test_add_array_to_group_udf_non_existing_group_raises_value_error(self):
+#         with self.assertRaises(ValueError):
+#             file_ingestion.add_arrays_to_group_udf(
+#                 array_uris=[f"tiledb://{self.namespace}/{self.input_file_names[0]}"],
+#                 group_uri=f"tiledb://{self.namespace}/non-existing-group",
+#                 config=client.Ctx().config().dict(),
+#                 verbose=True,
+#             )
 
 
-class TestFileIndexing(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Setup test files, group and destinations once before the file tests start."""
-        cls.input_file_location = "s3://tiledb-unittest/groups/file_indexing_test_files"
-        # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
-        # in the "cls.input_file_location"
-        cls.input_file_names = [f"file_to_index_{i}.pdf" for i in range(5)]
-        cls.test_file_uris = [
-            f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
-        ]
+# class TestFileIndexing(unittest.TestCase):
+#     @classmethod
+#     def setUpClass(cls) -> None:
+#         """
+#         Setup test files, group and destinations once before the file tests start.
+#         """
+#         cls.input_file_location = "s3://tiledb-unittest/groups/file_indexing_test_files"
+#         # Files with name "input_file_<n[0, 4]>.pdf" have already been placed
+#         # in the "cls.input_file_location"
+#         cls.input_file_names = [f"file_to_index_{i}.pdf" for i in range(5)]
+#         cls.test_file_uris = [
+#             f"{cls.input_file_location}/{fname}" for fname in cls.input_file_names
+#         ]
 
-        cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
-        cls.namespace = cls.namespace.rstrip("/")
-        cls.storage_path = cls.storage_path.rstrip("/")
-        cls.destination = (
-            f"{cls.storage_path}/{testonly.random_name('file-indexing-test')}"
-        )
+#         cls.namespace, cls.storage_path, cls.acn = groups._default_ns_path_cred()
+#         cls.namespace = cls.namespace.rstrip("/")
+#         cls.storage_path = cls.storage_path.rstrip("/")
+#         cls.destination = (
+#             f"{cls.storage_path}/{testonly.random_name('file-indexing-test')}"
+#         )
 
-        # Ingest test files for testing
-        cls.ingested_array_uris = file_ingestion.ingest_files_udf(
-            dataset_uri=cls.destination,
-            file_uris=cls.test_file_uris,
-            acn=cls.acn,
-            namespace=cls.namespace,
-        )
+#         # Ingest test files for testing
+#         cls.ingested_array_uris = file_ingestion.ingest_files_udf(
+#             dataset_uri=cls.destination,
+#             file_uris=cls.test_file_uris,
+#             acn=cls.acn,
+#             namespace=cls.namespace,
+#         )
 
-        return super().setUpClass()
+#         return super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Remove index testing residuals"""
-        _cleanup_residual_test_arrays(array_uris=cls.ingested_array_uris)
-        return super().tearDownClass()
+#     @classmethod
+#     def tearDownClass(cls) -> None:
+#         """Remove index testing residuals"""
+#         _cleanup_residual_test_arrays(array_uris=cls.ingested_array_uris)
+#         return super().tearDownClass()
 
-    def tearDown(self) -> None:
-        """Cleanup indexing arrays between tests"""
-        groups.delete(self.created_index_uri, recursive=True)
-        # FIXME: Not a nice way to cleanup vector search residuals:
-        _cleanup_residual_test_arrays(
-            array_uris=[
-                f"tiledb://{self.namespace}/object_metadata",
-                f"tiledb://{self.namespace}/updates",
-                f"tiledb://{self.namespace}/shuffled_vectors",
-                f"tiledb://{self.namespace}/shuffled_vector_ids",
-                f"tiledb://{self.namespace}/partition_indexes",
-                f"tiledb://{self.namespace}/partition_centroids",
-            ]
-        )
-        return super().tearDown()
+#     def tearDown(self) -> None:
+#         """Cleanup indexing arrays between tests"""
+#         groups.delete(self.created_index_uri, recursive=True)
+#         # FIXME: Not a nice way to cleanup vector search residuals:
+#         _cleanup_residual_test_arrays(
+#             array_uris=[
+#                 f"tiledb://{self.namespace}/object_metadata",
+#                 f"tiledb://{self.namespace}/updates",
+#                 f"tiledb://{self.namespace}/shuffled_vectors",
+#                 f"tiledb://{self.namespace}/shuffled_vector_ids",
+#                 f"tiledb://{self.namespace}/partition_indexes",
+#                 f"tiledb://{self.namespace}/partition_centroids",
+#             ]
+#         )
+#         return super().tearDown()
 
-    @unittest.skip("Extremely slow execution times in the CI/CD client")
-    def test_create_and_update_dataset_udf(self):
-        with self.assertLogs(get_logger_wrapper()) as lg:
-            # Create a vector search group with 1 file
-            self.created_index_uri = file_indexing.create_dataset_udf(
-                search_uri=self.input_file_location,
-                index_uri=f"tiledb://{self.namespace}/{self.destination}",
-                config=client.Ctx().config().dict(),
-                max_files=3,
-            )
-            self.assertTrue("Creating dataset" in lg.output[0])
+#     @unittest.skip("Extremely slow execution times in the CI/CD client")
+#     def test_create_and_update_dataset_udf(self):
+#         with self.assertLogs(get_logger_wrapper()) as lg:
+#             # Create a vector search group with 1 file
+#             self.created_index_uri = file_indexing.create_dataset_udf(
+#                 search_uri=self.input_file_location,
+#                 index_uri=f"tiledb://{self.namespace}/{self.destination}",
+#                 config=client.Ctx().config().dict(),
+#                 max_files=3,
+#             )
+#             self.assertTrue("Creating dataset" in lg.output[0])
 
-            # Update the group with all the available files
-            file_indexing.create_dataset_udf(
-                search_uri=self.input_file_location,
-                index_uri=self.created_index_uri,
-                config=client.Ctx().config().dict(),
-            )
-            self.assertTrue("Updating reader" in lg.output[1])
-            index_group_info = groups.info(self.created_index_uri)
-            self.assertIsNotNone(index_group_info)
-            self.assertEqual(index_group_info.asset_count, 6)
+#             # Update the group with all the available files
+#             file_indexing.create_dataset_udf(
+#                 search_uri=self.input_file_location,
+#                 index_uri=self.created_index_uri,
+#                 config=client.Ctx().config().dict(),
+#             )
+#             self.assertTrue("Updating reader" in lg.output[1])
+#             index_group_info = groups.info(self.created_index_uri)
+#             self.assertIsNotNone(index_group_info)
+#             self.assertEqual(index_group_info.asset_count, 6)


### PR DESCRIPTION
Suppress file ingestion and indexing tests until #595 is finalized, in order to avoid unrelated errors like in #612 automated tests.