### PR TITLE
Set VCF record count to 0 when the index is bad

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -715,6 +715,7 @@ def ingest_manifest_udf(
                         if records is None:
                             status = "" if status == "ok" else status + ","
                             status += "bad index"
+                            records = 0
 
                     keys.append(sample_name)
                     values["status"].append(status)


### PR DESCRIPTION
Previously the record value was left as `None` when the VCF index is bad. The `None` value is not compatible with the manifest's "records" attribute, resulting in an error when writing:
```console
ValueError: NumPy array conversion check failed for attr 'records'
```