### PR TITLE
Add submit_taskgraph for a common UX

### DIFF
--- a/src/tiledb/cloud/utilities/__init__.py
+++ b/src/tiledb/cloud/utilities/__init__.py
@@ -10,6 +10,7 @@ from ._common import read_file
 from ._common import run_dag
 from ._common import serialize_filter
 from ._common import set_aws_context
+from ._common import submit_taskgraph
 from .consolidate import consolidate_and_vacuum
 from .consolidate import consolidate_fragments
 from .consolidate import group_fragments
@@ -31,6 +32,7 @@ __all__ = [
     "read_file",
     "run_dag",
     "set_aws_context",
+    "submit_taskgraph",
     "consolidate_fragments",
     "consolidate_and_vacuum",
     "group_fragments",


### PR DESCRIPTION
This PR adds `tiledb.cloud.utilities.submit_taskgraph` as a proposed common function to launch ingestion (and other) taskgraphs.

If `tqdm` is available, a progress timer is displayed.

Output while running:
```
Taskgraph submitted to TileDB - https://cloud.tiledb.com/activity/taskgraphs/...
Running:  5:30 min:sec 
```

Output when complete:
```
Taskgraph submitted to TileDB - https://cloud.tiledb.com/activity/taskgraphs/...
Completed:  10:32 min:sec 
```