### PR TITLE
Preserve SOMA ingest keyword arguments

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -38,6 +38,7 @@ def ingest(
     converter: Optional[str] = None,
     output_ext: str = "",
     tile_scale: int = 128,
+    _propagate_resources: bool = False,
     **kwargs,
 ) -> tiledb.cloud.dag.DAG:
     """The function ingests microscopy images into TileDB arrays
@@ -369,6 +370,7 @@ def ingest(
         max_workers=threads,
         compressor=compressor_serial,
         access_credentials_name=acn,
+        _propagate_resources=_propagate_resources,
         **kwargs,
     )
 
@@ -394,4 +396,4 @@ def ingest(
 
 
 # Wrapper function for batch VCF ingestion
-ingest_batch = as_batch(ingest)
+ingest_batch = as_batch(ingest, _propagate_resources=True)

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -948,7 +948,6 @@ class DAG:
         _fallback_name: Optional[str] = None,
         store_results=True,
         expand_node_output: Optional[Node] = None,
-        _propagate_resources=False,
         **kwargs,
     ):
         with self._lifecycle_condition:
@@ -980,7 +979,6 @@ class DAG:
                 dag=self,
                 name=name,
                 expand_node_output=expand_node_output,
-                _propagate_resources=_propagate_resources,
                 **kwargs,
             )
             return self._add_node_internal(node)
@@ -1014,15 +1012,11 @@ class DAG:
         kwargs.setdefault("name", functions.full_name(func))
         return self._add_raw_node(func, *args, mode=Mode.LOCAL, **kwargs)
 
-    def submit_udf(self, func: Callable, *args, _propagate_resources=False, **kwargs):
+    def submit_udf(self, func: Callable, *args, **kwargs):
         """Submit a function that will be executed in the cloud serverlessly.
 
         :param func: Function to execute in UDF task.
         :param *args: Postional arguments to pass into Node instantation.
-        :param _propagate_resources: True if the Node should propagate
-            "resources" and "resource_class" parameters to the function
-            it executes instead of consuming the parameters. Default:
-            False.
         :param **kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created.
         """
@@ -1041,7 +1035,6 @@ class DAG:
             func,
             *args,
             _fallback_name=functions.full_name(func),
-            _propagate_resources=_propagate_resources,
             **kwargs,
         )
 

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -149,8 +149,9 @@ class Node(futures.FutureLike[_T]):
         """Processing mode of Node."""
         self._expand_node_output: Optional[Node] = expand_node_output
 
-        self._resource_class = kwargs.get("resource_class", None)
-        self._resources = kwargs.get("resources", None)
+        # This is root of the problem.
+        self._resource_class = kwargs.pop("resource_class", None)
+        self._resources = kwargs.pop("resources", None)
 
         self._wrapped_func: Callable[..., "results.Result[_T]"]
 

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -149,8 +149,8 @@ class Node(futures.FutureLike[_T]):
         """Processing mode of Node."""
         self._expand_node_output: Optional[Node] = expand_node_output
 
-        self._resource_class = kwargs.pop("resource_class", None)
-        self._resources = kwargs.pop("resources", None)
+        self._resource_class = kwargs.get("resource_class", None)
+        self._resources = kwargs.get("resources", None)
 
         self._wrapped_func: Callable[..., "results.Result[_T]"]
 

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -25,6 +25,7 @@ def register_dataset_udf(
     namespace: Optional[str] = None,
     config: Optional[Mapping[str, Any]] = None,
     verbose: bool = False,
+    **kwargs,
 ) -> None:
     """
     Register the dataset on TileDB Cloud.
