### PR TITLE
Allow passing URIs for asset-related functions.

### DIFF
--- a/src/tiledb/cloud/array.py
+++ b/src/tiledb/cloud/array.py
@@ -233,6 +233,7 @@ def register_array(
     description=None,
     access_credentials_name=None,
     async_req=False,
+    dest_uri: Optional[str] = None,
 ):
     """
     Register this array with the tiledb cloud service
@@ -243,8 +244,13 @@ def register_array(
     :param str access_credentials_name: optional name of access credentials to use,
         if left blank default for namespace will be used
     :param async_req: return future instead of results for async support
+    :param dest_uri: If set, the ``tiledb://`` URI of the destination.
     """
     api_instance = client.build(rest_api.ArrayApi)
+
+    namespace, array_name = utils.canonicalize_ns_name_uri(
+        namespace=namespace, array_name=array_name, dest_uri=dest_uri
+    )
 
     namespace = namespace or client.default_user().username
 

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -3,7 +3,7 @@
 from functools import partial
 from typing import Callable, List, Mapping, Optional, Union
 
-import tiledb  # type: ignore
+import tiledb
 
 from . import array  # type: ignore
 from . import groups  # type: ignore
@@ -15,6 +15,7 @@ def register(
     storage_uri: str,
     type: str,
     *,
+    dest_uri: Optional[str] = None,
     name: Optional[str] = None,
     namespace: Optional[str] = None,
     credentials_name: Optional[str] = None,
@@ -56,6 +57,7 @@ def register(
             namespace=namespace,
             array_name=name,
             access_credentials_name=credentials_name,
+            dest_uri=dest_uri,
         )
     elif type == "group":
         groups.register(
@@ -64,9 +66,10 @@ def register(
             namespace=namespace,
             credentials_name=credentials_name,
             parent_uri=parent_uri,
+            dest_uri=dest_uri,
         )
     else:
-        raise tiledb.TileDBError(f"Invalid asset type '{type}'")
+        raise ValueError(f"Invalid asset type {type!r}")
 
 
 def deregister(uri: str, *, recursive: Optional[bool] = False) -> None:

--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -27,8 +27,9 @@ def create(
 ) -> None:
     """Creates a new TileDB Cloud group.
 
-    :param name: The name of the group to create.
+    :param name: The name of the group to create, or its URI.
     :param namespace: The namespace to create the group in.
+        If ``name`` is a URI, this must not be provided.
         If not provided, the current logged-in user will be used.
     :param parent_uri: The parent URI to add the group to, if desired.
     :param storage_uri: The backend URI where the group will be stored.
@@ -37,6 +38,7 @@ def create(
         creating the group. If not provided, uses the namespace's default
         credential for groups.
     """
+    namespace, name = utils.canonicalize_nameuri_namespace(name, namespace)
     if not (namespace and storage_uri and credentials_name):
         namespace, default_path, default_cred = _default_ns_path_cred(namespace)
         storage_uri = storage_uri or (default_path + "/" + name)
@@ -60,12 +62,16 @@ def create(
 def register(
     storage_uri: str,
     *,
+    dest_uri: Optional[str] = None,
     name: Optional[str] = None,
     namespace: Optional[str] = None,
     credentials_name: Optional[str] = None,
     parent_uri: Optional[str] = None,
 ):
     """Registers a pre-existing group."""
+    namespace, name = utils.canonicalize_ns_name_uri(
+        namespace=namespace, name=name, dest_uri=dest_uri
+    )
     if not (namespace and credentials_name):
         namespace, _, default_cred = _default_ns_path_cred(namespace)
         credentials_name = credentials_name or default_cred

--- a/src/tiledb/cloud/notebook.py
+++ b/src/tiledb/cloud/notebook.py
@@ -106,8 +106,9 @@ def download_notebook_contents(
 def upload_notebook_from_file(
     ipynb_file_name: str,
     *,
+    dest_uri: Optional[str] = None,
     namespace: Optional[str] = None,
-    array_name: str,
+    array_name: Optional[str] = None,
     storage_path: Optional[str] = None,
     storage_credential_name: Optional[str] = None,
     on_exists: OnExists = OnExists.FAIL,
@@ -116,8 +117,11 @@ def upload_notebook_from_file(
     Uploads a local-disk notebook file to TileDB Cloud.
     :param ipnyb_file_name: such as "./mycopy.ipynb". Must be local; no S3 URI
       support at present.
+    :param dest_uri: The destination URI to upload the notebook to,
+      such as ``tiledb://janedoe/testing-upload``. If this is set,
+      ``namespace`` and ``array_name`` may not be set.
     :param namespace: such as "janedoe".
-    :param array_name : name to be seen in the UI, such as "testing-upload".
+    :param array_name: name to be seen in the UI, such as "testing-upload".
     :param storage_path: such as "s3://acmecorp-janedoe", typically from the
       user's account settings.
     :param storage_credential_name: such as "janedoe-creds", typically from the
@@ -134,6 +138,7 @@ def upload_notebook_from_file(
         str(ipynb_file_contents, "utf-8"),
         namespace=namespace,
         array_name=array_name,
+        dest_uri=dest_uri,
         storage_path=storage_path,
         storage_credential_name=storage_credential_name,
         on_exists=on_exists,
@@ -143,8 +148,9 @@ def upload_notebook_from_file(
 def upload_notebook_contents(
     ipynb_file_contents: str,
     *,
+    dest_uri: Optional[str] = None,
     namespace: Optional[str] = None,
-    array_name: str,
+    array_name: Optional[str] = None,
     storage_path: Optional[str] = None,
     storage_credential_name: Optional[str] = None,
     on_exists: OnExists,
@@ -153,6 +159,9 @@ def upload_notebook_contents(
     Uploads a notebook file to TileDB Cloud.
     :param ipynb_file_contents: The contents of the notebook file as a string,
       nominally in JSON format.
+    :param dest_uri: The destination URI to upload the notebook to,
+      such as ``tiledb://janedoe/testing-upload``. If this is set,
+      ``namespace`` and ``array_name`` may not be set.
     :param storage_path: such as "s3://acmecorp-janedoe", typically from the
       user's account settings.
     :param array_name : name to be seen in the UI, such as "testing-upload"
@@ -162,6 +171,10 @@ def upload_notebook_contents(
     :param on_exists: such as OnExists.FAIL (default), OVERWRITE or AUTO-INCREMENT
     :return: TileDB array name, such as "tiledb://janedoe/testing-upload".
     """
+
+    namespace, array_name = utils.canonicalize_ns_name_uri(
+        namespace=namespace, array_name=array_name, dest_uri=dest_uri
+    )
 
     storage_credential_name = storage_credential_name or (
         client.default_user().default_s3_path_credentials_name

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -170,7 +170,11 @@ def test_asset_register_array_dispatch(register_array, object_type):
     """Dispatch to array.register_array when URI is an array."""
     asset.register("a", "array", name="foo", credentials_name="bar")
     register_array.assert_called_once_with(
-        "a", namespace=None, array_name="foo", access_credentials_name="bar"
+        "a",
+        namespace=None,
+        array_name="foo",
+        access_credentials_name="bar",
+        dest_uri=None,
     )
 
 
@@ -180,7 +184,12 @@ def test_asset_register_group_dispatch(register_group, object_type):
     """Dispatch to groups.register when URI is a group."""
     asset.register("a", "group", name="foo", credentials_name="bar")
     register_group.assert_called_once_with(
-        "a", name="foo", namespace=None, credentials_name="bar", parent_uri=None
+        "a",
+        name="foo",
+        namespace=None,
+        credentials_name="bar",
+        parent_uri=None,
+        dest_uri=None,
     )
 
 


### PR DESCRIPTION
We had a mix of functions that accepted a (namespace, name) pair, and functions which accepted a URI. This is annoying. In this change, we update all these functions to also accept URIs.

In most cases, the namespace and name are positional arguments, and often have other positional arguments after them. This means we usually can't just accept a URI in the same positional argument, because that would end up with everything else offset.

Instead, in these cases, we add a new param, `dest_uri`, which a user can pass instead of the namespace/name pair. Support for namespace/name is maintained, and we ensure that both are never passed.

---

It took a little time to figure out what I think is a good API for this. If you have any ideas, I am open to suggestions.