### PR TITLE
VCF Toolbox: Fix `df_transform` to not obscure wrapped functions docstring

### DIFF
--- a/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
+++ b/src/tiledb/cloud/vcf/vcf_toolbox/transform.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Callable
 
 import pandas as pd
@@ -64,6 +65,7 @@ def df_transform(
         the `tiledb.cloud.vcf.query` function
     """
 
+    @wraps(fn)
     def wrapper(
         *args: _PS.args, **kwargs: _PS.kwargs
     ) -> Callable[[pa.Table], pa.Table]:


### PR DESCRIPTION
Fixes the `df_transform` wrapper using `functools.wraps` that applies the `update_wrapper` to the wrapped function.

The `update_wrapper` function ["Updates a wrapper function to look like the wrapped function"](https://github.com/python/cpython/blob/3.10/Lib/functools.py#L35) thus preserving the wrapped functions docstring etc.

