### PR TITLE
Give tasks and registered datasets unique names

### DIFF
--- a/src/tiledb/cloud/soma/ingest.py
+++ b/src/tiledb/cloud/soma/ingest.py
@@ -159,6 +159,7 @@ def run_ingest_workflow_udf(
             resources=ingest_resources,  # Apply propagated resources here.
             access_credentials_name=carry_along.get("access_credentials_name", acn),
             logging_level=logging_level,
+            name=f"H5ad ingestion: {stem}",
             dry_run=dry_run,
         )
         collector.depends_on(node)
@@ -168,12 +169,15 @@ def run_ingest_workflow_udf(
                 register_dataset_udf,
                 output_group_uri,
                 namespace=namespace,
-                register_name=register_name,
+                register_name=register_name
+                if len(input_files) == 1
+                else f"{register_name} - {stem}",
                 config=extra_tiledb_config,
                 verbose=logging_level == logging.DEBUG,
                 access_credentials_name=carry_along.get("access_credentials_name", acn),
                 acn=carry_along.get("access_credentials_name", acn),
                 logging_level=logging_level,
+                name=f"H5ad registration: {stem}",
             )
             register_soma.depends_on(collector)
 


### PR DESCRIPTION
We've enabled multi-file ingestion, but didn't give the datasets or the tasks that create them unique names.

The stem of a file now appears in task names. Note "pbmc3k_unprocessed" and "pbmc3k_unprocessed_copy" in the listings below.

![tasks](https://github.com/user-attachments/assets/56934388-5b9d-4e3c-9192-ec394cb793ef)

Similarly, the stem of the file is now used when registering. See below:

![assets](https://github.com/user-attachments/assets/303a5ac4-aa39-414e-9e95-1f00644985e0)
