### PR TITLE
Improve handling of unsorted VCF files

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -129,16 +129,18 @@ jobs:
         run: |
           if [ -f .test_durations ]; then
             echo ".test_durations file exists."
-            cat .test_durations
+            file_content=$(cat .test_durations)
+            echo $file_content
+            if [ "$file_content" = "null" ]; then
+              echo "Removing 'null' .test_durations file."
+              rm .test_durations
+            fi
           else
             echo ".test_durations file does not exist."
           fi
 
       - name: Run tests
         # Test pinned dependencies on commit / tag and fresh installs on nightlies
-        # TODO: restore the spltting algorithm after debugging
-        #            --splitting-algorithm least_duration \
-
         if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pytest -sv \
@@ -147,6 +149,7 @@ jobs:
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
             --group ${{ matrix.pytest-split-group }} \
             --store-durations \
+            --splitting-algorithm least_duration \
             --clean-durations \
           || .github/scripts/retry 2 \
             pytest -sv \

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -125,8 +125,20 @@ jobs:
           restore-keys: |
             ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-
 
+      - name: "Check .test_durations file"
+        run: |
+          if [ -f .test_durations ]; then
+            echo ".test_durations file exists."
+            cat .test_durations
+          else
+            echo ".test_durations file does not exist."
+          fi
+
       - name: Run tests
         # Test pinned dependencies on commit / tag and fresh installs on nightlies
+        # TODO: restore the spltting algorithm after debugging
+        #            --splitting-algorithm least_duration \
+
         if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pytest -sv \
@@ -135,7 +147,6 @@ jobs:
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
             --group ${{ matrix.pytest-split-group }} \
             --store-durations \
-            --splitting-algorithm least_duration \
             --clean-durations \
           || .github/scripts/retry 2 \
             pytest -sv \

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -799,15 +799,15 @@ def ingest_samples_udf(
                         logger.info("indexing %r", uri)
                         try:
                             create_index_file(uri)
-                        except Exception as e:
-                            logger.warning("%r: %s", uri, e)
+                        except RuntimeError as exc:
+                            logger.warning("%r: %s", uri, exc)
                             logger.info("sort, bgzip, and index %r", uri)
                             try:
                                 uri = sort_and_bgzip(uri, tmp_space=tmp_space)
                                 tmp_uris.append(uri)
                                 create_index_file(uri)
-                            except Exception as e:
-                                logger.error("%r: %s", uri, e)
+                            except RuntimeError as exc:
+                                logger.error("%r: %s", uri, exc)
                                 return None
                 return uri
 

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -32,8 +32,13 @@ _CONFIG = tiledb.cloud.Config()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def tag_wheel():
+def tag_wheel(tmp_path_factory):
     """Make a tagged copy of the wheel before running tests."""
+
+    global _LOCAL_WHEEL
+
+    tmp_path = tmp_path_factory.mktemp("wheel")
+    _LOCAL_WHEEL = os.path.join(tmp_path, os.path.basename(_LOCAL_WHEEL))
 
     logger.info(f"Copying {_LOCAL_WHEEL_ORIG} to {_LOCAL_WHEEL}")
     shutil.copy(_LOCAL_WHEEL_ORIG, _LOCAL_WHEEL)

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import uuid
 
 import pytest
 
@@ -13,7 +14,7 @@ from tiledb.cloud.utilities.wheel import PipInstall
 logger = get_logger()
 
 _LOCAL_WHEEL = "tests/utilities/data/fake_unittest_wheel-0.1.0-py3-none-any.whl"
-_ARRAY_NAME = os.path.basename(_LOCAL_WHEEL)
+_ARRAY_NAME = os.path.basename(_LOCAL_WHEEL) + "-" + str(uuid.uuid4())
 _NAMESPACE = tiledb.cloud.client.default_user().username
 _S3_OBJECT_PATH = tiledb.cloud.client.default_user().default_s3_path
 _FULL_URI = os.path.join(

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import uuid
 
@@ -13,14 +14,13 @@ from tiledb.cloud.utilities.wheel import PipInstall
 
 logger = get_logger()
 
-_LOCAL_WHEEL = "tests/utilities/data/fake_unittest_wheel-0.1.0-py3-none-any.whl"
+_TAG = str(uuid.uuid4())[-8:]
+_LOCAL_WHEEL_ORIG = "tests/utilities/data/fake_unittest_wheel-0.1.0-py3-none-any.whl"
+# Add random tag to avoid collisions between concurrent tests
+_LOCAL_WHEEL = f"tests/utilities/data/fake_unittest_wheel-0.1.0-{_TAG}-py3-none-any.whl"
 _ARRAY_NAME = os.path.basename(_LOCAL_WHEEL)
 _NAMESPACE = tiledb.cloud.client.default_user().username
-# Add random suffix to avoid collisions between concurrent tests
-_S3_OBJECT_PATH = (
-    tiledb.cloud.client.default_user().default_s3_path
-    + f"/test-wheel-{str(uuid.uuid4())[-8:]}"
-)
+_S3_OBJECT_PATH = tiledb.cloud.client.default_user().default_s3_path
 _FULL_URI = os.path.join(
     "tiledb://",
     _NAMESPACE,
@@ -29,6 +29,19 @@ _FULL_URI = os.path.join(
 )
 _TDB_URI = os.path.join("tiledb://", _NAMESPACE, _ARRAY_NAME)
 _CONFIG = tiledb.cloud.Config()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def tag_wheel():
+    """Make a tagged copy of the wheel before running tests."""
+
+    logger.info(f"Copying {_LOCAL_WHEEL_ORIG} to {_LOCAL_WHEEL}")
+    shutil.copy(_LOCAL_WHEEL_ORIG, _LOCAL_WHEEL)
+
+    yield None
+
+    logger.info(f"Removing {_LOCAL_WHEEL}")
+    os.remove(_LOCAL_WHEEL)
 
 
 @pytest.fixture


### PR DESCRIPTION
* Improve handling unsorted VCF files, by not relying on the filename extension. 
* Simplify VCF `sort/bgzip/index` by using one `ThreadPool`.

Non-related CI changes:
* Add GHA step to check for valid `.test_durations` and avoid error splitting pytests
* Modify `test_wheel.py` to avoid failures due to collisions between concurrent tests.
