### PR TITLE
Updated VCF multiple sample check to split on comma

### DIFF
--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -691,7 +691,7 @@ def ingest_manifest_udf(
 
                     if not sample_name:
                         status = "missing sample name"
-                    elif len(sample_name.split()) > 1:
+                    elif len(sample_name.split(",")) > 1:
                         status = "multiple samples"
                     elif sample_name in keys:
                         # TODO: check for duplicate sample names across all


### PR DESCRIPTION
Previously the sample name was split using the default whitespace behavior. This caused VCFs with multiple samples to be added to the manifest as "ok" for ingestion.