### PR TITLE
CI updates and noise reduction

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -72,6 +72,8 @@ jobs:
             dependencies: pinned
           - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
             is-pr: true
+          # - dependencies: fresh
+          #   is-pr: true
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:
@@ -159,16 +161,12 @@ jobs:
           fi
 
       - name: Run tests for vendored cloudpickle
-        # Test pinned dependencies on commit / tag and fresh installs on nightlies
-        if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pip install psutil
           pip install src/tiledb/cloud/_vendor/cloudpickle/tests/cloudpickle_testpkg
           pytest -sv src/tiledb/cloud/_vendor/cloudpickle
 
       - name: Run tests
-        # Test pinned dependencies on commit / tag and fresh installs on nightlies
-        if: (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           pytest -sv \
             --tb short \

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -72,8 +72,8 @@ jobs:
             dependencies: pinned
           - tiledb-version-spec: "tiledb@git+https://github.com/TileDB-Inc/TileDB-Py.git@main"
             is-pr: true
-          # - dependencies: fresh
-          #   is-pr: true
+          - dependencies: fresh
+            is-pr: true
         pytest-split-group: [1, 2, 3, 4, 5, 6] # Range the parallel test groups defined by env.PYTEST_SPLIT_GROUPS
 
     steps:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -918,6 +918,9 @@ class DAGCloudApplyTest(unittest.TestCase):
 
         self.assertEqual(node.result()["a"][0], numpy.sum(orig["a"]))
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_dag_apply_exec_multiple(self):
         uri_sparse = "tiledb://TileDB-Inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-Inc/quickstart_dense"
@@ -975,6 +978,9 @@ class DAGCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(d.status, dag.Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_dag_apply_exec_multiple_2(self):
         uri_sparse = "tiledb://TileDB-Inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-Inc/quickstart_dense"

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -312,6 +312,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
             node.result(), numpy.sum(orig_sparse["a"]) + numpy.sum(orig_dense["a"])
         )
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_array_apply_by_name(self):
         uri = "tiledb://TileDB-inc/quickstart_sparse"
         with tiledb.open(uri, ctx=tiledb.cloud.Ctx()) as A:
@@ -359,6 +362,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
 
         self.assertEqual(node.result()["a"][0], numpy.sum(orig["a"]))
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_apply_exec_multiple(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"
@@ -403,6 +409,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(node_exec.dag.status, Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_apply_exec_multiple_2(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"

--- a/tests/test_delayed.py
+++ b/tests/test_delayed.py
@@ -466,6 +466,9 @@ class DelayedCloudApplyTest(unittest.TestCase):
         )
         self.assertEqual(node_exec.status, Status.COMPLETED)
 
+    @pytest.mark.xfail(
+        np.__version__.startswith("2"), reason="Numpy 2 is not allowed in UDFs"
+    )
     def test_name_to_task_name(self):
         uri_sparse = "tiledb://TileDB-inc/quickstart_sparse"
         uri_dense = "tiledb://TileDB-inc/quickstart_dense"

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -14,7 +14,7 @@ from tiledb.cloud.utilities.wheel import PipInstall
 
 logger = get_logger()
 
-_TAG = str(uuid.uuid4())[-8:]
+_TAG = str(int(uuid.uuid4()))
 _LOCAL_WHEEL_ORIG = "tests/utilities/data/fake_unittest_wheel-0.1.0-py3-none-any.whl"
 # Add random tag to avoid collisions between concurrent tests
 _LOCAL_WHEEL = f"tests/utilities/data/fake_unittest_wheel-0.1.0-{_TAG}-py3-none-any.whl"


### PR DESCRIPTION
This moves test job conditions to matrix exclusion rules to eliminate no-op jobs from GitHub actions reports and xfails several tests when they use unsupported numpy 2 in UDFs.