### PR TITLE
Add Panel dashboard wrapper for Voila

### DIFF
--- a/src/tiledb/cloud/dashboard.py
+++ b/src/tiledb/cloud/dashboard.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import socket
+from typing import Any
+
+
+def panel_dashboard(
+    app: Any,
+    *,
+    full_screen_link: bool = True,
+    title="Dashboard - TileDB",
+    verbose: bool = False,
+    vh_delta: int = 70,
+) -> Any:
+    """
+    Start a Panel server with the provided app and return an iframe that enables
+    viewing the app in Voila. This wrapper avoids issues with reactive Panel apps
+    in Voila.
+
+    :param app: The Panel app to serve.
+    :param full_screen_link: Include a link to the full screen view, defaults to True.
+    :param title: Title for the Panel server, defaults to "Dashboard - TileDB".
+    :param verbose: Enable verbose logging, defaults to False.
+    :param vh_delta: The vertical height delta for the iframe in px. This value is
+        subtracted from 100vh to set the height of the iframe.
+    :return: A Panel HTML pane containing an iframe that displays the app.
+    """
+
+    # Import Panel here to avoid a dependency on Panel.
+    import panel as pn
+
+    # Get a random open port.
+    with socket.socket() as sock:
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+
+    # Reduce noise from the panel server
+    if not verbose:
+        logging.getLogger("bokeh").setLevel(logging.CRITICAL)
+
+    # Start the panel server.
+    pn.serve(
+        app,
+        port=port,
+        address="localhost",
+        show=False,
+        title=title,
+        websocket_origin="*",
+        verbose=verbose,
+    )
+
+    # Create the link for the iframe.
+    if os.getenv("JUPYTERHUB_API_URL"):
+        user = os.getenv("JUPYTERHUB_USER")
+        url = f"/user/{user}/proxy/{port}/"
+    else:
+        url = f"http://localhost:{port}/"
+
+    # Create the iframe.
+    html = (
+        f"<iframe src='{url}' width='100%' "
+        f"style='border: 0;height: calc(100vh - {vh_delta}px);"
+        "margin: 0;'></iframe>"
+    )
+
+    # Add a link to pop out a full screen view.
+    if full_screen_link:
+        html += f"\n<a href='{url}' target='_blank'>Full screen view</a>"
+
+    return pn.pane.HTML(html, sizing_mode="stretch_both")

--- a/src/tiledb/cloud/notebook.py
+++ b/src/tiledb/cloud/notebook.py
@@ -3,11 +3,15 @@ Python support for notebook I/O on Tiledb Cloud. All notebook JSON content
 is assumed to be encoded as UTF-8.
 
 """
+
 import datetime
 import enum
+import logging
+import os
 import posixpath
+import socket
 import time
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import numpy
 
@@ -363,3 +367,66 @@ def _write_notebook_to_array(
         arr.meta["file_size"] = len(contents_as_array)
         arr.meta["type"] = rest_api.FileType.NOTEBOOK
         arr.meta["format"] = "json"
+
+
+def panel_dashboard(
+    app: Any,
+    *,
+    full_screen_link: bool = True,
+    verbose: bool = False,
+    vh_delta: int = 70,
+) -> Any:
+    """
+    Start a panel server with the provided app and return an iframe that enables
+    viewing the app in Voila. This wrapper avoids issues with reactive Panel apps
+    in Voila.
+
+    :param app: The Panel app to serve.
+    :param full_screen_link: Include a link to the full screen view, defaults to True.
+    :param verbose: Enable verbose logging, defaults to False.
+    :param vh_delta: The vertical height delta for the iframe in px. This value is
+        subtracted from 100vh to set the height of the iframe.
+    :return: A Panel HTML pane containing an iframe that displays the app.
+    """
+
+    # Import Panel here to avoid a dependency on Panel.
+    import panel as pn
+
+    # Get a random open port.
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+
+    # Reduce noise from the panel server
+    if not verbose:
+        logging.getLogger("bokeh").setLevel(logging.CRITICAL)
+
+    # Start the panel server.
+    pn.serve(
+        app,
+        port=port,
+        address="localhost",
+        show=False,
+        websocket_origin="*",
+        verbose=verbose,
+    )
+
+    # Create the link for the iframe.
+    if os.getenv("JUPYTERHUB_API_URL"):
+        user = os.getenv("JUPYTERHUB_USER")
+        url = f"/user/{user}/proxy/{port}/"
+    else:
+        url = f"http://localhost:{port}/"
+
+    # Create the iframe.
+    html = (
+        f"<iframe src='{url}' width='100%' "
+        f"style='border: 0;height: calc(100vh - {vh_delta}px);"
+        "margin: 0;'></iframe>"
+    )
+
+    # Add a link to pop out a full screen view.
+    if full_screen_link:
+        html += f"\n<a href='{url}' target='_blank'>Full screen view</a>"
+
+    return pn.pane.HTML(html, sizing_mode="stretch_both")

--- a/src/tiledb/cloud/notebook.py
+++ b/src/tiledb/cloud/notebook.py
@@ -3,15 +3,11 @@ Python support for notebook I/O on Tiledb Cloud. All notebook JSON content
 is assumed to be encoded as UTF-8.
 
 """
