### PR TITLE
Validate "memory" string in given resources.

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -224,8 +224,7 @@ class Node(futures.FutureLike[_T]):
             # suffix and request "2" instead of "2Gi". Anything less than 10 Mb
             # (written in bytes) was probably a user error.
             if resources_set and "memory" in self._resources:
-                pattern = re.compile("^[0-9]{1,7}$")
-                if pattern.match(self._resources["memory"]) is not None:
+                if re.match(r"^[0-9]{1,7}$", self._resources["memory"]):
                     raise tce.TileDBCloudError(
                         "The `memory` key in `resources` is missing a"
                         " unit suffix. Did you forget to append 'Mi' or 'Gi'?"

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -678,9 +678,9 @@ class DAG:
         """Number of works to allocate to execute DAG."""
         self.retry_strategy: Optional[models.RetryStrategy] = retry_strategy
         """K8S retry policy to be applied to each Node."""
-        self.workflow_retry_strategy: Optional[models.RetryStrategy] = (
-            workflow_retry_strategy
-        )
+        self.workflow_retry_strategy: Optional[
+            models.RetryStrategy
+        ] = workflow_retry_strategy
         """K8S retry policy to be applied to DAG."""
         self.deadline: Optional[str] = deadline
         """Duration (sec) DAG allowed to execute before timeout."""

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -196,6 +196,9 @@ class DAGClassTest(unittest.TestCase):
             grf.submit_local(repr, None, resources={"x": "y"})
         with self.assertRaises(tce.TileDBCloudError):
             grf.submit_local(repr, None, resource_class="hello")
+        grf = dag.DAG(mode=Mode.BATCH)
+        with self.assertRaises(tce.TileDBCloudError):
+            grf.submit(repr, None, resources={"memory": "100"})
 
     def test_kwargs(self):
         d = dag.DAG()


### PR DESCRIPTION
It's easy to forget that the memory string requires a unit suffix to specify something other than bytes.  That results in users passing "2", thinking that it's Gigabytes but it's really bytes.

This commit validates the given memory string. If it's a unitless number less than 10,000,000 (i.e., 10 Mb), the code raises an exception.