### PR TITLE
Remove dest_config from kwargs

### DIFF
--- a/src/tiledb/cloud/bioimg/ingestion.py
+++ b/src/tiledb/cloud/bioimg/ingestion.py
@@ -247,7 +247,7 @@ def ingest(
                 verbose=verbose,
                 tile_scale=tile_scale,
                 source_config=config,
-                dest_config=kwargs.get("dest_config", None),
+                dest_config=kwargs.pop("dest_config", None),
                 experimental_reader=experimental_reader,
                 **kwargs,
             )


### PR DESCRIPTION
Desc:
    The bioimg ingestion function, receives a `multiple argument error` when `dest_config` is set.
Reason:
    `dest_config` is not being removed from `kwargs` and this way is being carried over in the upcoming function calls

This PR:

- Fixes the issue by `pop` instead of `get` the value of `dest_config` from the `kwargs`