### PR TITLE
More updates for VCF ingestion with tiledb URIs

### DIFF
--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -101,6 +101,7 @@ def consolidate_and_vacuum(
     logger = get_logger()
 
     with tiledb.scope_ctx(config):
+        # TODO: remove when remote fragment consolidation is supported
         is_remote = array_uri.startswith("tiledb://")
         if not is_remote and vacuum_fragments:
             logger.info("Vacuuming fragments")


### PR DESCRIPTION
Follow up to #623.

Skip `variant_stats` and `allele_count` consolidation when ingesting to a `tiledb://` URI.