### PR TITLE
Add tiledb main branch to CI matrix

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -47,6 +47,9 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
+        is-scheduled:
+          - ${{ github.event.schedule == "34 1 * * *" }}
+          - ${{ github.event.schedule != "34 1 * * *" }}
         tiledb-version-spec:
           [
             "tiledb==0.30",
@@ -61,6 +64,15 @@ jobs:
             path: ~/.cache/pip
           # - os: macos-12
           # path: ~/Library/Caches/pip
+        exclude:
+          - tiledb-version-spec: "tiledb==0.30"
+            dependencies: fresh
+          - tiledb-version-spec: "tiledb==0.30"
+            is-scheduled: false
+          - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
+            dependencies: pinned
+          - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
+            is-scheduled: false
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -37,7 +37,7 @@ jobs:
         run: pre-commit run -a -v
 
   run-tests:
-    name: "${{ matrix.tiledb-version-spec }}:${{ maxtrix.python-version }}:${{ matrix.os }}"
+    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'release' }}
     strategy:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -50,7 +50,7 @@ jobs:
           [
             "tiledb==0.30",
             "tiledb==0.33.3.rc0",
-            "tiledb @ https://github.com/TileDB-Inc/TileDB-Py.git@main",
+            "tiledb @ git+https://github.com/TileDB-Inc/TileDB-Py.git@main",
           ]
         dependencies:
           - pinned

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -37,7 +37,7 @@ jobs:
         run: pre-commit run -a -v
 
   run-tests:
-    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.os }}"
+    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.dependencies }}:${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'release' }}
     strategy:
@@ -115,10 +115,10 @@ jobs:
         if: ${{ matrix.dependencies == 'pinned' }}
         run: |
           pip install -r ci/requirements.txt
-          pip install ${{ matrix.tiledb-version-spec}}
 
       - name: Install TileDB-Cloud-Py
         run: |
+          pip install ${{ matrix.tiledb-version-spec}}
           pip install .[tests]
           pip install tiledb-vector-search --no-deps
 

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -47,9 +47,9 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
-        is-scheduled:
-          - ${{ github.event.schedule == "34 1 * * *" }}
-          - ${{ github.event.schedule != "34 1 * * *" }}
+        is-pr:
+          - ${{ github.event_name == "pull_request" }}
+          - ${{ github.event_name != "pull_request" }}
         tiledb-version-spec:
           [
             "tiledb==0.30",
@@ -68,11 +68,11 @@ jobs:
           - tiledb-version-spec: "tiledb==0.30"
             dependencies: fresh
           - tiledb-version-spec: "tiledb==0.30"
-            is-scheduled: false
+            is-pr: true
           - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
             dependencies: pinned
           - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
-            is-scheduled: false
+            is-pr: true
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -46,7 +46,12 @@ jobs:
           - ubuntu-20.04
           # - macos-12
         python-version: ["3.9", "3.12"]
-        tiledb-version-spec: ["tiledb==0.30", "tiledb>=0.33.3.rc0"]
+        tiledb-version-spec:
+          [
+            "tiledb==0.30",
+            "tiledb==0.33.3.rc0",
+            "tiledb @ https://github.com/TileDB-Inc/TileDB-Py.git@main",
+          ]
         dependencies:
           - pinned
           - fresh

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -37,6 +37,7 @@ jobs:
         run: pre-commit run -a -v
 
   run-tests:
+    name: "${{ matrix.tiledb-version-spec }}:${{ maxtrix.python-version }}:${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'release' }}
     strategy:
@@ -50,7 +51,7 @@ jobs:
           [
             "tiledb==0.30",
             "tiledb==0.33.3.rc0",
-            "tiledb @ git+https://github.com/TileDB-Inc/TileDB-Py.git@main",
+            "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main",
           ]
         dependencies:
           - pinned

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -48,8 +48,7 @@ jobs:
           # - macos-12
         python-version: ["3.9", "3.12"]
         is-pr:
-          - ${{ github.event_name == "pull_request" }}
-          - ${{ github.event_name != "pull_request" }}
+          - ${{ github.event_name == 'pull_request' }}
         tiledb-version-spec:
           [
             "tiledb==0.30",

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -50,7 +50,7 @@ jobs:
         tiledb-version-spec:
           [
             "tiledb==0.30",
-            "tiledb==0.33.3.rc0",
+            "tiledb",
             "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main",
           ]
         dependencies:


### PR DESCRIPTION
With this PR, we now test tiledb-cloud against 1) the minimum supported version of tiledb(-py), 2) the most recent supported release on PyPI, and 3) the main branch of the tiledb-py project.

In the first case, we `pip install tiledb==0.30` and, after, `pip install .[tests]` determines that 0.30.0 meets the requirements and uses it.

In the second case, we `pip install tiledb`, get 0.33.2, and then `pip install .[tests]` determines that 0.33.2 is excluded, and then replaces it with a new install of 0.33.0 from PyPI.

In the third case, we install tiledb-py's main branch from GitHub, and `pip install .[tests]` determines that it meets the requirements.

The current test failures are due to timeouts on the server side. I'll rerun and they'll pass.