### PR TITLE
Exclude tiledb-py versions 0.33.0-0.33.2

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -46,9 +46,13 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
+        tiledb-version-spec: ["tiledb==0.25", "tiledb>=0.33.3.rc0"]
         dependencies:
           - pinned
           - fresh
+        exclude:
+          - python-version: "3.12"
+          - tiledb-version-spec: "tiledb==0.25"
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip
@@ -108,6 +112,7 @@ jobs:
         if: ${{ matrix.dependencies == 'pinned' }}
         run: |
           pip install -r ci/requirements.txt
+          pip install ${{ matrix.tiledb-version-spec}}
 
       - name: Install TileDB-Cloud-Py
         run: |

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -52,7 +52,7 @@ jobs:
           - fresh
         exclude:
           - python-version: "3.12"
-          - tiledb-version-spec: "tiledb==0.25"
+            tiledb-version-spec: "tiledb==0.25"
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -46,13 +46,10 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
-        tiledb-version-spec: ["tiledb==0.25", "tiledb>=0.33.3.rc0"]
+        tiledb-version-spec: ["tiledb==0.30", "tiledb>=0.33.3.rc0"]
         dependencies:
           - pinned
           - fresh
-        exclude:
-          - python-version: "3.12"
-            tiledb-version-spec: "tiledb==0.25"
         include:
           - os: ubuntu-20.04
             path: ~/.cache/pip

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.8.2
 pytz==2024.1
 six==1.16.0
 tblib==1.7.0
-tiledb==0.32.5
+tiledb>=0.33.3.rc0
 typing_extensions==4.9.0
 tzdata==2023.4
 urllib3==2.2.0

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -10,7 +10,6 @@ python-dateutil==2.8.2
 pytz==2024.1
 six==1.16.0
 tblib==1.7.0
-tiledb>=0.33.3.rc0
 typing_extensions==4.9.0
 tzdata==2023.4
 urllib3==2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
     "tblib~=1.7",
-    "tiledb>=0.33.3.rc0",
+    "tiledb~=0.25,!=0.33.0,!=0.33.1,!=0.33.2",
     "typing-extensions",
     "urllib3>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
     "tblib~=1.7",
-    "tiledb~=0.25,!=0.33.0,!=0.33.1,!=0.33.2",
+    "tiledb~=0.30,!=0.33.0,!=0.33.1,!=0.33.2",
     "typing-extensions",
     "urllib3>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
     "tblib~=1.7",
-    "tiledb~=0.30,!=0.33.0,!=0.33.1,!=0.33.2",
+    "tiledb~=0.30,!=0.33.1,!=0.33.2",
     "typing-extensions",
     "urllib3>=1.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Not directly used on the client, but some server-side environments have
     # tblib transitively enabled, so this is needed for unpickling.
     "tblib~=1.7",
-    "tiledb>=0.15.2",
+    "tiledb>=0.33.3.rc0",
     "typing-extensions",
     "urllib3>=1.26",
 ]


### PR DESCRIPTION
I successfully ran a SOMA ingestion task graph using this branch on the client side + tiledb-py 0.33.3.rc0. The combination are compatible with our current production versions.