### PR TITLE
Patch config._config, not config.config

### DIFF
--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -672,13 +672,15 @@ class Client:
     @property
     def _client_v1(self):
         if not self.__client_v1:
-            self.retry_mode(self._mode)
+            self._retry_mode(self._mode)
+            self._rebuild_clients()
         return self.__client_v1
 
     @property
     def _client_v2(self):
         if not self.__client_v2:
-            self.retry_mode(self._mode)
+            self._retry_mode(self._mode)
+            self._rebuild_clients()
         return self.__client_v2
 
     def build(self, builder: Callable[[rest_api.ApiClient], _T]) -> _T:

--- a/src/tiledb/cloud/config.py
+++ b/src/tiledb/cloud/config.py
@@ -10,9 +10,14 @@ from tiledb.cloud.rest_api import configuration
 from tiledb.cloud.rest_api import models
 
 default_host = "https://api.tiledb.com"
-
-_config = configuration.Configuration()
 default_config_file = Path.joinpath(Path.home(), ".tiledb", "cloud.json")
+
+# Starting with version 0.12.30, "config" is a dynamic attribute of
+# this module. The actual state of the attribute is bound to "_config",
+# which begins uninitialized. Looking up "config" from
+# tiledb.cloud.config causes our stored configuration to be loaded
+# just as needed.
+_config = configuration.Configuration()
 
 
 def __getattr__(name):

--- a/src/tiledb/cloud/config.py
+++ b/src/tiledb/cloud/config.py
@@ -30,16 +30,6 @@ def __getattr__(name):
         raise AttributeError
 
 
-def __getattr__(name):
-    global logged_in
-    if name == "config":
-        if not logged_in:
-            logged_in = load_configuration(default_config_file)
-        return _config
-    else:
-        raise AttributeError
-
-
 def parse_bool(s: str) -> bool:
     return s.lower() in ["true", "1", "on"]
 

--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud import dag
 from tiledb.cloud.taskgraphs.server_executor import impl
@@ -19,6 +21,7 @@ class ConnectToExistingTest(unittest.TestCase):
         self.assertEqual(connected.node("one").result(1), 1)
         self.assertEqual(connected.node("two").result(1), 2)
 
+    @pytest.mark.xfail(reason="Server side error, graph not computed in expected time.")
     def test_running_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)
         one = to_run.submit(lambda: 1, name="one")
@@ -41,6 +44,7 @@ class ConnectToExistingTest(unittest.TestCase):
         self.assertIs(connected.node("two").status, tg.Status.SUCCEEDED)
         self.assertIs(connected.status, tg.Status.SUCCEEDED)
 
+    @pytest.mark.xfail(reason="Server side error, graph not computed in expected time.")
     def test_failing_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)
         to_run.submit(lambda: 1 / 0, name="oops")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ def test_login_bare_host(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         tiledb.cloud.client.config,
-        "config",
+        "_config",
         tiledb.cloud.config.configuration.Configuration(),
     )
     monkeypatch.setattr(tiledb.cloud.client.config, "logged_in", False)


### PR DESCRIPTION
Fixes failing config test, adds more notes to config.py. Also xfails two task graph tests that have consistently failed this week.

@ihnorton this is the finishing touch on #681.