### PR TITLE
xfail 5 tests because of 2 upstream issues

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -151,13 +151,13 @@ jobs:
             --store-durations \
             --splitting-algorithm least_duration \
             --clean-durations \
-            -r xX \
+            -r fExX \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \
             --tb short \
             --color yes \
-            -r fxX
+            -r fExX
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -151,11 +151,13 @@ jobs:
             --store-durations \
             --splitting-algorithm least_duration \
             --clean-durations \
+            -r fxX \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \
             --tb short \
-            --color yes
+            --color yes \
+            -r fxX
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -151,7 +151,7 @@ jobs:
             --store-durations \
             --splitting-algorithm least_duration \
             --clean-durations \
-            -r fxX \
+            -r xX \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \

--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud import dag
 from tiledb.cloud.taskgraphs.server_executor import impl
@@ -7,6 +9,9 @@ from tiledb.cloud.taskgraphs.server_executor import impl
 _WAIT_TIME_S = 120
 
 
+@pytest.mark.xfail(
+    reason="Two issues upstream prevent this test from reliably passing."
+)
 class ConnectToExistingTest(unittest.TestCase):
     def test_completed_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,6 +9,7 @@ import numpy as np
 import packaging.version as pkgver
 import pandas
 import pyarrow
+import pytest
 
 import tiledb
 import tiledb.cloud
@@ -34,6 +35,9 @@ class BasicTests(unittest.TestCase):
         all_mods = ast.literal_eval(all_mods_str.decode())
         assert "pandas" not in all_mods
 
+    @pytest.mark.xfail(
+        reason="An upstream issue prevents this test from reliably passing."
+    )
     def test_info(self):
         self.assertIsNotNone(array.info("tiledb://TileDB-Inc/quickstart_sparse"))
         self.assertIsNotNone(groups.info("tiledb://TileDB-Inc/TileDB_101"))
@@ -414,6 +418,9 @@ class BasicTests(unittest.TestCase):
         )
         self.assertEqual(2, len(got.groups))
 
+    @pytest.mark.xfail(
+        reason="An upstream issue prevents this test from reliably passing."
+    )
     def test_public_groups(self):
         got = client.list_public_groups(
             namespace="tiledb-inc",


### PR DESCRIPTION
1. Our retry script isn't working on these particular failures.
2. Instead of increasing the number of retries over time, I want to mark that we have upstream issues (or invalid usage) and then use passing of the marked tests as acceptance criteria for fixes.