@@ -233,6 +234,7 @@ def ingest_h5ad(
     ingest_mode: str = "write",
     logging_level: int = logging.INFO,
     dry_run: bool = False,
+    **kwargs,
 ) -> None:
     """Performs the actual work of ingesting H5AD data into TileDB.
 
@@ -402,12 +404,17 @@ def run_ingest_workflow(
         mode=dag.Mode.BATCH,
     )
 
-    # Step 1: Ingest workflow UDF
-    carry_along: Dict[str, str] = {
-        "resources": _DEFAULT_RESOURCES if resources is None else resources,
-        "namespace": namespace,
-        "access_credentials_name": acn,
-    }
+    carry_along: Dict[str, str] = kwargs.pop(
+        "carry_along",
+        {
+            "resources": _DEFAULT_RESOURCES if resources is None else resources,
+            # I don't see why this is needed. I'm not finding any code that
+            # pops "namespace" from kwargs.
+            "namespace": namespace,
+            # Because workflows might be using older user-defined functions?
+            "access_credentials_name": acn,
+        },
+    )
 
     grf.submit(
         _run_ingest_workflow_udf_byval,

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -392,7 +392,7 @@ def as_batch(func: _CT) -> _CT:
         if resources:
             _resources["resources"] = resources
         if resource_class:
-            _resources["resource_class"]: resource_class
+            _resources["resource_class"] = resource_class
         kwargs["_resources"] = _resources
 
         # Submit the function as a batch UDF.

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -345,7 +345,10 @@ def as_batch(func: _CT) -> _CT:
         name = kwargs.get("name", func.__name__)
         namespace = kwargs.get("namespace", None)
         acn = kwargs.get("acn", kwargs.pop("access_credentials_name", None))
-        kwargs["acn"] = acn  # for backwards compatibility
+        kwargs["acn"] = acn  # for backwards compatibility.
+
+        # We pop these off to use as named keyword args when submitting
+        # the function to our graph, below.
         resources = kwargs.pop("resources", None)
         image_name = kwargs.pop("image_name", None)
 
@@ -356,7 +359,7 @@ def as_batch(func: _CT) -> _CT:
             mode=dag.Mode.BATCH,
         )
 
-        # Submit the function as a batch UDF
+        # Submit the function as a batch UDF.
         graph.submit(
             func,
             *args,
@@ -367,7 +370,7 @@ def as_batch(func: _CT) -> _CT:
             **_filter_kwargs(func, kwargs),
         )
 
-        # Run the DAG asynchronously
+        # Run the DAG asynchronously.
         graph.compute()
 
         print(

--- a/src/tiledb/cloud/utilities/_common.py
+++ b/src/tiledb/cloud/utilities/_common.py
@@ -342,15 +342,10 @@ def as_batch(func: _CT, *, _propagate_resources=False) -> _CT:
     to the next graph in the workflow, and we're back to a default of
     8GB.
 
-    We're going to work around that issue by requiring functions
-    that need to preserve "resource_class" and "resources" to use a
-    "_resources" keyword argument.
-
     If you are writing a cloud function that is to be called from
     another cloud function, you should expect to receive a
-    "_resources" keyword argument and find "resource_class" and
-    "resources" in it. Likewise, you should propagate these to the
-    next cloud function in the same way.
+    "_propagate_resources" and should propagate this keyword argument
+    to the next cloud function.
     """
 
     @functools.wraps(func)

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1334,6 +1334,53 @@ class ReplaceNodesTest(unittest.TestCase):
         )
 
 
+def test_node_propagate_resources_false():
+    """Node() does not propagate by default."""
+
+    def func(*args, **kwargs):
+        pass
+
+    node = dag.Node(
+        func,
+        "arg1",
+        "arg2",
+        mode=Mode.BATCH,
+        name="test",
+        kwarg1="foo",
+        resources={"cpu": "8", "memory": "32Gi"},
+    )
+    assert node._name == "test"
+    assert node._resources == {"cpu": "8", "memory": "32Gi"}
+    assert "arg1" in node.args
+    assert "arg2" in node.args
+    assert node.kwargs["kwarg1"] == "foo"
+    assert "resources" not in node.kwargs
+
+
+def test_node_propagate_resources_true():
+    """Node() does propagate."""
+
+    def func(*args, **kwargs):
+        pass
+
+    node = dag.Node(
+        func,
+        "arg1",
+        "arg2",
+        mode=Mode.BATCH,
+        name="test",
+        kwarg1="foo",
+        resources={"cpu": "8", "memory": "32Gi"},
+        _propagate_resources=True,
+    )
+    assert node._name == "test"
+    assert node._resources == {"cpu": "8", "memory": "32Gi"}
+    assert "arg1" in node.args
+    assert "arg2" in node.args
+    assert node.kwargs["kwarg1"] == "foo"
+    assert node.kwargs["resources"] == {"cpu": "8", "memory": "32Gi"}
+
+
 def _node(val):
     """Creates a completed node with the given value."""
     n = dag.Node(lambda: None)

