### PR TITLE
Recategorize API reference

### DIFF
--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -22,101 +22,94 @@ website:
     style: "floating"
     collapse-level: 1
     contents:
-      - Cloud-Py
-      - section: Cloud Services
+      - section: Catalog
         contents:
-          - text: "`array`"
-            href: reference/array.qmd
-          - text: "`asset`"
-            href: reference/asset.qmd
-          - text: "`client`"
-            href: reference/client.qmd
-          - text: "`cloudarray`"
-            href: reference/cloudarray.qmd
-          - text: "`config`"
-            href: reference/config.qmd
-          - text: "`groups`"
+          - text: groups
             href: reference/groups.qmd
-          - text: "`invites`"
-            href: reference/invites.qmd
-          - text: "`notebook`"
+          - text: array
+            href: reference/array.qmd
+          - text: asset
+            href: reference/asset.qmd
+          - text: files
+            href: reference/files.qmd
+          - text: notebook
             href: reference/notebook.qmd
-          - text: "`pool_manager_wrapper`"
-            href: reference/pool_manager_wrapper.qmd
-          - text: "`tasks`"
-            href: reference/tasks.qmd
-          - text: "`tiledb_cloud_error`"
-            href: reference/tiledb_cloud_error.qmd
-          - text: "`udf`"
+          - text: udf
             href: reference/udf.qmd
-          - text: "`utils`"
-            href: reference/utils.qmd
-      - section: Bio-Imaging
+
+      - section: Collaborate
         contents:
-          - text: "`exportation`"
+          - text: groups
+            href: reference/groups.qmd
+          - text: array
+            href: reference/array.qmd
+          - text: asset
+            href: reference/asset.qmd
+          - text: invites
+            href: reference/invites.qmd
+
+      - section: Analyze
+        contents:
+          - text: bioimg.exportation
             href: reference/bioimg.exportation.qmd
-          - text: "`helpers`"
+          - text: bioimg.helpers
             href: reference/bioimg.helpers.qmd
-          - text: "`ingestion`"
+          - text: bioimg.ingestion
             href: reference/bioimg.ingestion.qmd
-      - section: Compute
-        contents:
-          - text: "`delayed`"
-            href: reference/compute.delayed.qmd
-      - section: DAG
-        contents:
-          - text: "`dag`"
-            href: reference/dag.dag.qmd
-          - text: "`mode`"
-            href: reference/dag.mode.qmd
-          - text: "`status`"
-            href: reference/dag.status.qmd
-          - text: "`visualization`"
-            href: reference/dag.visualization.qmd
-      - section: Region
-        contents:
-          - text: "`region`"
-            href: reference/region.qmd
-      - section: Files
-        contents:
-          - text: "`indexing`"
+          - text: files.indexing
             href: reference/files.indexing.qmd
-          - text: "`ingestion`"
+          - text: files.ingestion
             href: reference/files.ingestion.qmd
-          - text: "`udfs`"
+          - text: files.udfs
             href: reference/files.udfs.qmd
-          - text: "`utils`"
+          - text: files.utils
             href: reference/files.utils.qmd
-      - section: Geospatial
-        contents:
-          - text: "`ingestion`"
+          - text: geospatial.ingestion
             href: reference/geospatial.ingestion.qmd
-      - section: SOMA
-        contents:
-          - text: "`ingest`"
+          - text: soma.ingest
             href: reference/soma.ingest.qmd
-          - text: "`mapper`"
+          - text: soma.mapper
             href: reference/soma.mapper.qmd
-      - section: VCF
-        contents:
-          - text: "`allele_frequency`"
+          - text: vcf.allele_frequency
             href: reference/vcf.allele_frequency.qmd
-          - text: "`ingestion`"
+          - text: vcf.ingestionq
             href: reference/vcf.ingestion.qmd
-          - text: "`query`"
+          - text: vcf.query
             href: reference/vcf.query.qmd
-          - text: "`utils`"
+          - text: vcf.utils
             href: reference/vcf.utils.qmd
-          - text: "`split`"
+          - text: vcf.split
             href: reference/vcf.split.qmd
-      - section: Utilities
+
+      - section: Scale
         contents:
-          - text: "`consolidate`"
+          - text: cloudarray
+            href: reference/cloudarray.qmd
+          - text: compute.delayed
+            href: reference/compute.delayed.qmd
+          - text: dag.dag
+            href: reference/dag.dag.qmd
+          - text: dag.mode
+            href: reference/dag.mode.qmd
+          - text: dag.status
+            href: reference/dag.status.qmd
+          - text: dag.visualization
+            href: reference/dag.visualization.qmd
+          - text: tasks
+            href: reference/tasks.qmd
+          - text: udf
+            href: reference/udf.qmd
+          - text: utilities.consolidate
             href: reference/utilities.consolidate.qmd
-          - text: "`profiler`"
+          - text: utilities.profiler
             href: reference/utilities.profiler.qmd
-          - text: "`wheel`"
-            href: reference/utilities.wheel.qmd
+
+      - section: Account
+        contents:
+          - text: client
+            href: reference/client.qmd
+          - text: config
+            href: reference/config.qmd
 
 quartodoc:
   style: pkgdown