-
 import datetime
 import enum
-import logging
-import os
 import posixpath
-import socket
 import time
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy
 
@@ -367,69 +363,3 @@ def _write_notebook_to_array(
         arr.meta["file_size"] = len(contents_as_array)
         arr.meta["type"] = rest_api.FileType.NOTEBOOK
         arr.meta["format"] = "json"
-
-
-def panel_dashboard(
-    app: Any,
-    *,
-    full_screen_link: bool = True,
-    title="Dashboard - TileDB",
-    verbose: bool = False,
-    vh_delta: int = 70,
-) -> Any:
-    """
-    Start a Panel server with the provided app and return an iframe that enables
-    viewing the app in Voila. This wrapper avoids issues with reactive Panel apps
-    in Voila.
-
-    :param app: The Panel app to serve.
-    :param full_screen_link: Include a link to the full screen view, defaults to True.
-    :param title: Title for the Panel server, defaults to "Dashboard - TileDB".
-    :param verbose: Enable verbose logging, defaults to False.
-    :param vh_delta: The vertical height delta for the iframe in px. This value is
-        subtracted from 100vh to set the height of the iframe.
-    :return: A Panel HTML pane containing an iframe that displays the app.
-    """
-
-    # Import Panel here to avoid a dependency on Panel.
-    import panel as pn
-
-    # Get a random open port.
-    with socket.socket() as sock:
-        sock.bind(("localhost", 0))
-        port = sock.getsockname()[1]
-
-    # Reduce noise from the panel server
-    if not verbose:
-        logging.getLogger("bokeh").setLevel(logging.CRITICAL)
-
-    # Start the panel server.
-    pn.serve(
-        app,
-        port=port,
-        address="localhost",
-        show=False,
-        title=title,
-        websocket_origin="*",
-        verbose=verbose,
-    )
-
-    # Create the link for the iframe.
-    if os.getenv("JUPYTERHUB_API_URL"):
-        user = os.getenv("JUPYTERHUB_USER")
-        url = f"/user/{user}/proxy/{port}/"
-    else:
-        url = f"http://localhost:{port}/"
-
-    # Create the iframe.
-    html = (
-        f"<iframe src='{url}' width='100%' "
-        f"style='border: 0;height: calc(100vh - {vh_delta}px);"
-        "margin: 0;'></iframe>"
-    )
-
-    # Add a link to pop out a full screen view.
-    if full_screen_link:
-        html += f"\n<a href='{url}' target='_blank'>Full screen view</a>"
-
-    return pn.pane.HTML(html, sizing_mode="stretch_both")

--- a/src/tiledb/cloud/notebook.py
+++ b/src/tiledb/cloud/notebook.py
@@ -394,7 +394,7 @@ def panel_dashboard(
 
     # Get a random open port.
     with socket.socket() as sock:
-        sock.bind(("", 0))
+        sock.bind(("localhost", 0))
         port = sock.getsockname()[1]
 
     # Reduce noise from the panel server

--- a/src/tiledb/cloud/notebook.py
+++ b/src/tiledb/cloud/notebook.py
@@ -373,16 +373,18 @@ def panel_dashboard(
     app: Any,
     *,
     full_screen_link: bool = True,
+    title="Dashboard - TileDB",
     verbose: bool = False,
     vh_delta: int = 70,
 ) -> Any:
     """
-    Start a panel server with the provided app and return an iframe that enables
+    Start a Panel server with the provided app and return an iframe that enables
     viewing the app in Voila. This wrapper avoids issues with reactive Panel apps
     in Voila.
 
     :param app: The Panel app to serve.
     :param full_screen_link: Include a link to the full screen view, defaults to True.
+    :param title: Title for the Panel server, defaults to "Dashboard - TileDB".
     :param verbose: Enable verbose logging, defaults to False.
     :param vh_delta: The vertical height delta for the iframe in px. This value is
         subtracted from 100vh to set the height of the iframe.
@@ -407,6 +409,7 @@ def panel_dashboard(
         port=port,
         address="localhost",
         show=False,
+        title=title,
         websocket_origin="*",
         verbose=verbose,
     )


### PR DESCRIPTION
This PR provides a function that enables Panel dashboards in Voila, resolving the issue of Panel widget callbacks not working in Voila.

An [example Panel dashboard](https://cloud.tiledb.com/dashboards/details/TileDB-Inc/6a36996e-47d7-4e2b-bab0-d7d15b1ccc3f/overview) shows the `panel_dashboard` function in action.