### PR TITLE
Fix upload and restore of test durations

### DIFF
--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -142,7 +142,9 @@ jobs:
         continue-on-error: true
         with:
           path: .test_durations
-          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}
+          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-${{ hashFiles('.test_durations') }}
+          restore-keys: |
+            ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-
 
       - name: "Check .test_durations file"
         run: |
@@ -225,7 +227,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .test_durations
-          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}
+          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-${{ hashFiles('.test_durations') }}
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -182,8 +182,6 @@ jobs:
             --tb short \
             --color yes \
             -r fExX
-          ls -l .test_durations
-          cat .test_durations
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 
@@ -273,6 +271,7 @@ jobs:
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          attestations: false
           repository-url: https://test.pypi.org/legacy/
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -198,6 +198,7 @@ jobs:
         # if: ${{ matrix.is-pr == false }}
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
+          include-hidden-files: true
           path: .test_durations
           retention-days: 1
           overwrite: true

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         # We save only Python 3.9 durations because 3.12 tests are limited.
-        if: ${{ matrix.python-version }} == "3.9" }}
+        if: ${{ matrix.python-version }} == "3.9" }} && ${{ matrix.is-pr == false }}
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
           include-hidden-files: true

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -142,9 +142,7 @@ jobs:
         continue-on-error: true
         with:
           path: .test_durations
-          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-${{ hashFiles('.test_durations') }}
-          restore-keys: |
-            ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-
+          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}
 
       - name: "Check .test_durations file"
         run: |
@@ -194,8 +192,8 @@ jobs:
       - name: "Upload partial durations"
         uses: actions/upload-artifact@v4
         continue-on-error: true
-        # Ensure that we save the partial test durations from an ubuntu job that the tests actually run.
-        # if: ${{ matrix.is-pr == false }}
+        # We save only Python 3.9 durations because 3.12 tests are limited.
+        if: ${{ matrix.python-version }} == "3.9" }}
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
           include-hidden-files: true
@@ -229,7 +227,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .test_durations
-          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}-${{ hashFiles('.test_durations') }}
+          key: ${{ env.PYTEST_TEST_DURATIONS_CACHE_KEY }}
 
   upload-to-pypi:
     # Upload a wheel only if the entire matrix succeeds.

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -184,6 +184,8 @@ jobs:
             --tb short \
             --color yes \
             -r fExX
+          ls -l .test_durations
+          cat .test_durations
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
 

--- a/.github/workflows/tiledb-cloud-py.yaml
+++ b/.github/workflows/tiledb-cloud-py.yaml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         # Ensure that we save the partial test durations from an ubuntu job that the tests actually run.
-        if: matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.9' && (matrix.dependencies == 'fresh') == (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        # if: ${{ matrix.is-pr == false }}
         with:
           name: partial-test-durations-${{ matrix.pytest-split-group }}
           path: .test_durations


### PR DESCRIPTION
upload-artifact@v4 broke our test duration upload and caching. It's now fixed, along with a fix for a PyPI warning. CI runs now with no warnings except for the one about migrating to PyPI trusted publishers.