--- a/tests/utilities/test_as_batch.py
+++ b/tests/utilities/test_as_batch.py
@@ -1,0 +1,28 @@
+"""Tests of as_batch() and of the _resources parameter tunnel."""
+
+import unittest
+import unittest.mock
+
+import tiledb.cloud.utilities._common
+from tiledb.cloud.utilities._common import as_batch
+
+
+@unittest.mock.patch.object(tiledb.cloud.utilities._common.dag, "DAG")
+def test_propagate_resources(mock_dag):
+    """Assert that as_batch propagates resource parameters."""
+
+    def submit(func, *args, **kwargs):
+        """Roughly mimic DAG.submit()."""
+        _ = kwargs.pop("resource_class", None)
+        _ = kwargs.pop("resources", None)
+        func(*args, **kwargs)
+
+    mock_dag.configure_mock(**{"return_value.submit.side_effect": submit})
+
+    def func(*args, **kwargs):
+        """Demonstrate that the wrapped function receives resources."""
+        assert "_resources" in kwargs
+        assert kwargs["_resources"]["resource_class"] == "foo"
+        assert kwargs["_resources"]["resources"] == {"cpu": "8", "memory": "32Gi"}
+
+    as_batch(func)(resource_class="foo", resources={"cpu": "8", "memory": "32Gi"})

--- a/tests/utilities/test_as_batch.py
+++ b/tests/utilities/test_as_batch.py
@@ -11,18 +11,17 @@ from tiledb.cloud.utilities._common import as_batch
 def test_propagate_resources(mock_dag):
     """Assert that as_batch propagates resource parameters."""
 
-    def submit(func, *args, **kwargs):
+    def submit(func, *args, _propagate_resources=False, **kwargs):
         """Roughly mimic DAG.submit()."""
-        _ = kwargs.pop("resource_class", None)
-        _ = kwargs.pop("resources", None)
+        kwarg_accessor = getattr(kwargs, "get" if _propagate_resources else "pop")
+        _ = kwarg_accessor("resource_class", None)
+        _ = kwarg_accessor("resources", None)
         func(*args, **kwargs)
 
     mock_dag.configure_mock(**{"return_value.submit.side_effect": submit})
 
     def func(*args, **kwargs):
         """Demonstrate that the wrapped function receives resources."""
-        assert "_resources" in kwargs
-        assert kwargs["_resources"]["resource_class"] == "foo"
-        assert kwargs["_resources"]["resources"] == {"cpu": "8", "memory": "32Gi"}
+        assert kwargs["resources"] == {"cpu": "8", "memory": "32Gi"}
 
-    as_batch(func)(resource_class="foo", resources={"cpu": "8", "memory": "32Gi"})
+    as_batch(func, _propagate_resources=True)(resources={"cpu": "8", "memory": "32Gi"})


### PR DESCRIPTION
(Edited because I came up with a better idea)

The root cause is that `Node()` consumes its `resources` keyword argument and does not propagate it to the cloud function. In ingestion code, we've overlooked this or worked around it.

I propose adding a `_propagate_resources` flag to `Node()`. If `True` it does not consume the parameters and allows them to be passed to the function. The default should be `False` because it's likely that cloud functions aren't expecting any new keyword arguments.

For ingestion code, whenever you pass `resources` to `DAG.submit()`, consider also passing `_propagate_resources=True` if your cloud function needs to specify resources. Otherwise, they'll be lost.