### PR TITLE
Summarize XPASS-ing tests in CI

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -224,8 +224,8 @@ jobs:
         run: |
           ls -lR test-outputs
           cat test-outputs/*/test.log
-          grep --recursive --with-filename --extended-regexp 'test session starts' test-outputs || echo "No tests started."
-          grep --recursive --with-filename --extended-regexp '^XPASS' test-outputs || echo "No tests XPASSed."
+          grep --recursive --with-filename --extended-regexp "test session starts" test-outputs || echo "No tests started."
+          grep --recursive --with-filename --extended-regexp "XPASS|XFAIL" test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -224,6 +224,7 @@ jobs:
         run: |
           ls -lR test-outputs
           cat test-outputs/*/test.log
+          grep --recursive --with-filename --extended-regexp 'test session starts' test-outputs || echo "No tests started."
           grep --recursive --with-filename --extended-regexp '^XPASS' test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          ( pytest -sv \
+          pytest -sv \
             --tb short \
             --color yes \
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
@@ -179,13 +179,14 @@ jobs:
             --clean-durations \
             -r fExX \
             ${{ matrix.python-version == '3.12' && '-m "not udf"' || '' }} \
+            | tee -a test.log \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \
             --tb short \
             --color yes \
-            -r fExX ) \
-          | tee test.log
+            -r fExX \
+            | tee -a test.log
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 
@@ -222,9 +223,7 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          cd partial-test-outputs
-          grep --recursive --with-filename --extended-regexp '^XPASS' partial*
-          echo "Done"
+          grep --recursive --with-filename --extended-regexp '^XPASS' partial-test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -223,7 +223,8 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
-          grep --recursive --with-filename --extended-regexp '^XPASS' .
+          grep --recursive --with-filename --extended-regexp '^XPASS' partial*
+          echo "Done"
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: partial-test-output-${{ matrix.tiledb-version-spec }}-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.os }}-${{ matrix.pytest-split-group }}.log
+          name: partial-test-output-${{ matrix.tiledb-version-spec }}-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.os }}-${{ matrix.pytest-split-group }}
           path: test.log
           retention-days: 1
           overwrite: true
@@ -223,7 +223,7 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
-          grep -H "XPASS " *.log
+          grep -R -H "XPASS " .
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -218,11 +218,13 @@ jobs:
       - name: Download partial test outputs
         uses: actions/download-artifact@v4
         with:
-          path: partial-test-outputs
+          path: test-outputs
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          grep --recursive --with-filename --extended-regexp '^XPASS' partial-test-outputs || echo "No tests XPASSed."
+          ls -lR test-outputs
+          cat test-outputs/*/test.log
+          grep --recursive --with-filename --extended-regexp '^XPASS' test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          pytest -sv \
+          ( pytest -sv \
             --tb short \
             --color yes \
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
@@ -179,14 +179,13 @@ jobs:
             --clean-durations \
             -r fExX \
             ${{ matrix.python-version == '3.12' && '-m "not udf"' || '' }} \
-            | tee -a test.log \
+            | tee test.log ) \
           || .github/scripts/retry 2 \
             pytest -sv \
             --last-failed \
             --tb short \
             --color yes \
-            -r fExX \
-            | tee -a test.log
+            -r fExX
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -222,10 +222,7 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          ls -lR test-outputs
-          cat test-outputs/*/test.log
-          grep --recursive --with-filename --extended-regexp "test session starts" test-outputs || echo "No tests started."
-          grep --recursive --with-filename --extended-regexp "XPASS\s|XFAIL\s" test-outputs || echo "No tests XPASSed."
+          grep --recursive --with-filename "XPASS|XFAIL" test-outputs || echo "No tests XPASSed or XFAILed." >> $GITHUB_STEP_SUMMARY
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -223,8 +223,7 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
-          ls -lR
-          grep -R -H "XPASS " .
+          grep --recursive --with-filename 'XPASS ' .
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -167,6 +167,7 @@ jobs:
           pytest -sv src/tiledb/cloud/_vendor/cloudpickle
 
       - name: Run tests
