### PR TITLE
Resolve sc-49443 for workaround on member-list performance

### DIFF
--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -239,17 +239,11 @@ def build_collection_mapper_workflow_graph(
             % soma_collection_uri
         )
 
-        # Alternative:
-        #
-        # with tiledbsoma.Collection.open(soma_collection_uri) as soco:
-        #     soma_experiment_uris = {k: v.uri for k, v in soco.items()}
-        #
-        # -- however, that opens all the members sequentially, and we don't need
-        # that overhead here in the launcher node.
-        #
-        # See also: sc-49443
-        with tiledb.Group(soma_collection_uri) as grp:
-            soma_experiment_uris = {mbr.name: mbr.uri for mbr in grp}
+        with tiledbsoma.Collection.open(soma_collection_uri) as soco:
+            # Important:
+            # * soco.items() opens each element, which increases latency
+            # * soco.members().items() does not
+            soma_experiment_uris = {k: v.uri for k, v in soco.members().items()}
 
     if experiment_names is not None:
         logger.info("Filtering SOMA Experiment URIs for specified names")

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -240,9 +240,12 @@ def build_collection_mapper_workflow_graph(
 
         with tiledbsoma.Collection.open(soma_collection_uri) as soco:
             # Important:
-            # * soco.items() opens each element, which increases latency
+            # * soco.items() opens each element, which increases latency.
+            #   We need k, v.uri.
             # * soco.members().items() does not
-            soma_experiment_uris = {k: v.uri for k, v in soco.members().items()}
+            #   We need k, v[0] since values are a tuple of URI and object type
+            #   where object type is "SOMAGroup" or "SOMAArray".
+            soma_experiment_uris = {k: v[0] for k, v in soco.members().items()}
 
     if experiment_names is not None:
         logger.info("Filtering SOMA Experiment URIs for specified names")

--- a/src/tiledb/cloud/soma/mapper.py
+++ b/src/tiledb/cloud/soma/mapper.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 import anndata as ad
 import tiledbsoma
 
-import tiledb
 from tiledb.cloud import dag
 from tiledb.cloud._common import functions
 from tiledb.cloud.utilities import get_logger_wrapper


### PR DESCRIPTION
This is an old follow-up from [sc-49443](https://app.shortcut.com/tiledb-inc/story/49443/performance-issue-in-soma-group-member-retrieval), as descrbed in the comments in the affected code.