### PR TITLE
Register ingested groups using the correct URI

### DIFF
--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 import pathlib
 import re
 import warnings
@@ -138,7 +139,8 @@ def run_ingest_workflow_udf(
     )
 
     for input_file in input_files:
-        output_group_uri = pathlib.Path(output_uri.joinpath(input_file.stem))
+        stem = pathlib.Path(input_file).stem
+        output_group_uri = os.path.join(output_uri, stem)
         logger.info(
             "Building task for h5ad file: input_file=%r, output_group_uri=%r",
             input_file,
@@ -171,7 +173,7 @@ def run_ingest_workflow_udf(
             )
             register_soma.depends_on(collector)
 
-    logger.info("Computing DAG: grf=%r, grf")
+    logger.info("Computing DAG: grf=%r", grf)
     grf.compute()
     return grf.server_graph_uuid
 

--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -123,7 +123,7 @@ def run_ingest_workflow_udf(
                 input_files.append(input_item)
 
     elif vfs.is_file(input_uri):
-        input_files.append(input_item)
+        input_files.append(input_uri)
     else:
         raise ValueError("input_uri %r is neither a file nor a directory", input_uri)
 


### PR DESCRIPTION
In the directory ingestion case, the deployed code creates groups at `OUTPUT_URI/NAME/NAME/` (note the doubled `NAME`) where `NAME` is the basename/stem of an H5ad file. But then it tries to register a group at `OUTPUT_URI`. There's no group there, so this fails.

As a part of solving this problem, I'm generalizing directory ingest to cover the single file case. We no longer have two ingestion branches. There's much less code and I think the intent of the remaining code is more clear. This change helped me fix the bug and helps us make sure it stays fixed.

There's an output change, though: every H5ad file becomes a group at `OUTPUT_URI/NAME/` where `NAME` is the basename/stem of the H5ad file no matter what. Ingested as a single file, or as an item in a folder, the same output. In theory (and practice, often) this kind of symmetry and de-specialization is a win. I'm going to need some review from actual SOMA users and developers, for sure.

The test failures are unrelated. Trouble with task graph run times again.