### PR TITLE
Register DAG

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -45,7 +45,7 @@ jobs:
         os:
           - ubuntu-20.04
           # - macos-12
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.12"]
         dependencies:
           - pinned
           - fresh
@@ -107,7 +107,7 @@ jobs:
       - name: Install pinned dependencies
         if: ${{ matrix.dependencies == 'pinned' }}
         run: |
-          pip install -r ci/requirements-py${{ matrix.python-version }}.txt
+          pip install -r ci/requirements.txt
 
       - name: Install TileDB-Cloud-Py
         run: |
@@ -160,6 +160,7 @@ jobs:
             --splitting-algorithm least_duration \
             --clean-durations \
             -r fExX \
+            ${{ matrix.python-version == '3.12' && '-m "not udf"' || '' }} \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -46,6 +46,7 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
+        tiledb-version-spec: ["tiledb==0.30", "tiledb>=0.33.3.rc0"]
         dependencies:
           - pinned
           - fresh
@@ -108,6 +109,7 @@ jobs:
         if: ${{ matrix.dependencies == 'pinned' }}
         run: |
           pip install -r ci/requirements.txt
+          pip install ${{ matrix.tiledb-version-spec}}
 
       - name: Install TileDB-Cloud-Py
         run: |

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           # - macos-12
         python-version: ["3.9", "3.12"]
         is-pr:
@@ -59,7 +59,7 @@ jobs:
           - pinned
           - fresh
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             path: ~/.cache/pip
           # - os: macos-12
           # path: ~/Library/Caches/pip
@@ -195,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         # Ensure that we save the partial test durations from an ubuntu job that the tests actually run.
-        if: matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.9' && (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.9' && (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
           path: .test_durations
@@ -206,7 +206,7 @@ jobs:
   # into a single file and save it to cache for future use.
   save-test-durations-to-cache:
     name: Download, combine and save test_durations to the actions cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: run-tests
     continue-on-error: true
     env:
@@ -241,7 +241,7 @@ jobs:
       (github.event_name == 'release' && github.event.action == 'published' && ${{ startsWith(github.event.release.tag_name, 'v') }}) ||
       (github.event_name == 'push')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -10,7 +10,7 @@ on:
     types: [published]
   schedule:
     # 01:30 UTC = 20:30/21:30 America/New_York = 03:30/04:30 Europe/Athens
-    - cron: "30 1 * * *"
+    - cron: "34 1 * * *"
 
 env:
   PYTEST_SPLIT_GROUPS: 6 # How many parallel groups to create for the tests.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -72,6 +72,8 @@ jobs:
             dependencies: pinned
           - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
             is-pr: true
+          - dependencies: fresh
+            is-pr: true
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:
@@ -159,16 +161,12 @@ jobs:
           fi
 
       - name: Run tests for vendored cloudpickle
-        # Test pinned dependencies on commit / tag and fresh installs on nightlies
-        if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pip install psutil
           pip install src/tiledb/cloud/_vendor/cloudpickle/tests/cloudpickle_testpkg
           pytest -sv src/tiledb/cloud/_vendor/cloudpickle
 
       - name: Run tests
-        # Test pinned dependencies on commit / tag and fresh installs on nightlies
-        if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pytest -sv \
             --tb short \

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -37,6 +37,7 @@ jobs:
         run: pre-commit run -a -v
 
   run-tests:
+    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.dependencies }}:${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'release' }}
     strategy:
@@ -46,7 +47,14 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
-        tiledb-version-spec: ["tiledb==0.30", "tiledb>=0.33.3.rc0"]
+        is-pr:
+          - ${{ github.event_name == 'pull_request' }}
+        tiledb-version-spec:
+          [
+            "tiledb==0.30",
+            "tiledb",
+            "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main",
+          ]
         dependencies:
           - pinned
           - fresh
@@ -55,6 +63,15 @@ jobs:
             path: ~/.cache/pip
           # - os: macos-12
           # path: ~/Library/Caches/pip
