### PR TITLE
return all columns by default in SOMA Collection mapper

### DIFF
--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -361,6 +361,10 @@ def experiment_to_anndata_slice(
     if var_attrs is not None:
         column_names["var"] = var_attrs
 
+    if not column_names:
+        # return all columns by default
+        column_names = tiledbsoma.AxisColumnNames()
+
     adata = query.to_anndata(X_name=X_layer_name, column_names=column_names)
 
     return adata


### PR DESCRIPTION
See Zendesk ticket 417

I believe the intended behavior is to return all columns when None is passed, but this is currently not happening.
This is just one way one could force the correct behavior