### PR TITLE
WIP: VCF Ingestion Tests

### DIFF
--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -140,6 +140,7 @@ def consolidate_fragments(
     graph: Optional[dag.DAG] = None,
     dependencies: Optional[Sequence[dag.Node]] = None,
     consolidate_resources: Optional[Mapping[str, str]] = None,
+    group_fragments_resources: Optional[Mapping[str, str]] = None,
     namespace: Optional[str] = None,
     max_fragment_size: int = MAX_FRAGMENT_SIZE_BYTES,
 ) -> None:
@@ -164,7 +165,10 @@ def consolidate_fragments(
     :param group_by_first_dim: group fragment by first dimension, defaults to True
     :param graph: graph to submit nodes to, defaults to None
     :param dependencies: list of nodes in the graph to depend on, defaults to None
-    :param consolidate_resources: resources for the consolidate node, defaults to None
+    :param consolidate_resources: resources for the consolidate node,
+        defaults to None
+    :param group_fragments_resources: resources for the group_fragments node,
+        defaults to None
     :param namespace: TileDB Cloud namespace, defaults to the user's default namespace
     :param max_fragment_size: max size of consolidated fragments,
         defaults to MAX_FRAGMENT_SIZE_BYTES
@@ -197,6 +201,12 @@ def consolidate_fragments(
         "memory": "16Gi",
     }
 
+    # Set resources for the group fragments node, if not provided.
+    group_fragments_resources = group_fragments_resources or {
+        "cpu": "2",
+        "memory": "16Gi",
+    }
+
     name = basename(array_uri)
 
     fragment_groups = graph.submit(
@@ -206,10 +216,7 @@ def consolidate_fragments(
         group_by_first_dim=group_by_first_dim,
         name=f"Groups Fragments - {name}",
         access_credentials_name=acn,
-        resources={
-            "cpu": "1",
-            "memory": "1Gi",
-        },
+        resources=group_fragments_resources,
     )
 
     if dependencies:


### PR DESCRIPTION
Tests are run against data in s3://tiledb-unittest/vcf-ingestion-test/. Specifically, there's 6 `.vcf.gz` files, each corresponding to a different success/failure code path in VCF ingestion. Additionally, there's a TileDB "metadata" array and a file containing the `.vcf.gz` URIs. These, and the `.vcf.gz` files themselves, are used to exercise all 3 ways VCF URIs can be provided during ingestion.

These tests won't be runnable via CI because the unittest user doesn't have adequate privileges. However, these tests can be run locally, which is better than nothing!

Currently looking for any/all feedback.

Note, this is a branch of [alancleary/vcf-12/ingestion-failure-handling](https://github.com/TileDB-Inc/TileDB-Cloud-Py/tree/alancleary/vcf-12/ingestion-failure-handling) and is intended to be merged after PR #723.