### PR TITLE
Perform HEAD requests to find the correct location to upload.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ repository = "https://github.com/TileDB-Inc/TileDB-Cloud-Py"
 requires = ["setuptools>=42", "wheel", "setuptools_scm>=6"]
 
 [tool.pytest.ini_options]
-explicit-only = ["geospatial", "vcf"]
+explicit-only = ["bigfiles", "geospatial", "vcf"]
 markers = [
+    "bigfiles: tests that create and upload really big files",
     "geospatial: tests that require the geospatial libraries",
     "vcf: VCF tests that run on TileDB Cloud",
 ]

--- a/src/tiledb/cloud/tiledb_cloud_error.py
+++ b/src/tiledb/cloud/tiledb_cloud_error.py
@@ -1,6 +1,9 @@
 import json
 from typing import Dict, Optional
 
+import urllib3
+from typing_extensions import Self
+
 import tiledb
 from tiledb.cloud import rest_api
 
@@ -11,7 +14,7 @@ class TileDBCloudError(tiledb.TileDBError):
         http_status: Optional[int] = None,
         *,
         json_data: Optional[Dict[str, object]] = None,
-        body: Optional[str] = None,
+        body: Optional[bytes] = None,
     ) -> None:
         super().__init__()
         self.json_data = json_data
@@ -28,6 +31,14 @@ class TileDBCloudError(tiledb.TileDBError):
         if self.http_status == 404:
             return "HTTP 404: resource not found"
         return f"Unknown HTTP {self.http_status} error; response body: {self.body!r}"
+
+    @classmethod
+    def from_response(cls, resp: urllib3.BaseHTTPResponse) -> Self:
+        try:
+            json_data = resp.json()
+            return cls(resp.status, json_data=json_data)
+        except ValueError:
+            return cls(resp.status, body=resp.data)
 
 
 def maybe_wrap(exc: Exception) -> TileDBCloudError:


### PR DESCRIPTION
The service at https://api.tiledb.com which redirects requests to the appropriate TileDB Cloud backend doesn't accept large uploads (and even if it did, we don't want to make unnecessarily large requests). However, it *will* respond with redirect information to a HTTP HEAD request.

This change starts uploads by probing the correct destination URL by making HEAD requests before it tries actually sending the data.

---

Tests for this live behind the `--run-bigfiles` test flag. I have manually confirmed that `test_big_file` works; `test_huge_file` is pending a cluster configuration change.