### PR TITLE
Skip sub-folders and make pattern matching more useful

### DIFF
--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -178,6 +178,9 @@ def run_ingest_workflow_udf(
             namespace=carry_along.get("namespace", namespace),
         )
 
+        # We've propagated ingest_resources to this function so that
+        # we can use it as the resources argument of this method
+        # call.
         h5ad_ingest = grf.submit(
             _ingest_h5ad_byval,
             output_uri=output_uri,
@@ -186,7 +189,7 @@ def run_ingest_workflow_udf(
             extra_tiledb_config=extra_tiledb_config,
             ingest_mode=ingest_mode,
             platform_config=platform_config,
-            resources=carry_along.get("resources", resources),
+            resources=ingest_resources,  # Apply propagated resources here.
             access_credentials_name=carry_along.get("access_credentials_name", acn),
             logging_level=logging_level,
             dry_run=dry_run,

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -150,7 +150,7 @@ def run_ingest_workflow_udf(
         )
 
         for entry_input_uri in vfs.ls(input_uri):
-            # Subdirectories/subfolders can't be ingested, we skip them.
+            # Subdirectories/subfolders can't be ingested.
             if vfs.is_dir(entry_input_uri):
                 logger.info(
                     "Skipping sub-directory: entry_input_uri=%r", entry_input_uri
@@ -172,6 +172,8 @@ def run_ingest_workflow_udf(
                     entry_input_uri,
                 )
                 continue
+
+            logger.info("Submitting h5ad file: entry_input_uri=%r", entry_input_uri)
 
             node = grf.submit(
                 _ingest_h5ad_byval,

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -103,10 +103,6 @@ def run_ingest_workflow_udf(
     # https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/512
 
     logger = get_logger_wrapper(level=logging_level)
-    logger.debug("ENUMERATOR ENTER")
-    logger.debug("ENUMERATOR INPUT_URI  %s", input_uri)
-    logger.debug("ENUMERATOR OUTPUT_URI %s", output_uri)
-    logger.debug("ENUMERATOR DRY_RUN    %s", str(dry_run))
 
     h5ad_ingest = None
     collector = None
@@ -114,8 +110,6 @@ def run_ingest_workflow_udf(
     vfs = tiledb.VFS(config=extra_tiledb_config)
 
     if vfs.is_file(input_uri):
-        logger.debug("ENUMERATOR VFS.IS_FILE")
-
         name = ("dry-run" if dry_run else "ingest") + "-h5ad-file"
 
         grf = dag.DAG(
@@ -139,8 +133,6 @@ def run_ingest_workflow_udf(
         )
 
     elif vfs.is_dir(input_uri):
-        logger.debug("ENUMERATOR VFS.IS_DIR")
-
         if dry_run:
             name = "dry-run-h5ad-files"
         else:
@@ -165,7 +157,6 @@ def run_ingest_workflow_udf(
                 )
                 continue
 
-            logger.debug("ENUMERATOR ENTRY_INPUT_URI=%r", entry_input_uri)
             base = os.path.basename(entry_input_uri)
             base, _ = os.path.splitext(base)
 
@@ -173,7 +164,6 @@ def run_ingest_workflow_udf(
             if not output_uri.endswith("/"):
                 entry_output_uri += "/"
             entry_output_uri += base
-            logger.debug("ENUMERATOR ENTRY_OUTPUT_URI=%r", entry_output_uri)
 
             if pattern is not None and not re.search(pattern, entry_input_uri):
                 logger.info(
@@ -220,7 +210,6 @@ def run_ingest_workflow_udf(
 
     grf.compute()
 
-    logger.debug("ENUMERATOR EXIT server_graph_uuid = %r", grf.server_graph_uuid)
     return grf.server_graph_uuid
 
 

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -158,6 +158,13 @@ def run_ingest_workflow_udf(
         )
 
         for entry_input_uri in vfs.ls(input_uri):
+            # Subdirectories/subfolders can't be ingested, we skip them.
+            if vfs.is_dir(entry_input_uri):
+                logger.info(
+                    "Skipping sub-directory: entry_input_uri=%r", entry_input_uri
+                )
+                continue
+
             logger.debug("ENUMERATOR ENTRY_INPUT_URI=%r", entry_input_uri)
             base = os.path.basename(entry_input_uri)
             base, _ = os.path.splitext(base)
@@ -168,8 +175,12 @@ def run_ingest_workflow_udf(
             entry_output_uri += base
             logger.debug("ENUMERATOR ENTRY_OUTPUT_URI=%r", entry_output_uri)
 
-            if pattern is not None and not re.match(pattern, entry_input_uri):
-                logger.debug("ENUMERATOR SKIP NO MATCH ON <<%r>>", pattern)
+            if pattern is not None and not re.search(pattern, entry_input_uri):
+                logger.info(
+                    "Skipping non-matching input: pattern=%r, entry_input_uri=%r",
+                    pattern,
+                    entry_input_uri,
+                )
                 continue
 
             node = grf.submit(


### PR DESCRIPTION
These changes help unlock 1-click ingestion of folders of SOMA sources.

Unneeded log messages have been removed.