### PR TITLE
Remove xfail on 3 graph connection tests

### DIFF
--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud import dag
 from tiledb.cloud.taskgraphs.server_executor import impl
@@ -9,9 +7,6 @@ from tiledb.cloud.taskgraphs.server_executor import impl
 _WAIT_TIME_S = 120
 
 
-@pytest.mark.xfail(
-    reason="Two issues upstream prevent this test from reliably passing."
-)
 class ConnectToExistingTest(unittest.TestCase):
     def test_completed_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)


### PR DESCRIPTION
The upstream issue has been resolved and these marks can be removed.