### PR TITLE
Fix error when passing `output_array_name` to `tiledb.cloud.sql.exec`

### DIFF
--- a/src/tiledb/cloud/sql/_execution.py
+++ b/src/tiledb/cloud/sql/_execution.py
@@ -112,7 +112,7 @@ def exec_base(
             array_api = client.build(rest_api.ArrayApi)
             array_api.update_array_metadata(
                 namespace=namespace,
-                output_uri=output_uri,
+                array=output_uri,
                 array_metadata=rest_api.models.ArrayInfoUpdate(name=output_array_name),
             )
 


### PR DESCRIPTION
Based on this discussion: https://tiledb.slack.com/archives/C5RLSKUF9/p1738880642359909