@@ -130,69 +123,50 @@ quartodoc:
     include_attributes: true
 
   sections:
-    - title: Cloud Services
-      desc: Cloud Interaction Services
+    - title: Catalog
+      desc: PLACEHOLDER CATEGORY DESCRIPTION
       contents:
+        - groups
         - array
         - asset
-        - client
-        - cloudarray
-        - config
-        - groups
-        - invites
+        - files
         - notebook
-        - pool_manager_wrapper
-        - tasks
-        - tiledb_cloud_error
         - udf
-        - utils
 
-    - title: bioimg
-      desc: Bio imaging API
+    - title: Collaborate
+      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      contents:
+        - groups
+        - array
+        - asset
+        - invites
+
+    - title: Analyze
+      desc: PLACEHOLDER CATEGORY DESCRIPTION
+
+    - subtitle: Bio Imaging
       contents:
         - bioimg.exportation
         - bioimg.helpers
         - bioimg.ingestion
 
-    - title: compute
-      desc: Compute API
-      contents:
-        - compute.delayed
-
-    - title: dag
-      desc: DAG API
-      contents:
-        - dag.dag
-        - dag.mode
-        - dag.status
-        - dag.visualization
-
-    - title: region
-      desc: Cloud regions
-      contents:
-        - region
-
-    - title: files
-      desc: File API.
+    - subtitle: Files
       contents:
         - files.indexing
         - files.ingestion
         - files.udfs
         - files.utils
 
-    - title: geospatial
-      desc: Geospatial API
+    - subtitle: Geospatial
       contents:
         - geospatial.ingestion
 
-    - title: soma
-      desc: SOMA API
+    - subtitle: SOMA
       contents:
         - soma.ingest
         - soma.mapper
 
-    - title: vcf
-      desc: VCF API
+    - subtitle: VCF
       contents:
         - vcf.allele_frequency
         - vcf.ingestion
@@ -200,9 +174,22 @@ quartodoc:
         - vcf.utils
         - vcf.split
 
-    - title: utilities
-      desc: Common Utilities API
+    - title: Scale
+      desc: PLACEHOLDER CATEGORY DESCRIPTION
       contents:
+        - cloudarray
+        - compute.delayed
+        - dag.dag
+        - dag.mode
+        - dag.status
+        - dag.visualization
+        - tasks
+        - udf
         - utilities.consolidate
         - utilities.profiler
-        - utilities.wheel
+
+    - title: Account
+      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      contents:
+        - client
+        - config

--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -142,7 +142,7 @@ quartodoc:
         - invites
 
     - title: Analyze
-      desc: "Gain understanding domain-specific data."
+      desc: "Gain understanding of data."
 
     - subtitle: Bio Imaging
       contents:

--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -124,7 +124,7 @@ quartodoc:
 
   sections:
     - title: Catalog
-      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      desc: "Find and register private and public assets."
       contents:
         - groups
         - array
@@ -134,7 +134,7 @@ quartodoc:
         - udf
 
     - title: Collaborate
-      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      desc: "Share private assets with other users and organizations, or make them public."
       contents:
         - groups
         - array
@@ -142,7 +142,7 @@ quartodoc:
         - invites
 
     - title: Analyze
-      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      desc: "Gain understanding domain-specific data."
 
     - subtitle: Bio Imaging
       contents:
@@ -171,11 +171,11 @@ quartodoc:
         - vcf.allele_frequency
         - vcf.ingestion
         - vcf.query
-        - vcf.utils
         - vcf.split
+        - vcf.utils
 
     - title: Scale
-      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      desc: "Ingest and analyze data that is too large for a single computer."
       contents:
         - cloudarray
         - compute.delayed
@@ -189,7 +189,7 @@ quartodoc:
         - utilities.profiler
 
     - title: Account
-      desc: PLACEHOLDER CATEGORY DESCRIPTION
+      desc: "Profile, settings, and usage."
       contents:
         - client
         - config


### PR DESCRIPTION
Previously, our API reference had 8 sections in the main body and sidebar, and every module in the API reference was in exactly one section.

We're reducing the number of sections to 5:

* Catalog
* Collaborate
* Analyze
* Scale
* Account

And reorganizing the modules within these new sections like so:

* Domain-specific modules (SOMA, VCF, etc) are merged into the new "Analyze" category.
* The previous "Compute", "DAG", and "Utilities" categories are merged into the new "Scale" category.
* Modules of the previous "Cloud Services" category are distributed to "Catalog", "Collaborate", "Scale", and "Account".
* There is overlap between the new "Catalog" and "Collaborate" sections. Some API modules are in both. That is because the Cloud-Py API has historically been organized around types of assets (groups, arrays, files, notebooks). The new categories cut across some existing modules.

#### Important details

* This PR does not add any new API documentation for modules, it only moves existing documentation to new categories.
* Placeholder descriptions for categories are used and should be replaced by real, useful text that is aligned with the website.
* The quartodoc software that we're using for the API reference appears to have some deficiencies. For example, we've put a lot of work into making sure that functions in all `vcf` submodules are exported from `tiledb.cloud.vcf`, but quartodoc seems unable to produce API documentation for that high-level module.

#### Summary

Let's fix any obvious errors in categorization of modules now and then iterate as we progress.