### PR TITLE
Optimize VCF ingestion.

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -822,15 +822,14 @@ def ingest_samples_udf(
                             return None
                 return uri
 
-            # Run sort and bgzip on uncompressed VCF files
             with ThreadPool(threads) as pool:
+                # Run sort and bgzip on uncompressed VCF files
                 sample_uris = pool.map(bgzip_worker, sample_uris)
 
-            # Filter out failed bgzip operations
-            sample_uris = [uri for uri in sample_uris if uri]
+                # Filter out failed bgzip operations
+                sample_uris = [uri for uri in sample_uris if uri]
 
-            # Create index files
-            with ThreadPool(threads) as pool:
+                # Create index files
                 sample_uris = pool.map(create_index_file_worker, sample_uris)
 
             # Filter out failed index operations

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -7,17 +7,19 @@ import tiledb
 from tiledb.cloud.utilities import process_stream
 
 
-def find_index(vcf_uri: str) -> Optional[str]:
+def find_index(vcf_uri: str, vfs: Optional[tiledb.VFS] = None) -> Optional[str]:
     """
     Find the index file for a VCF file or None if not found.
 
     :param vcf_uri: URI of the VCF file
+    :param vfs: Optional preallocated VFS object to use
     :return: URI of the index file
     """
 
+    vfs = vfs or tiledb.VFS()
     for ext in ["tbi", "csi"]:
         index = f"{vcf_uri}.{ext}"
-        if tiledb.VFS().is_file(index):
+        if vfs.is_file(index):
             return index
     return None
 
@@ -56,12 +58,13 @@ def get_sample_name(vcf_uri: str) -> str:
     return ",".join(stdout.splitlines())
 
 
-def get_record_count(vcf_uri: str, index_uri: str) -> Optional[int]:
+def get_record_count(vcf_uri: str, index_uri: str, vfs: Optional[tiledb.VFS]) -> Optional[int]:
     """
     Return the record count in a VCF file.
 
     :param vcf_uri: URI of the VCF file
     :param index_uri: URI of the VCF index file
+    :param vfs: Optional preallocated VFS object to use
     :return: record count or None if there is an error
     """
 
@@ -72,7 +75,7 @@ def get_record_count(vcf_uri: str, index_uri: str) -> Optional[int]:
 
     # Make a local copy of the index file
     local_file = os.path.basename(index_uri)
-    with tiledb.VFS().open(index_uri) as infile:
+    with (vfs or tiledb.VFS()).open(index_uri) as infile:
         with open(local_file, "wb") as outfile:
             shutil.copyfileobj(infile, outfile, length=16 << 20)
 

--- a/src/tiledb/cloud/vcf/utils.py
+++ b/src/tiledb/cloud/vcf/utils.py
@@ -58,7 +58,9 @@ def get_sample_name(vcf_uri: str) -> str:
     return ",".join(stdout.splitlines())
 
 
-def get_record_count(vcf_uri: str, index_uri: str, vfs: Optional[tiledb.VFS]) -> Optional[int]:
+def get_record_count(
+    vcf_uri: str, index_uri: str, vfs: Optional[tiledb.VFS]
+) -> Optional[int]:
     """
     Return the record count in a VCF file.
 


### PR DESCRIPTION
[SC-53394](https://app.shortcut.com/tiledb-inc/story/53394/vcf-ingestion-optimization-opportunities)

* The `find_index` and `get_record_count` utility functions were updated to accept a TileDB VFS object which enables caching previously obtained temporary credentials.
* Instead of creating two thread pools one after the other, while we could have reused them for both map stages, and go even further by merging them, allowing to reuse the TileDB contexts created per thread.