### PR TITLE
Adding PNG support and enabling experimental reader in kwargs

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from enum import Enum
 from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
 import tiledb
@@ -17,6 +18,11 @@ DEFAULT_IMG_NAME = "3.9-imaging-dev"
 DEFAULT_DAG_NAME = "bioimg-ingestion"
 _SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".ndpi", ".png")
 _SUPPORTED_CONVERTERS = ("tiff", "zarr", "osd", "png")
+
+
+class ReaderType(Enum):
+    PRODUCTION = "production"
+    EXPERIMENTAL = "experimental"
 
 
 def ingest(
@@ -358,8 +364,8 @@ def ingest(
     compressor = kwargs.pop("compressor", None)
 
     # Get either the new experimental or default reader
-    reader = kwargs.pop("reader", "production")
-    experimental_reader = True if reader == "experimental" else False
+    reader = kwargs.pop("reader", ReaderType.PRODUCTION.value)
+    experimental_reader = reader == ReaderType.EXPERIMENTAL.value
 
     logger.debug("Compressor: %r", compressor)
     compressor_serial = serialize_filter(compressor) if compressor else None

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -15,8 +15,8 @@ from tiledb.cloud.utilities._common import run_dag
 DEFAULT_RESOURCES = {"cpu": "8", "memory": "4Gi"}
 DEFAULT_IMG_NAME = "3.9-imaging-dev"
 DEFAULT_DAG_NAME = "bioimg-ingestion"
-_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".ndpi")
-_SUPPORTED_CONVERTERS = ("tiff", "zarr", "osd")
+_SUPPORTED_EXTENSIONS = (".tiff", ".tif", ".svs", ".ndpi", ".png")
+_SUPPORTED_CONVERTERS = ("tiff", "zarr", "osd", "png")
 
 
 def ingest(
@@ -203,8 +203,10 @@ def ingest(
         user_converter = {
             "zarr": Converters.OMEZARR,
             "osd": Converters.OSD,
+            "png": Converters.PNG,
         }.get(converter, Converters.OMETIFF)
 
+        experimental_reader = kwargs.get("experimental_reader", False)
         compressor = kwargs.get("compressor", None)
         if compressor:
             compressor_args = dict(compressor)
@@ -229,8 +231,10 @@ def ingest(
                 tile_scale=tile_scale,
                 source_config=config,
                 dest_config=kwargs.get("dest_config", None),
+                experimental_reader=experimental_reader,
                 **kwargs,
             )
+
         return io_uris
 
     def register_dataset_udf(
@@ -350,6 +354,7 @@ def ingest(
 
     # serialize udf arguments
     compressor = kwargs.pop("compressor", None)
+    experimental_reader = kwargs.pop("experimental_reader", False)
     logger.debug("Compressor: %r", compressor)
     compressor_serial = serialize_filter(compressor) if compressor else None
 
@@ -368,6 +373,7 @@ def ingest(
         image_name=DEFAULT_IMG_NAME,
         max_workers=threads,
         compressor=compressor_serial,
+        experimental_reader=experimental_reader,
         access_credentials_name=acn,
         **kwargs,
     )

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -74,6 +74,8 @@ def ingest(
         registered in TileDB Cloud (ARN type) if ``acn`` is not set.
     :param dest_config: dict configuration to pass on tiledb.VFS for the destination's
         resolution
+    :param reader: The selected reader backend implementation either "experimental"
+        or "production". Default["production"]
     """
 
     logger = get_logger_wrapper(verbose)
@@ -354,7 +356,11 @@ def ingest(
 
     # serialize udf arguments
     compressor = kwargs.pop("compressor", None)
-    experimental_reader = kwargs.pop("experimental_reader", False)
+
+    # Get either the new experimental or default reader
+    reader = kwargs.pop("reader", "production")
+    experimental_reader = True if reader == "experimental" else False
+
     logger.debug("Compressor: %r", compressor)
     compressor_serial = serialize_filter(compressor) if compressor else None
 


### PR DESCRIPTION
This PR:

- Enables the `experimental_reader` in the Cloud-py ingestor which was introduced in tiledb-bioimg 0.3.0 and onwards
- Incorporates the new PNG converter for use in cloud ingestion