### PR TITLE
Updates for VCF ingestion with tiledb URIs

### DIFF
--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -101,7 +101,8 @@ def consolidate_and_vacuum(
     logger = get_logger()
 
     with tiledb.scope_ctx(config):
-        if vacuum_fragments:
+        is_remote = array_uri.startswith("tiledb://")
+        if not is_remote and vacuum_fragments:
             logger.info("Vacuuming fragments")
             tiledb.vacuum(
                 array_uri,


### PR DESCRIPTION
* Add the manifest and log arrays to the dataset properly when the dataset is a tiledb:// URI.
* If an array is remote (`tiledb://` URI) only consolidate/vacuum commits and fragment metadata.