### PR TITLE
Reverting #607 due to version dependencies

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -46,7 +46,7 @@ def ingest(
         If the uri points to a directory of files make sure it ends with a trailing '/'
     :param output: uri / iterable of uris of output files.
         If the uri points to a directory of files make sure it ends with a trailing '/'
-    :param config: dict configuration to pass on tiledb.VFS for the source's resolution
+    :param config: dict configuration to pass on tiledb.VFS
     :param acn: Access Credentials Name (ACN) registered in TileDB Cloud (ARN type)
     :param taskgraph_name: Optional name for taskgraph, defaults to None
     :param num_batches: Number of graph nodes to spawn.
@@ -72,8 +72,6 @@ def ingest(
         Larger scale factors will result in less I/O operations.
     :param access_credentials_name: [TBDeprecated] Access Credentials Name (ACN)
         registered in TileDB Cloud (ARN type) if ``acn`` is not set.
-    :param dest_config: dict configuration to pass on tiledb.VFS for the destination's
-        resolution
     """
 
     logger = get_logger_wrapper(verbose)
@@ -219,18 +217,21 @@ def ingest(
             else:
                 raise ValueError
 
+        write_context = tiledb.Ctx(config)
+        vfs = tiledb.VFS(ctx=write_context)
+
         for input, output in io_uris:
-            from_bioimg(
-                input,
-                output,
-                converter=user_converter,
-                exclude_metadata=exclude_metadata,
-                verbose=verbose,
-                tile_scale=tile_scale,
-                source_config=config,
-                dest_config=kwargs.get("dest_config", None),
-                **kwargs,
-            )
+            with vfs.open(input) as src:
+                with tiledb.scope_ctx(ctx_or_config=write_context):
+                    from_bioimg(
+                        src,
+                        output,
+                        converter=user_converter,
+                        exclude_metadata=exclude_metadata,
+                        verbose=verbose,
+                        tile_scale=tile_scale,
+                        **kwargs,
+                    )
         return io_uris
 
     def register_dataset_udf(


### PR DESCRIPTION
This PR:

- Reverts the changes in the latest 0.12.19 release on supporting double configuration in bioimg ingestor due to lack of appropriate tiledb-py/core 0.31.0/2.25 dependencies respectively.