### PR TITLE
Remove urllib3.BaseHTTPResponse as a type-hint.

### DIFF
--- a/src/tiledb/cloud/tiledb_cloud_error.py
+++ b/src/tiledb/cloud/tiledb_cloud_error.py
@@ -1,7 +1,6 @@
 import json
 from typing import Dict, Optional
 
-import urllib3
 from typing_extensions import Self
 
 import tiledb
@@ -33,7 +32,7 @@ class TileDBCloudError(tiledb.TileDBError):
         return f"Unknown HTTP {self.http_status} error; response body: {self.body!r}"
 
     @classmethod
-    def from_response(cls, resp: urllib3.BaseHTTPResponse) -> Self:
+    def from_response(cls, resp) -> Self:
         try:
             json_data = resp.json()
             return cls(resp.status, json_data=json_data)

--- a/src/tiledb/cloud/tiledb_cloud_error.py
+++ b/src/tiledb/cloud/tiledb_cloud_error.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, Optional
 
+import urllib3
 from typing_extensions import Self
 
 import tiledb
@@ -32,7 +33,7 @@ class TileDBCloudError(tiledb.TileDBError):
         return f"Unknown HTTP {self.http_status} error; response body: {self.body!r}"
 
     @classmethod
-    def from_response(cls, resp) -> Self:
+    def from_response(cls, resp: "urllib3.BaseHTTPResponse") -> Self:
         try:
             json_data = resp.json()
             return cls(resp.status, json_data=json_data)


### PR DESCRIPTION
# Issue

By merging [this PR ](https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/645) we introduced an unforeseen issue coming from `urllib3` ([although the issue is documented as fixed](https://github.com/urllib3/urllib3/issues/3078)).
```
Traceback (most recent call last):
1368
  File "/mnt/test/verify_tiledb_version.py", line 9, in <module>
1369
    import tiledb
1370
  File "/opt/conda/lib/python3.9/site-packages/tiledb/__init__.py", line 119, in <module>
1371
    from tiledb.cloud.cloudarray import CloudArray
1372
  File "/opt/conda/lib/python3.9/site-packages/tiledb/cloud/__init__.py", line 3, in <module>
1373
    from . import array
1374
  File "/opt/conda/lib/python3.9/site-packages/tiledb/cloud/array.py", line 7, in <module>
1375
    from . import client
1376
  File "/opt/conda/lib/python3.9/site-packages/tiledb/cloud/client.py", line 17, in <module>
1377
    from tiledb.cloud import tiledb_cloud_error
1378
  File "/opt/conda/lib/python3.9/site-packages/tiledb/cloud/tiledb_cloud_error.py", line 11, in <module>
1379
    class TileDBCloudError(tiledb.TileDBError):
1380
  File "/opt/conda/lib/python3.9/site-packages/tiledb/cloud/tiledb_cloud_error.py", line 36, in TileDBCloudError
1381
    def from_response(cls, resp: urllib3.BaseHTTPResponse) -> Self:
1382
AttributeError: module 'urllib3' has no attribute 'BaseHTTPResponse'
``` 

# Proposed Solution

Remove [that type hint](https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/514ad4e244b4533e972df3a0c26f0b7c0921cb53/src/tiledb/cloud/tiledb_cloud_error.py#L36)