### PR TITLE
Add http(s) scheme if missing when logging in

### DIFF
--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -89,7 +89,9 @@ def login(
     if host is None:
         host = config.default_host
     # See sc-56351. Usually, a hostname doesn't include a protocol
-    # scheme, but our SDK strictly requires the https scheme.
+    # scheme, but our SDK strictly requires the http(s) scheme.
+    elif host.startswith("http://"):
+        pass
     elif not host.startswith("https://"):
         host = f"https://{host}"
 

--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -90,9 +90,7 @@ def login(
         host = config.default_host
     # See sc-56351. Usually, a hostname doesn't include a protocol
     # scheme, but our SDK strictly requires the http(s) scheme.
-    elif host.startswith("http://"):
-        pass
-    elif not host.startswith("https://"):
+    elif not host.startswith(("http://", "https://")):
         host = f"https://{host}"
 
     if (token is None or token == "") and (

--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -88,6 +88,10 @@ def login(
     """
     if host is None:
         host = config.default_host
+    # See sc-56351. Usually, a hostname doesn't include a protocol
+    # scheme, but our SDK strictly requires the https scheme.
+    elif not host.startswith("https://"):
+        host = f"https://{host}"
 
     if (token is None or token == "") and (
         (username is None or username == "") and (password is None or password == "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,24 @@ import tiledb.cloud
 import tiledb.cloud.config
 
 
-def test_login_bare_host():
+def test_login_bare_host(monkeypatch, tmp_path):
     """Accept a bare host, store it with https scheme."""
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "default_config_file",
+        tmp_path.joinpath("cloud.json"),
+    )
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "config",
+        tiledb.cloud.config.configuration.Configuration(),
+    )
+    monkeypatch.setattr(tiledb.cloud.client.config, "logged_in", False)
+    monkeypatch.setattr(tiledb.cloud.client, "client", tiledb.cloud.client.Client())
     tiledb.cloud.login(token="foo", host="bar")
     assert tiledb.cloud.config.config.host == "https://bar"
+
+
+def test_login_bare_host_bis():
+    """Check on the first."""
+    assert tiledb.cloud.config.config.host != "https://bar"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+"""Tests of configuration and login."""
+
+import tiledb.cloud
+import tiledb.cloud.config
+
+
+def test_login_bare_host():
+    """Accept a bare host, store it with https scheme."""
+    tiledb.cloud.login(token="foo", host="bar")
+    assert tiledb.cloud.config.config.host == "https://bar"


### PR DESCRIPTION
Usually, a hostname doesn't include a protocol scheme, but our SDK strictly requires the http(s) scheme. Thus, we add it if it is missing when logging in.