+        exclude:
+          - tiledb-version-spec: "tiledb==0.30"
+            dependencies: fresh
+          - tiledb-version-spec: "tiledb==0.30"
+            is-pr: true
+          - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
+            dependencies: pinned
+          - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
+            is-pr: true
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:
@@ -109,10 +126,10 @@ jobs:
         if: ${{ matrix.dependencies == 'pinned' }}
         run: |
           pip install -r ci/requirements.txt
-          pip install ${{ matrix.tiledb-version-spec}}
 
       - name: Install TileDB-Cloud-Py
         run: |
+          pip install ${{ matrix.tiledb-version-spec}}
           pip install .[tests]
           pip install tiledb-vector-search --no-deps
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -10,7 +10,6 @@ python-dateutil==2.8.2
 pytz==2024.1
 six==1.16.0
 tblib==1.7.0
-tiledb==0.32.5
 typing_extensions==4.9.0
 tzdata==2023.4
 urllib3==2.2.0

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.8.2
 pytz==2024.1
 six==1.16.0
 tblib==1.7.0
-tiledb==0.25.0
+tiledb==0.32.5
 typing_extensions==4.9.0
 tzdata==2023.4
 urllib3==2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,12 @@ life-sciences = ["tiledbsoma"]
 docs = ["quartodoc"]
 dev = ["black", "pytest", "ruff"]
 tests = [
-    "xarray",
+    "cloudpickle",
     "pytest-cov",
     "pytest-explicit",
     "pytest-split",
     "tiledbsoma",
+    "xarray",
 ]
 
 [project.urls]
