### PR TITLE
Accept workspace id when logging in, add client support for v4 requests

### DIFF
--- a/src/tiledb/cloud/client.py
+++ b/src/tiledb/cloud/client.py
@@ -142,6 +142,7 @@ def login(
         client.set_threads(threads)
 
         # TODO: future migration to new server API.
+        # See sc-64479.
         user_api = build(rest_api.UserApi)
         session = user_api.get_session(remember_me=True)
         token = session.token

--- a/src/tiledb/cloud/config.py
+++ b/src/tiledb/cloud/config.py
@@ -172,13 +172,13 @@ def setup_configuration(
     workspace_id = workspace
 
 
+# Loading of the default configuration file and determination of
+# whether we are logged in or not is now deferred to the first access
+# of this module's "config" attribute.
 workspace_id = None
 logged_in = None
 """Whether logged in or not, and into which workspace."""
 
-# Loading of the default configuration file and determination of
-# whether we are logged in or not is now deferred to the first access
-# of this module's "config" attribute.
 
 user: Optional[models.User] = None
 """The default user to use.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,109 @@
+"""Tests of low-level client construction."""
+
+import json
+
+import pytest
+
+import tiledb.cloud.client
+from tiledb.cloud._common.api_v4.api import assets_api
+
+
+class NoResponseError(Exception):
+    """Raise when an intercepted request has no response."""
+
+
+@pytest.fixture(scope="function")
+def workspace_header_check(monkeypatch):
+    """Intercept server requests and checks the headers."""
+
+    def fake_and_check_request(self, method, url, *args, **kwargs):
+        assert kwargs["headers"]["X-TILEDB-WORKSPACE-ID"] == "workspace"
+        raise NoResponseError("Intercepted request has no response")
+
+    monkeypatch.setattr("urllib3.PoolManager.urlopen", fake_and_check_request)
+
+
+def test_workspace_header(monkeypatch, workspace_header_check):
+    """Check v4 HTTP request for workspace header."""
+    # Simulate login to a workspace using username/password.
+    monkeypatch.setattr(tiledb.cloud.client.config, "workspace_id", "workspace")
+    monkeypatch.setattr(tiledb.cloud.client.config._config, "username", "testuser")
+    monkeypatch.setattr(tiledb.cloud.client.config._config, "password", "password")
+    monkeypatch.setattr(tiledb.cloud.client.config._config, "api_key", {})
+    monkeypatch.setattr(tiledb.cloud.client.config, "logged_in", True)
+
+    client = tiledb.cloud.client.Client()
+    # We could use any v4 endpoint, asset listing is a choice.
+    api_instance = client.build(assets_api.AssetsApi)
+
+    # The workspace_header_check fixture asserts that the HTTP request
+    # the X-TILEDB-WORKSPACE-ID header. No valid response is prepared,
+    # we catch the fixture's normal exception instead. If the expected
+    # header wasn't found, an AssertionError would be raised.
+    with pytest.raises(NoResponseError):
+        api_instance.list_assets("teamspace")
+
+
+def test_login_workspace(monkeypatch, tmp_path):
+    """Accept and store workspace when logging in."""
+    # Use monkeypatch to simulate logging out.
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "default_config_file",
+        tmp_path.joinpath("cloud.json"),
+    )
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "_config",
+        tiledb.cloud.config.configuration.Configuration(),
+    )
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "workspace_id",
+        None,
+    )
+    monkeypatch.setattr(tiledb.cloud.client.config, "logged_in", False)
+
+    tiledb.cloud.login(
+        username="testuser", password="password", workspace="workspace", no_session=True
+    )
+    assert tiledb.cloud.client.config.config.username == "testuser"
+    assert tiledb.cloud.client.config.config.password == "password"
+    assert tiledb.cloud.client.config.workspace_id == "workspace"
+    assert tiledb.cloud.client.config.logged_in
+    assert tmp_path.joinpath("cloud.json").exists()
+    assert json.load(tmp_path.joinpath("cloud.json").open())["workspace"] == "workspace"
+
+
+def test_login_error(monkeypatch, tmp_path):
+    """Token and workspace are incompatible."""
+    # Use monkeypatch to simulate logging out.
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "default_config_file",
+        tmp_path.joinpath("cloud.json"),
+    )
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "_config",
+        tiledb.cloud.config.configuration.Configuration(),
+    )
+    monkeypatch.setattr(
+        tiledb.cloud.client.config,
+        "workspace_id",
+        None,
+    )
+    monkeypatch.setattr(tiledb.cloud.client.config, "logged_in", False)
+
+    with pytest.raises(tiledb.cloud.client.LoginError):
+        tiledb.cloud.login(
+            username="testuser", token="token", workspace="workspace", no_session=True
+        )
+
+    # Assert that login state hasn't changed.
+    assert tiledb.cloud.client.config.config.username is None
+    assert tiledb.cloud.client.config.config.password is None
+    assert tiledb.cloud.client.config.config.api_key == {}
+    assert tiledb.cloud.client.config.workspace_id is None
+    assert not tiledb.cloud.client.config.logged_in
+    assert not tmp_path.joinpath("cloud.json").exists()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ class NoResponseError(Exception):
 
 @pytest.fixture(scope="function")
 def workspace_header_check(monkeypatch):
-    """Intercept server requests and checks the headers."""
+    """Intercept server requests and check the headers."""
 
     def fake_and_check_request(self, method, url, *args, **kwargs):
         assert kwargs["headers"]["X-TILEDB-WORKSPACE-ID"] == "workspace"
@@ -36,7 +36,7 @@ def test_workspace_header(monkeypatch, workspace_header_check):
     # We could use any v4 endpoint, asset listing is a choice.
     api_instance = client.build(assets_api.AssetsApi)
 
-    # The workspace_header_check fixture asserts that the HTTP request
+    # The workspace_header_check fixture asserts that the HTTP request contains
     # the X-TILEDB-WORKSPACE-ID header. No valid response is prepared,
     # we catch the fixture's normal exception instead. If the expected
     # header wasn't found, an AssertionError would be raised.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,11 +12,6 @@ def test_login_bare_host(monkeypatch, tmp_path):
         tmp_path.joinpath("cloud.json"),
     )
     monkeypatch.setattr(
-        tiledb.cloud.config,
-        "default_config_file",
-        tmp_path.joinpath("cloud.json"),
-    )
-    monkeypatch.setattr(
         tiledb.cloud.client.config,
         "_config",
         tiledb.cloud.config.configuration.Configuration(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,11 @@ def test_login_bare_host(monkeypatch, tmp_path):
         tmp_path.joinpath("cloud.json"),
     )
     monkeypatch.setattr(
+        tiledb.cloud.config,
+        "default_config_file",
+        tmp_path.joinpath("cloud.json"),
+    )
+    monkeypatch.setattr(
         tiledb.cloud.client.config,
         "_config",
         tiledb.cloud.config.configuration.Configuration(),


### PR DESCRIPTION
Workspace id is stored for now in tiledb.cloud.config. If this is set, `X-TILEDB-WORKSPACE-ID` is added to the default headers of new v4 clients.

Unit tests exist and pass. Testing against a server instance is a TODO.