+        shell: bash
         run: |
           { pytest -sv \
             --tb short \
@@ -192,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: partial-test-output-${{ matrix.pytest-split-group }}
+          name: partial-test-output-${{ matrix.tiledb-version-spec }}-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.os }}-${{ matrix.pytest-split-group }}.log
           path: test.log
           retention-days: 1
           overwrite: true
@@ -221,7 +222,8 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          cat partial-test-outputs/*
+          cd partial-test-output
+          grep -H "XPASS " *.log
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -222,7 +222,7 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          grep --recursive --with-filename "XPASS|XFAIL" test-outputs || echo "No tests XPASSed or XFAILed." >> $GITHUB_STEP_SUMMARY
+          (grep --recursive --with-filename "XPASS|XFAIL" test-outputs || echo "No tests XPASSed or XFAILed.") >> $GITHUB_STEP_SUMMARY
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -223,6 +223,9 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
+          ls
+          cat */*.log
+          grep --recursive --with-filename xpass .
           grep --recursive --with-filename 'XPASS ' .
 
   upload-to-pypi:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -sv \
+          { pytest -sv \
             --tb short \
             --color yes \
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
@@ -183,50 +183,45 @@ jobs:
             --last-failed \
             --tb short \
             --color yes \
-            -r fExX
+            -r fExX } \
+          | tee test.log
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
+
+      - name: "Upload partial test output"
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: partial-test-output-${{ matrix.pytest-split-group }}
+          path: test.log
+          retention-days: 1
+          overwrite: true
 
       # Uploads the partial durations from one of the run (specifically from the ubuntu run but it would be the same with macos).
       # These partial duration files will be combined into a single .test_durations file and used to update the test cache for the next runs
       - name: "Upload partial durations"
         uses: actions/upload-artifact@v4
         continue-on-error: true
-        # Ensure that we save the partial test durations from an ubuntu job that the tests actually run.
-        if: matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.9' && (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
           path: .test_durations
           retention-days: 1
           overwrite: true
 
-  # Download and combine the partial test durations uploaded by the run-tests job,
-  # into a single file and save it to cache for future use.
-  save-test-durations-to-cache:
-    name: Download, combine and save test_durations to the actions cache
+  summarize-test-output:
+    name: Summarize test output
     runs-on: ubuntu-24.04
     needs: run-tests
     continue-on-error: true
-    env:
-      FolderPrefix: partial-test-durations
     steps:
-      - name: Download partial durations
+      - name: Download partial test outputs
         uses: actions/download-artifact@v4
         with:
-          # Download partial test duration artifacts in the same folder
-          path: partial-test-durations
-          pattern: partial-test-durations-*
-
-      - name: "Combine test duration cache files in .test_durations"
+          path: partial-test-outputs
+          pattern: partial-test-output-*
+      - name: "Concatenate partial test outputs"
         run: |
-          jq -s add $(find partial-test-durations -type f -name .test_durations) > .test_durations
-          cat .test_durations
-
-      - name: "Save combined test durations to cache"
-        uses: actions/cache/save@v4
-        with:
-          path: .test_durations
-          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-${{ hashFiles('.test_durations') }}
+          cat partial-test-outputs/*
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -225,7 +225,7 @@ jobs:
           ls -lR test-outputs
           cat test-outputs/*/test.log
           grep --recursive --with-filename --extended-regexp "test session starts" test-outputs || echo "No tests started."
