### PR TITLE
Update find to use VFS.ls_recursive

### DIFF
--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -455,7 +455,7 @@ def find(
     :param max_count: Optional stop point when searching for files
     """
     with tiledb.scope_ctx(config):
-        vfs = tiledb.VFS()
+        vfs = tiledb.VFS(config=config, ctx=tiledb.Ctx(config))
 
         uris = []
 


### PR DESCRIPTION
Update `tiledb.cloud.utilities.find` to use the more performant `vfs.ls_recursive`.

`tiledb.cloud.utilities.find` is currently used in `files` and `geospatial` ingestion. `vcf` ingestion will update to use the same version (instead of a custom `vcf` version) after this PR is merged.