### PR TITLE
typ{o,e} fixes

### DIFF
--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1655,7 +1655,7 @@ class DAG:
                 if name not in _SKIP_BATCH_UDF_KWARGS
             }
 
-            all_args = types.Arguments(node_args, filtered_node_kwargs)
+            all_args = types.Arguments(tuple(node_args), filtered_node_kwargs)
             encoder = _BatchArgEncoder(input_is_expanded=bool(node._expand_node_output))
             kwargs["arguments"] = encoder.encode_arguments(all_args)
 

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -46,7 +46,7 @@ from . import status as st
 from . import visualization as viz
 from .mode import Mode
 
-Status = st.Status  # Re-export for compabitility.
+Status = st.Status  # Re-export for compatibility.
 _T = TypeVar("_T")
 # Special string included in server errors when there is a problem loading
 # stored parameters.
@@ -981,8 +981,8 @@ class DAG:
         """Submit a function that will be executed in the cloud serverlessly.
 
         :param func: Function to execute in UDF task.
-        :param *args: Postional arguments to pass into Node instantation.
-        :param **kwargs: Keyword args to pass into Node instantiation.
+        :param args: Positional arguments to pass into Node instantiation.
+        :param kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created.
         """
 
@@ -998,8 +998,8 @@ class DAG:
         """Submit a function that will run locally.
 
         :param func: Function to execute in UDF task.
-        :param *args: Postional arguments to pass into Node instantation.
-        :param **kwargs: Keyword args to pass into Node instantiation.
+        :param args: Positional arguments to pass into Node instantiation.
+        :param kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created
         """
 
@@ -1010,8 +1010,8 @@ class DAG:
         """Submit a function that will be executed in the cloud serverlessly.
 
         :param func: Function to execute in UDF task.
-        :param *args: Postional arguments to pass into Node instantation.
-        :param **kwargs: Keyword args to pass into Node instantiation.
+        :param args: Positional arguments to pass into Node instantiation.
+        :param kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created.
         """
 
@@ -1062,10 +1062,10 @@ class DAG:
         ```
 
         :param func: Function to execute in UDF task.
-        :param *args: Postional arguments to pass into Node instantation.
+        :param args: Positional arguments to pass into Node instantiation.
         :param expand_node_output: Node that we want to expand the output of.
             The output of the node should be a JSON encoded list.
-        :param **kwargs: Keyword args to pass into Node instantiation.
+        :param kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created.
         """
 
@@ -1083,17 +1083,18 @@ class DAG:
             **kwargs,
         )
 
-    def submit_sql(self, *args: Any, **kwargs: Any) -> Node:
+    def submit_sql(self, sql: str, *args: Any, **kwargs: Any) -> Node:
         """Submit a sql query to run serverlessly in the cloud.
 
         :param sql: Query to execute.
-        :param *args: Postional arguments to pass into Node instantation.
-        :param **kwargs: Keyword args to pass into Node instantiation.
+        :param args: Positional arguments to pass into Node instantiation.
+        :param kwargs: Keyword args to pass into Node instantiation.
         :return: Node that is created
         """
 
         return self._add_prewrapped_node(
             _sql_exec.exec_base,
+            sql,
             *args,
             _internal_accepts_stored_params=False,
             _fallback_name="SQL query",
@@ -2001,7 +2002,7 @@ class _StoredParamReplacer(visitor.ReplacingVisitor):
 def _topo_sort(
     lst: Sequence[rest_api.TaskGraphNodeMetadata],
 ) -> Sequence[rest_api.TaskGraphNodeMetadata]:
-    """Topologically sorts the list of node metadatas."""
+    """Topologically sorts the list of node metadata."""
     by_uuid: Dict[str, rest_api.TaskGraphNodeMetadata] = {
         node.client_node_uuid: node for node in lst
     }

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -191,14 +191,14 @@ class DAGClassTest(unittest.TestCase):
 
     def test_resource_checks(self):
         grf = dag.DAG()
-        with self.assertRaises(tce.TileDBCloudError):
+        with self.assertRaises(ValueError):
             grf.submit(repr, None, resources={"x": "y"})
-        with self.assertRaises(tce.TileDBCloudError):
+        with self.assertRaises(ValueError):
             grf.submit_local(repr, None, resources={"x": "y"})
-        with self.assertRaises(tce.TileDBCloudError):
+        with self.assertRaises(ValueError):
             grf.submit_local(repr, None, resource_class="hello")
         grf = dag.DAG(mode=Mode.BATCH)
-        with self.assertRaises(tce.TileDBCloudError):
+        with self.assertRaises(ValueError):
             grf.submit(repr, None, resources={"memory": "100"})
 
     def test_kwargs(self):
@@ -522,7 +522,7 @@ class DAGFailureTest(unittest.TestCase):
         d1 = dag.DAG()
         n1 = d1.submit(repr, "whatever")
         d2 = dag.DAG()
-        with self.assertRaises(tce.TileDBCloudError):
+        with self.assertRaises(ValueError):
             d2.submit(repr, n1)
 
     def test_retry(self):


### PR DESCRIPTION
- First arg to `TileDBCloudError` is supposed to be `http_status: Optional[int]`, but these callsites were passing a `str.
  - I guessed that those should be `body` (and `body` should be allowed to be `str | bytes`, not just `bytes`)
- Couple docstr/comment typos