-          grep --recursive --with-filename --extended-regexp "XPASS|XFAIL" test-outputs || echo "No tests XPASSed."
+          grep --recursive --with-filename "^(XPASS|XFAIL)" test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          { pytest -sv \
+          ( pytest -sv \
             --tb short \
             --color yes \
             --splits ${{ env.PYTEST_SPLIT_GROUPS }} \
@@ -184,7 +184,7 @@ jobs:
             --last-failed \
             --tb short \
             --color yes \
-            -r fExX } \
+            -r fExX ) \
           | tee test.log
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -223,6 +223,7 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
+          ls -lR
           grep -R -H "XPASS " .
 
   upload-to-pypi:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -225,7 +225,7 @@ jobs:
           ls -lR test-outputs
           cat test-outputs/*/test.log
           grep --recursive --with-filename --extended-regexp "test session starts" test-outputs || echo "No tests started."
-          grep --recursive --with-filename "^[XPASS|XFAIL]" test-outputs || echo "No tests XPASSed."
+          grep --recursive --with-filename --extended-regexp "XPASS\s|XFAIL\s" test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -222,7 +222,8 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          (grep --recursive --with-filename "XPASS|XFAIL" test-outputs || echo "No tests XPASSed or XFAILed.") >> $GITHUB_STEP_SUMMARY
+          echo "XPASSes:" >> $GITHUB_STEP_SUMMARY
+          grep --recursive --with-filename "XPASS" test-outputs >> $GITHUB_STEP_SUMMARY
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -222,7 +222,7 @@ jobs:
           pattern: partial-test-output-*
       - name: "Concatenate partial test outputs"
         run: |
-          cd partial-test-output
+          cd partial-test-outputs
           grep -H "XPASS " *.log
 
   upload-to-pypi:

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -225,7 +225,7 @@ jobs:
           ls -lR test-outputs
           cat test-outputs/*/test.log
           grep --recursive --with-filename --extended-regexp "test session starts" test-outputs || echo "No tests started."
-          grep --recursive --with-filename "^(XPASS|XFAIL)" test-outputs || echo "No tests XPASSed."
+          grep --recursive --with-filename "^[XPASS|XFAIL]" test-outputs || echo "No tests XPASSed."
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -223,10 +223,7 @@ jobs:
       - name: "Concatenate partial test outputs"
         run: |
           cd partial-test-outputs
-          ls
-          cat */*.log
-          grep --recursive --with-filename xpass .
-          grep --recursive --with-filename 'XPASS ' .
+          grep --recursive --with-filename --extended-regexp '^XPASS' .
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -37,7 +37,7 @@ jobs:
         run: pre-commit run -a -v
 
   run-tests:
-    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.dependencies }}:${{ matrix.os }}"
+    name: "${{ matrix.tiledb-version-spec }}:${{ matrix.python-version }}:${{ matrix.dependencies }}:${{ matrix.pytest-split-group }}"
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'release' }}
     strategy:
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: partial-test-output-${{ matrix.tiledb-version-spec }}-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.os }}-${{ matrix.pytest-split-group }}
+          name: partial-test-output-${{ matrix.tiledb-version-spec }}-${{ matrix.python-version }}-${{ matrix.dependencies }}-${{ matrix.pytest-split-group }}
           path: test.log
           retention-days: 1
           overwrite: true


### PR DESCRIPTION
We're xfailing some tests that have a history of flakiness or timing out, but it's difficult to see when they xpass in the GitHub UI. You have to click through each job, find the step and scroll through it. And we've got a lot of jobs.

I've tried to add a summary job. It's not very fancy (I'm having trouble reproducing some unexpected grep behavior on my laptop), but it does show every xfailing test with information that helps guide us back to the particular job.

For example, this

```
XPASSes:
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-2/test.log:tests/taskgraphs/test_server_side.py::ConnectToExistingTest::test_running_graph �[33mXPASS�[0m
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-2/test.log:=================================== XPASSES ====================================
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-2/test.log:�[33mXPASS�[0m tests/taskgraphs/test_server_side.py::�[1mConnectToExistingTest::test_running_graph�[0m - Server side error, graph not computed in expected time.
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-4/test.log:tests/test_dag.py::DAGClassTest::test_resource_class �[33mXPASS�[0m (Requires...)
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-4/test.log:=================================== XPASSES ====================================
test-outputs/partial-test-output-tiledb-3.9-pinned-ubuntu-24.04-4/test.log:�[33mXPASS�[0m tests/test_dag.py::�[1mDAGClassTest::test_resource_class�[0m - Requires resolution of upstream issue.
```

tells us that two tests unexpectedly passed. Both with Python 3.9 (the Python 3.12 tests don't exercise UDFs or task graphs), pinned dependencies. One test is part 2 of the batch of splits, one in part 4.

In the UI, it looks like this:

![summary](https://github.com/user-attachments/assets/85c6447f-4618-4cfe-919f-e869b9fe4566)

The history of this PR is a mess. The net changes are small.