@@ -50,6 +51,7 @@ explicit-only = ["bigfiles", "geospatial", "vcf"]
 markers = [
     "bigfiles: tests that create and upload really big files",
     "geospatial: tests that require the geospatial libraries",
+    "udf: tests that require a server UDF container",
     "vcf: VCF tests that run on TileDB Cloud",
 ]
 norecursedirs = ["tiledb/cloud"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
     "tblib~=1.7",
-    "tiledb>=0.15.2",
+    "tiledb~=0.30,!=0.33.1,!=0.33.2",
     "typing-extensions",
     "urllib3>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "six>=1.10",
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
-    "tblib~=1.7",
+    "tblib>=1.7",
     "tiledb~=0.30,!=0.33.1,!=0.33.2",
     "typing-extensions",
     "urllib3>=1.26",

--- a/src/tiledb/cloud/array.py
+++ b/src/tiledb/cloud/array.py
@@ -1,3 +1,7 @@
+"""Register, search, and manage arrays with TileDB."""
+
+import posixpath
+import urllib.parse
 import uuid
 import warnings
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
@@ -237,12 +241,16 @@ def register_array(
 ):
     """
     Register this array with the tiledb cloud service
-    :param str namespace: The user or organization to register the array under.
-        If unset will default to the user
-    :param str array_name: name of array
+
+    :param str uri: storage URI of array.
+    :param str namespace: The user or organization to register the array
+        under. If unset will default to the user
+    :param str array_name: name of array, optional. Defaults to stem of
+        the storage URI.
     :param str description: optional description
-    :param str access_credentials_name: optional name of access credentials to use,
-        if left blank default for namespace will be used
+    :param str access_credentials_name: optional name of access
+        credentials to use. If left blank default for namespace will be
+        used.
     :param async_req: return future instead of results for async support
     :param dest_uri: If set, the ``tiledb://`` URI of the destination.
     """
@@ -253,6 +261,11 @@ def register_array(
     )
 
     namespace = namespace or client.default_user().username
+
+    if not array_name:
+        # Extract the basename from the storage URI and use it for the name.
+        parsed_uri = urllib.parse.urlparse(uri)
+        array_name = posixpath.basename(parsed_uri.path)
 
     try:
         return api_instance.register_array(

--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -209,8 +209,10 @@ def info(uri: str) -> Union[models.ArrayInfo, models.GroupInfo]:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
-    info_map: Mapping[str, Callable] = {"array": array.info, "group": groups.info}
     asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    if not asset_type:
+        raise ValueError("Given URI resolves to no asset and is invalid.")
+    info_map: Mapping[str, Callable] = {"array": array.info, "group": groups.info}
     func = info_map[asset_type]
     return func(uri)
 

--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -247,7 +247,7 @@ def ingest(
                 verbose=verbose,
                 tile_scale=tile_scale,
                 source_config=config,
-                dest_config=kwargs.get("dest_config", None),
+                dest_config=kwargs.pop("dest_config", None),
                 experimental_reader=experimental_reader,
                 **kwargs,
             )

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -43,6 +43,7 @@ from .._results import types
 from ..rest_api import models
 from ..sql import _execution as _sql_exec
 from ..taskgraphs import _results as _tg_results
+from ..taskgraphs import registration
 from . import status as st
 from . import visualization as viz
 from .mode import Mode
@@ -1881,6 +1882,28 @@ class DAG:
             "name": override_name or self.name,
             "nodes": node_jsons,
         }
+
+    def register(
+        self,
+        namespace: Optional[str] = None,
+        override_name: Optional[str] = None,
+    ) -> None:
+        """Register DAG to TileDB.
+
+        :param namespace: Namespace to register. If not set, uses default.
+        :param override_name: Name to register DAG as. Uses self.name as default.
+        """
+
+        if not self.name and not override_name:
+            raise ValueError(
+                "Must specify registration name to DAG.name or override_name."
+            )
+
+        registration.register(
+            graph=self,
+            name=override_name or self.name,
+            namespace=namespace,
+        )
 
 
 def list_logs(

--- a/src/tiledb/cloud/dag/dag.py
+++ b/src/tiledb/cloud/dag/dag.py
@@ -1887,11 +1887,12 @@ class DAG:
         self,
         namespace: Optional[str] = None,
         override_name: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Register DAG to TileDB.
 
         :param namespace: Namespace to register. If not set, uses default.
         :param override_name: Name to register DAG as. Uses self.name as default.
+        :return: Registered name of task graph.
         """
 
         if not self.name and not override_name:
@@ -1904,6 +1905,8 @@ class DAG:
             name=override_name or self.name,
             namespace=namespace,
         )
+
+        return override_name or self.name
 
 
 def list_logs(

--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -104,6 +104,59 @@ def info(uri: str) -> object:
     return groups_client.get_group(group_namespace=namespace, group_name=group_name)
 
 
+def contents(
+    uri: str,
+    async_req: bool = None,
+    page: int = None,
+    per_page: int = None,
+    namespace: str = None,
+    search: str = None,
+    orderby: str = None,
+    tag: list[str] = None,
+    exclude_tag: list[str] = None,
+    member_type: list[str] = None,
+    exclude_member_type: list[str] = None,
+) -> rest_api.GroupContents:
+    """Get a group's contents.
+
+    :param async_req bool: execute request asynchronously
+    :param int page: pagination offset for assets
+    :param int per_page: pagination limit for assets
+    :param str namespace: namespace to search for
+    :param str search: search string that will look at name, namespace
+        or description fields
+    :param str orderby: sort by which field valid values include
+        last_accessed, size, name
+    :param list[str] tag: tag to search for, more than one can be
+        included
+    :param list[str] exclude_tag: tags to exclude matching array in
+        results, more than one can be included
+    :param list[str] member_type: member type to search for, more than
+        one can be included
+    :param list[str] exclude_member_type: member type to exclude
+        matching groups in results, more than one can be included
+    :return: GroupContents
+        If the method is called asynchronously, returns the request
+        thread.
+    """
+    namespace, group_name = utils.split_uri(uri)
+    groups_client = client.build(rest_api.GroupsApi)
+    return groups_client.get_group_contents(
+        group_namespace=namespace,
+        group_name=group_name,
+        async_req=async_req,
+        page=page,
+        per_page=per_page,
+        namespace=namespace,
+        search=search,
+        orderby=orderby,
+        tag=tag,
+        exclude_tag=exclude_tag,
+        member_type=member_type,
+        exclude_member_type=exclude_member_type,
+    )
+
+
 def update_info(
     uri: str,
     *,

--- a/src/tiledb/cloud/groups.py
+++ b/src/tiledb/cloud/groups.py
@@ -80,6 +80,7 @@ def register(
         # Extract the basename from the storage URI and use it for the name.
         parsed_uri = urllib.parse.urlparse(storage_uri)
         name = posixpath.basename(parsed_uri.path)
+
     groups_client = client.build(api_v2.GroupsApi)
     groups_client.register_group(
         group_namespace=namespace,

--- a/src/tiledb/cloud/sql/_execution.py
+++ b/src/tiledb/cloud/sql/_execution.py
@@ -112,7 +112,7 @@ def exec_base(
             array_api = client.build(rest_api.ArrayApi)
             array_api.update_array_metadata(
                 namespace=namespace,
-                output_uri=output_uri,
+                array=output_uri,
                 array_metadata=rest_api.models.ArrayInfoUpdate(name=output_array_name),
             )
 

--- a/tests/common/test_pickle_compat.py
+++ b/tests/common/test_pickle_compat.py
@@ -58,6 +58,10 @@ def test_pandas_compat(pd_ver: str, name_want: Tuple[str, Callable[[], Any]]) ->
     assert want.equals(got)
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12, 0),
+    reason="serialization is now controlled by vendored cloudpickle frozen at 2.1.0.",
+)
 # These are the versions of cloudpickle that introduce serialization changes.
 @pytest.mark.parametrize("cp_ver", ["1.4.1", "1.5.0", "2.1.0"])
 def test_cloudpickle_compat(cp_ver: str) -> None:

--- a/tests/taskgraphs/delayed/test_delayed_funcs.py
+++ b/tests/taskgraphs/delayed/test_delayed_funcs.py
@@ -1,3 +1,10 @@
+"""Tests of tiledb.cloud.taskgraphs.delayed.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import operator
 import os.path
 import tempfile
@@ -5,6 +12,7 @@ import time
 import unittest
 
 import numpy as np
+import pytest
 
 from tiledb.cloud import client
 from tiledb.cloud import taskgraphs
@@ -13,6 +21,8 @@ from tiledb.cloud._common import testonly
 from tiledb.cloud.taskgraphs import delayed
 from tiledb.cloud.taskgraphs import executor
 from tiledb.cloud.taskgraphs import registration
+
+pytestmark = pytest.mark.udf
 
 
 class FunctionsTest(unittest.TestCase):

--- a/tests/taskgraphs/test_client_executor.py
+++ b/tests/taskgraphs/test_client_executor.py
@@ -1,3 +1,10 @@
+"""Tests of tiledb.cloud.taskgraphs.executor.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import datetime
 import operator
 import tempfile
@@ -6,12 +13,15 @@ import unittest
 
 import numpy
 import pyarrow
+import pytest
 
 from tiledb.cloud._common import futures
 from tiledb.cloud.taskgraphs import builder
 from tiledb.cloud.taskgraphs import client_executor
 from tiledb.cloud.taskgraphs import executor
 from tiledb.cloud.taskgraphs import types
+
+pytestmark = pytest.mark.udf
 
 
 class ClientExecutorTestUDFs(unittest.TestCase):

--- a/tests/taskgraphs/test_codec.py
+++ b/tests/taskgraphs/test_codec.py
@@ -249,9 +249,8 @@ class PandasArrowTest(unittest.TestCase):
 
         # We don't test the exact contents of the base64 data,
         # because it varies based upon Python/Pandas version.
-        self.assertDictContainsSubset(
-            {"__tdbudf__": "immediate", "format": "python_pickle"},
-            encoded,
+        self.assertEqual(
+            encoded, encoded | {"__tdbudf__": "immediate", "format": "python_pickle"}
         )
         # Instead we just make sure the roundtrip works.
         round_trip = tiledb_json.Decoder().visit(encoded)

--- a/tests/taskgraphs/test_retries.py
+++ b/tests/taskgraphs/test_retries.py
@@ -1,11 +1,22 @@
+"""Tests of tiledb.cloud.taskgraphs.client_executor.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import operator
 import unittest
 from concurrent import futures
+
+import pytest
 
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud import client
 from tiledb.cloud._common import testonly
 from tiledb.cloud.taskgraphs import client_executor
+
+pytestmark = pytest.mark.udf
 
 
 class RetryTest(unittest.TestCase):

--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -19,6 +19,7 @@ _WAIT_TIME_S = 120
 
 
 class ConnectToExistingTest(unittest.TestCase):
+    @pytest.mark.xfail(reason="Time to complete is not predictable.")
     def test_completed_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)
         one = to_run.submit(lambda: 1, name="one")

--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -1,3 +1,10 @@
+"""Tests of tiledb.cloud.taskgraphs.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import unittest
 
 import pytest
@@ -5,6 +12,8 @@ import pytest
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud import dag
 from tiledb.cloud.taskgraphs.server_executor import impl
+
+pytestmark = pytest.mark.udf
 
 _WAIT_TIME_S = 120
 

--- a/tests/taskgraphs/test_taskgraphs.py
+++ b/tests/taskgraphs/test_taskgraphs.py
@@ -1,10 +1,19 @@
-"""Test for the unified ``tiledb.cloud.taskgraphs`` namespace."""
+"""Tests of tiledb.cloud.taskgraphs.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
 
 import datetime
 import unittest
 
+import pytest
+
 import tiledb.cloud.taskgraphs as tg
 from tiledb.cloud._common import testonly
+
+pytestmark = pytest.mark.udf
 
 
 class TaskGraphsTest(unittest.TestCase):

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -221,7 +221,9 @@ class ListingTest(unittest.TestCase):
     @pytest.mark.udf
     def test_list(self) -> None:
         # Ensure that we have at least one asset registered (a UDF)
-        with testonly.register_udf(lambda: 1, func_name="some_lambda"):
+        with testonly.register_udf(
+            lambda: 1, func_name=testonly.random_name("some_lambda")
+        ):
             result = asset.list(page=1, per_page=2)
         self.assertGreater(result.pagination_metadata.total_items, 0)
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -218,6 +218,7 @@ def test_asset_deregister_group_recursive_dispatch(deregister_group, object_type
 
 
 class ListingTest(unittest.TestCase):
+    @pytest.mark.udf
     def test_list(self) -> None:
         # Ensure that we have at least one asset registered (a UDF)
         with testonly.register_udf(lambda: 1, func_name="some_lambda"):

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -298,3 +298,9 @@ class RegistrationTest(unittest.TestCase):
                 time.sleep(2)
         self.assert_group_not_exists(outer_name)
         self.assert_group_not_exists(inner_name)
+
+
+def test_failure_bogus_uri():
+    """Raise ValueError."""
+    with pytest.raises(ValueError):
+        asset.info("bogus")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,6 +64,7 @@ class BasicTests(unittest.TestCase):
     def test_list_public_arrays(self):
         self.assertTrue(len(client.list_public_arrays().arrays) > 0)
 
+    @pytest.mark.udf
     def test_quickstart(self):
         with tiledb.open(
             "tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.Ctx()
@@ -111,6 +112,7 @@ class BasicTests(unittest.TestCase):
                 numpy.sum(orig["a"]),
             )
 
+    @pytest.mark.udf
     def test_quickstart_arbitrary_parameters(self):
         with tiledb.open(
             "tiledb://TileDB-Inc/quickstart_sparse", ctx=tiledb.cloud.Ctx()
@@ -126,6 +128,7 @@ class BasicTests(unittest.TestCase):
                 "hello world",
             )
 
+    @pytest.mark.udf
     def test_quickstart_async(self):
         with tiledb.open(
             "tiledb://TileDB-Inc/quickstart_dense", ctx=tiledb.cloud.Ctx()
@@ -294,6 +297,7 @@ class BasicTests(unittest.TestCase):
             ) as A:
                 A.apply_async(test, [(1, 4), (1, 4)], timeout=1).get()
 
+    @pytest.mark.udf
     def test_empty_arrow(self):
         def test():
             import pyarrow

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -10,6 +10,8 @@ import unittest
 import uuid
 from concurrent import futures
 from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -26,6 +28,7 @@ from tiledb.cloud._results import decoders
 from tiledb.cloud._results import results
 from tiledb.cloud._results import stored_params as sp
 from tiledb.cloud._vendor import cloudpickle as tdbcp
+from tiledb.cloud.client import default_user
 from tiledb.cloud.dag import Mode
 from tiledb.cloud.dag import dag as dag_dag
 from tiledb.cloud.rest_api import models
@@ -1348,6 +1351,33 @@ def _uid(num: int) -> uuid.UUID:
 
 def _b64(x: bytes) -> str:
     return str(base64.b64encode(x), encoding="ascii")
+
+
+@pytest.fixture
+def dag_fixture():
+    """DAG fixture for pytests."""
+
+    graph = dag.DAG(name="dag-test-fixture", namespace=default_user().username)
+
+    yield graph
+
+
+@patch("tiledb.cloud.dag.dag.registration.register")
+def test_dag_register(mock_register: MagicMock, dag_fixture: dag.DAG) -> None:
+    """Test DAG.register"""
+
+    # verify DAG.name used to register
+    registered_name1 = dag_fixture.register()
+    assert registered_name1 == dag_fixture.name
+
+    # verify override name
+    registered_name2 = dag_fixture.register(override_name="override-name")
+    assert registered_name2 == "override-name"
+
+    # verify catch if no name set to DAG.name or override_name
+    dag_fixture.name = None
+    with pytest.raises(ValueError):
+        dag_fixture.register()
 
 
 # This is the base64 of the Arrow data returned by this query:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,3 +1,10 @@
+"""Tests of tiledb.cloud.dag.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import base64
 import collections
 import collections.abc as cabc
@@ -32,6 +39,8 @@ from tiledb.cloud.client import default_user
 from tiledb.cloud.dag import Mode
 from tiledb.cloud.dag import dag as dag_dag
 from tiledb.cloud.rest_api import models
+
+pytestmark = pytest.mark.udf
 
 
 class DAGClassTest(unittest.TestCase):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1372,7 +1372,10 @@ def _b64(x: bytes) -> str:
 def dag_fixture():
     """DAG fixture for pytests."""
 
-    graph = dag.DAG(name="dag-test-fixture", namespace=default_user().username)
+    graph = dag.DAG(
+        name=f"dag-test-fixture-{uuid.uuid4()}",
+        namespace=default_user().username,
+    )
 
     yield graph
 
@@ -1391,8 +1394,9 @@ def test_dag_register(
     assert registered_name1 == f"{dag_fixture.namespace}/{dag_fixture.name}"
 
     # verify override name
-    registered_name2 = dag_fixture.register(name="override-name")
-    assert registered_name2 == f"{dag_fixture.namespace}/override-name"
+    override_name = f"override-name-{uuid.uuid4()}"
+    registered_name2 = dag_fixture.register(name=override_name)
+    assert registered_name2 == f"{dag_fixture.namespace}/{override_name}"
 
     # verify catch if no name set to DAG.name or override_name
     dag_fixture.name = None

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1362,8 +1362,6 @@ def dag_fixture():
     yield graph
 
 
-# @patch("tiledb.cloud.dag.dag.registration.register")
-# @patch("tiledb.cloud.dag.dag.DAG.register")
 @patch("tiledb.cloud.dag.dag.tiledb.open")
 @patch("tiledb.cloud.dag.dag.rest_api.RegisteredTaskGraphsApi")
 def test_dag_register(

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -921,6 +921,9 @@ class DAGCloudApplyTest(unittest.TestCase):
 
         self.assertEqual(node.result()["a"][0], numpy.sum(orig["a"]))
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_dag_apply_exec_multiple(self):
         uri_sparse = "tiledb://TileDB-Inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-Inc/quickstart_dense"
@@ -978,6 +981,9 @@ class DAGCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(d.status, dag.Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_dag_apply_exec_multiple_2(self):
         uri_sparse = "tiledb://TileDB-Inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-Inc/quickstart_dense"

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1362,17 +1362,24 @@ def dag_fixture():
     yield graph
 
 
-@patch("tiledb.cloud.dag.dag.registration.register")
-def test_dag_register(mock_register: MagicMock, dag_fixture: dag.DAG) -> None:
+# @patch("tiledb.cloud.dag.dag.registration.register")
+# @patch("tiledb.cloud.dag.dag.DAG.register")
+@patch("tiledb.cloud.dag.dag.tiledb.open")
+@patch("tiledb.cloud.dag.dag.rest_api.RegisteredTaskGraphsApi")
+def test_dag_register(
+    mock_register: MagicMock,
+    mock_open: MagicMock,
+    dag_fixture: dag.DAG,
+) -> None:
     """Test DAG.register"""
 
     # verify DAG.name used to register
     registered_name1 = dag_fixture.register()
-    assert registered_name1 == dag_fixture.name
+    assert registered_name1 == f"{dag_fixture.namespace}/{dag_fixture.name}"
 
     # verify override name
-    registered_name2 = dag_fixture.register(override_name="override-name")
-    assert registered_name2 == "override-name"
+    registered_name2 = dag_fixture.register(name="override-name")
+    assert registered_name2 == f"{dag_fixture.namespace}/override-name"
 
     # verify catch if no name set to DAG.name or override_name
     dag_fixture.name = None

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -312,6 +312,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
             node.result(), numpy.sum(orig_sparse["a"]) + numpy.sum(orig_dense["a"])
         )
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_array_apply_by_name(self):
         uri = "tiledb://TileDB-inc/quickstart_sparse"
         with tiledb.open(uri, ctx=tiledb.cloud.Ctx()) as A:
@@ -359,6 +362,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
         self.assertEqual(node.result()["a"][0], numpy.sum(orig["a"]))
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_apply_exec_multiple(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"
@@ -403,6 +409,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(node_exec.dag.status, Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_apply_exec_multiple_2(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"
@@ -457,6 +466,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(node_exec.status, Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_name_to_task_name(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -1,9 +1,17 @@
+"""Tests of tiledb.cloud.compute.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import operator
 import threading
 import unittest
 from concurrent import futures
 
 import numpy as np
+import pytest
 
 import tiledb.cloud
 from tiledb.cloud._common import testonly
@@ -14,6 +22,8 @@ from tiledb.cloud.compute import Status
 from tiledb.cloud.compute.delayed import DelayedMultiArrayUDF
 from tiledb.cloud.dag import Mode
 from tiledb.cloud.dag import dag
+
+pytestmark = pytest.mark.udf
 
 
 class DelayedClassTest(unittest.TestCase):

--- a/tests/test_generic_udf.py
+++ b/tests/test_generic_udf.py
@@ -1,7 +1,15 @@
+"""Tests of tiledb.cloud.udf.
+
+Almost all of these tests require remote code execution that is time
+consuming and restricted to certain versions of Python. To skip, pass
+-m 'not udf' to pytest.
+"""
+
 import datetime
 import unittest
 
 import numpy as np
+import pytest
 import urllib3
 
 import tiledb.cloud
@@ -13,6 +21,8 @@ from tiledb.cloud import udf
 from tiledb.cloud._common import testonly
 from tiledb.cloud._common import utils
 from tiledb.cloud.rest_api import models
+
+pytestmark = pytest.mark.udf
 
 
 class GenericUDFTest(unittest.TestCase):

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -106,3 +106,19 @@ class GroupsTest(unittest.TestCase):
         self.assertEqual(len(sharing), 0)
 
         groups.delete(group_uri)
+
+
+def test_group_contents():
+    """Get a public group's complete contents."""
+    contents = groups.contents(
+        "tiledb://TileDB-Inc/52febfb7-79ec-48cf-9f0c-f35e2adb4a1b"
+    )
+    assert contents.pagination_metadata.total_items == 2
+
+
+def test_group_contents_search():
+    """Search a public group's contents."""
+    contents = groups.contents(
+        "tiledb://TileDB-Inc/52febfb7-79ec-48cf-9f0c-f35e2adb4a1b", search="obs"
+    )
+    assert contents.pagination_metadata.total_items == 1

--- a/tests/test_soma.py
+++ b/tests/test_soma.py
@@ -65,14 +65,17 @@ class TestSOMAMapper(unittest.TestCase):
         super().__init__(foo)
         self.maxDiff = None
 
+    @pytest.mark.udf
     @pytest.mark.skipif(not testonly.is_unittest_user, reason="Requires unittest user.")
     def test_mapper_basic_realtime(self):
         self._test_mapper_basic(False)
 
+    @pytest.mark.udf
     @pytest.mark.skipif(not testonly.is_unittest_user, reason="Requires unittest user.")
     def test_mapper_basic_batch(self):
         self._test_mapper_basic(True)
 
+    @pytest.mark.udf
     def _test_mapper_basic(self, use_batch_mode):
         if sys.version_info < (3, 8, 0):
             # https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/86

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -69,6 +69,7 @@ def array_teardown():
     tiledb.Array.delete_array(_FULL_URI, ctx=ctx)
 
 
+@pytest.mark.skip(reason="Race condition in tests.")
 def test_upload_wheel(array_teardown) -> None:
     # first time uploading array
     upload_wheel(
@@ -174,6 +175,7 @@ def test_pip_install_install(pip_install_pypi):
         assert "django" not in sys.modules
 
 
+@pytest.mark.skip(reason="Race condition in tests.")
 def test_install_wheel(pip_install_tdb):
     # install from tiledb cloud array
     assert "fake_unittest_wheel" not in sys.modules

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -14,7 +14,7 @@ from tiledb.cloud.utilities.wheel import PipInstall
 
 logger = get_logger()
 
-_TAG = str(uuid.uuid4())[-8:]
+_TAG = str(int(uuid.uuid4()))
 _LOCAL_WHEEL_ORIG = "tests/utilities/data/fake_unittest_wheel-0.1.0-py3-none-any.whl"
 # Add random tag to avoid collisions between concurrent tests
 _LOCAL_WHEEL = f"tests/utilities/data/fake_unittest_wheel-0.1.0-{_TAG}-py3-none-any.whl"


### PR DESCRIPTION
Adds functionality to register a `DAG` instance:

```python
from tiledb.cloud.dag import DAG

graph = DAG(name="dag-testing-tg-deps-2", namespace="spencerseale")

stagea = graph.submit(func=lambda x: x)
stageb = graph.submit(func=lambda x: x, args=(stagea,))
stagec = graph.submit(func=lambda x: x, args=(stagea,))
staged = graph.submit(func=lambda x, y: (x, y), args=(stageb, stagec,))

graph.register()

# OR

from tiledb.cloud.taskgraphs.registration import register

register(
    graph=graph,
    namespace="spencerseale"
)
```

The `DAG.register` method is to be prioritized, but also usable with `registration.register` as that's what's used in the `DAG.register` method.

### Open question about type hinting

I need to update type hint in `tiledb.cloud.taskgraphs.registration.register` to `graph: Union[tgbuilder, DAG]`. So I then add the import to that module `from tiledb.cloud.dag.dag import DAG`. But it's interesting, when I go to do that using my editable install and then run:

`python -m src.tiledb.cloud.dag.dag`

 I get: 
```
(tiledb-cloud-py-py39) spencerseale 12:27 PM $ TileDB-Cloud-Py python -m src.tiledb.cloud.dag.dag

Traceback (most recent call last):
  File "/Users/spencerseale/miniconda3/envs/tiledb-cloud-py-py39/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/Users/spencerseale/miniconda3/envs/tiledb-cloud-py-py39/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/Users/spencerseale/tiledb_apis/TileDB-Cloud-Py/src/tiledb/cloud/__init__.py", line 3, in <module>
    from . import array
  File "/Users/spencerseale/tiledb_apis/TileDB-Cloud-Py/src/tiledb/cloud/array.py", line 7, in <module>
    from . import client
  File "/Users/spencerseale/tiledb_apis/TileDB-Cloud-Py/src/tiledb/cloud/client.py", line 13, in <module>
    import tiledb.cloud._common.api_v2.models as models_v2
ImportError: cannot import name 'cloud' from 'tiledb' (/Users/spencerseale/miniconda3/envs/tiledb-cloud-py-py39/lib/python3.9/site-packages/tiledb/__init__.py)
```

I get the same stack trace when I update the module `tiledb.cloud.taskgraphs.registration` to import anything. I think this is the way we have cloud-py wired up and how the Py system path is getting created. Switching to `poetry` or something similar would fix the dev experience a lot so the current dev library is installed into the system path as a Python library to simulate how cloud-py will execute as an installed library.

@sgillies any ideas on this?