### PR TITLE
Reference Registered UDF to as_batch

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -114,6 +114,13 @@ class Node(futures.FutureLike[_T]):
         Applies only when ``_prewrapped_func`` is used.
         ``True`` if ``_prewrapped_func`` can accept stored parameters.
         ``False`` if it cannot, and all parameters must be serialized.
+    :param namespace: TileDB Cloud namespace, defaults to the user's default namespace.
+    :param acn: Access Credentials Name (ACN) registered in TileDB Cloud (ARN type).
+    :param access_credentials_name: Alias for acn, for backwards compatibility.
+    :param resources: Resources to allocate for the UDF (e.g. {"cpu": "2", "memory":
+        "10Gi"}, defaults to None.
+    :param image_name: Docker image_name to use for UDFs, defaults to default
+        image (see docs).
     :param **kwargs: Keyword arguments to pass to UDF.
     """
 


### PR DESCRIPTION
I want to be able to run registered UDFs using `as_batch`

Repro:

```python
batched_ls = as_batch("TileDB-Inc/ls_uri")

batched_ls(
    "s3://tiledb-spencer/projects",
    config={"vfs.s3.region": "us-west-2"},
    namespace="TileDB-Inc",
    acn="tiledb-cloud-sandbox-role",
)
```

results: https://cloud.tiledb.com/taskgraphlogs/TileDB-Inc/c643bc0c-5dfb-479f-ac9a-a1485ba47638

Can you double check my changes closely here? I _think_ we can actually just pop those args we pass into `Node` rather than getting them and then ignoring them downstream.

### ALSO

We have code in `tiledb.cloud.utilities._common`, how do we want to make these available to the api ref: https://tiledb-inc.github.io/TileDB-Cloud-Py/reference/

If we import from module `_common`, I wish we could get those to show up just under the utilities library in the sidebar. 