### PR TITLE
Raise ValueError when asset.info's uri doesn't resolve

### DIFF
--- a/src/tiledb/cloud/asset.py
+++ b/src/tiledb/cloud/asset.py
@@ -209,8 +209,10 @@ def info(uri: str) -> Union[models.ArrayInfo, models.GroupInfo]:
     """
     # Note: the URI can be either of the two forms, yes?
     # tiledb://namespace/name or tiledb://namespace/UUID.
-    info_map: Mapping[str, Callable] = {"array": array.info, "group": groups.info}
     asset_type: str = tiledb.object_type(uri, ctx=tiledb.cloud.Ctx())
+    if not asset_type:
+        raise ValueError("Given URI resolves to no asset and is invalid.")
+    info_map: Mapping[str, Callable] = {"array": array.info, "group": groups.info}
     func = info_map[asset_type]
     return func(uri)
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -298,3 +298,9 @@ class RegistrationTest(unittest.TestCase):
                 time.sleep(2)
         self.assert_group_not_exists(outer_name)
         self.assert_group_not_exists(inner_name)
+
+
+def test_failure_bogus_uri():
+    """Raise ValueError."""
+    with pytest.raises(ValueError):
+        asset.info("bogus")


### PR DESCRIPTION
Previously, a user would see a cryptic and irrelevant `KeyError`.