### PR TITLE
Improve missing object detection in upload_wheel

### DIFF
--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -71,7 +71,8 @@ def upload_wheel(
             )
 
         # Create the array if it doesn't exist
-# `object_type == "None"` is work-around for regression, see https://app.shortcut.com/tiledb-inc/story/55930 for fix
+        # `object_type == "None"` is work-around for regression,
+        # see https://app.shortcut.com/tiledb-inc/story/55930 for fix
         if object_type is None or object_type == "None":
             tiledb.Array.create(dest_uri, tiledb.ArraySchema.from_file(wheel_path))
             logger.info(f"Created filestore at '{dest_uri}'")

--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -71,7 +71,7 @@ def upload_wheel(
             )
 
         # Create the array if it doesn't exist
-        if object_type is None:
+        if object_type is None or object_type == "None":
             tiledb.Array.create(dest_uri, tiledb.ArraySchema.from_file(wheel_path))
             logger.info(f"Created filestore at '{dest_uri}'")
         elif object_type == "group":

--- a/src/tiledb/cloud/utilities/wheel.py
+++ b/src/tiledb/cloud/utilities/wheel.py
@@ -71,6 +71,7 @@ def upload_wheel(
             )
 
         # Create the array if it doesn't exist
+# `object_type == "None"` is work-around for regression, see https://app.shortcut.com/tiledb-inc/story/55930 for fix
         if object_type is None or object_type == "None":
             tiledb.Array.create(dest_uri, tiledb.ArraySchema.from_file(wheel_path))
             logger.info(f"Created filestore at '{dest_uri}'")


### PR DESCRIPTION
`upload_wheel` uses `tiledb.object_type(...)` to check for existing objects. 

* `tiledb-py<=0.31.1` returns `None` (NoneType) if the object doesn't exist. 
* `tiledb-py>=0.32.0` returns `"None"` (a string) if the object doesn't exist. 

This PR updates the `upload_wheel` to handle both return values.