### PR TITLE
Workaround for object_type in py>=0.32.0

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -274,7 +274,7 @@ def ingest(
                     logger.debug("Object type of %s : %s", tiledb_uri, object_type)
                     if object_type == "group":
                         found = True
-                    elif object_type is not None:
+                    elif object_type is not None or object_type != "None":
                         raise ValueError(
                             f"Another object is already registered at '{tiledb_uri}'."
                         )

--- a/src/tiledb/cloud/geospatial/ingestion.py
+++ b/src/tiledb/cloud/geospatial/ingestion.py
@@ -942,7 +942,7 @@ def register_dataset_udf(
             object_type = tiledb.object_type(tiledb_uri)
             if object_type == "array":
                 found = True
-            elif object_type is not None:
+            elif object_type is not None or object_type != "None":
                 raise ValueError(
                     f"Another object is already registered at '{tiledb_uri}'."
                 )

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -47,7 +47,7 @@ def register_dataset_udf(
             object_type = tiledb.object_type(tiledb_uri)
             if object_type == "group":
                 found = True
-            elif object_type is not None:
+            elif object_type is not None or object_type != "None":
                 raise ValueError(
                     f"Another object is already registered at '{tiledb_uri}'."
                 )

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -256,7 +256,7 @@ def register_dataset_udf(
             object_type = tiledb.object_type(tiledb_uri)
             if object_type == "group":
                 found = True
-            elif object_type is not None:
+            elif object_type is not None or object_type != "None":
                 raise ValueError(
                     f"Another object is already registered at '{tiledb_uri}'."
                 )


### PR DESCRIPTION
This PR:

- Fixes all the occurrences of if-condition statements in ingestors that use the `tiledb.object_type` to work around a regression in tiledb-py==0.32.0 and upwards.