### PR TITLE
Use List[str] instead of list[str] for Python 3.8 compatibility

### DIFF
--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -1,7 +1,7 @@
 """An asset may be an array or a group."""
 
 from functools import partial
-from typing import Callable, Mapping, Optional, Union
+from typing import Callable, List, Mapping, Optional, Union
 
 import tiledb  # type: ignore
 
@@ -125,7 +125,7 @@ def update_info(
     *,
     description: Optional[str] = None,
     name: Optional[str] = None,
-    tags: Optional[list[str]] = None,
+    tags: Optional[List[str]] = None,
     access_credentials_name: Optional[str] = None,
 ) -> None:
     """
@@ -138,7 +138,7 @@ def update_info(
     :param name: Asset name, defaults to None
     :type name: str
     :param tags: Asset tags, defaults to None
-    :type tags: list[str]
+    :type tags: List[str]
 
     For example, to update only the description of an asset, call update_info()
     with only a 'description' keyword argument:
@@ -182,7 +182,7 @@ def list_shared_with(uri: str) -> None:
 
 
 def share(
-    uri: str, namespace: str, permissions: Optional[Union[str, list[str]]] = "read"
+    uri: str, namespace: str, permissions: Optional[Union[str, List[str]]] = "read"
 ) -> None:
     """Give another namespace permission to access an asset.
 
@@ -191,7 +191,7 @@ def share(
     :param namespace: the target namespace.
     :type namespace: str
     :param permissions: 'read', 'write', or ['read', 'write'].
-    :type permissions: str or list[str]
+    :type permissions: str or List[str]
 
     For example, to make an asset readable by all, share it with the
     "public" namespace:


### PR DESCRIPTION
Restores compatibility with Python 3.8.