### PR TITLE
Exclude more unpredictable tests

### DIFF
--- a/tests/taskgraphs/test_server_side.py
+++ b/tests/taskgraphs/test_server_side.py
@@ -19,6 +19,7 @@ _WAIT_TIME_S = 120
 
 
 class ConnectToExistingTest(unittest.TestCase):
+    @pytest.mark.xfail(reason="Time to complete is not predictable.")
     def test_completed_graph(self) -> None:
         to_run = dag.DAG(mode=dag.Mode.BATCH)
         one = to_run.submit(lambda: 1, name="one")

--- a/tests/utilities/test_wheel.py
+++ b/tests/utilities/test_wheel.py
@@ -69,6 +69,7 @@ def array_teardown():
     tiledb.Array.delete_array(_FULL_URI, ctx=ctx)
 
 
+@pytest.mark.skip(reason="Race condition in tests.")
 def test_upload_wheel(array_teardown) -> None:
     # first time uploading array
     upload_wheel(
@@ -174,6 +175,7 @@ def test_pip_install_install(pip_install_pypi):
         assert "django" not in sys.modules
 
 
+@pytest.mark.skip(reason="Race condition in tests.")
 def test_install_wheel(pip_install_tdb):
     # install from tiledb cloud array
     assert "fake_unittest_wheel" not in sys.modules


### PR DESCRIPTION
This PR xfails a task graph test with an unpredictable finishing time, and skips two wheel upload tests that are too flaky.