### PR TITLE
Spencer/cloud 983 add udf and taskgraph decorators

### DIFF
--- a/src/tiledb/cloud/dag/__init__.py
+++ b/src/tiledb/cloud/dag/__init__.py
@@ -3,6 +3,8 @@ from types import MappingProxyType
 from tiledb.cloud.dag import dag
 from tiledb.cloud.dag import mode
 from tiledb.cloud.dag import status
+from tiledb.cloud.dag.decorators import taskgraph
+from tiledb.cloud.dag.decorators import udf
 
 # Globals
 MIN_BATCH_RESOURCES = MappingProxyType({"cpu": "1", "memory": "2Gi"})
@@ -24,4 +26,6 @@ __all__ = (
     "Status",
     "list_logs",
     "server_logs",
+    "taskgraph",
+    "udf",
 )

--- a/src/tiledb/cloud/dag/__init__.py
+++ b/src/tiledb/cloud/dag/__init__.py
@@ -3,8 +3,6 @@ from types import MappingProxyType
 from tiledb.cloud.dag import dag
 from tiledb.cloud.dag import mode
 from tiledb.cloud.dag import status
-from tiledb.cloud.dag.decorators import taskgraph
-from tiledb.cloud.dag.decorators import udf
 
 # Globals
 MIN_BATCH_RESOURCES = MappingProxyType({"cpu": "1", "memory": "2Gi"})
@@ -17,7 +15,6 @@ Status = status.Status
 list_logs = dag.list_logs
 server_logs = dag.server_logs
 
-
 __all__ = (
     "DAG",
     "MIN_BATCH_RESOURCES",
@@ -26,6 +23,4 @@ __all__ = (
     "Status",
     "list_logs",
     "server_logs",
-    "taskgraph",
-    "udf",
 )

--- a/src/tiledb/cloud/dag/decorators/__init__.py
+++ b/src/tiledb/cloud/dag/decorators/__init__.py
@@ -1,0 +1,7 @@
+from tiledb.cloud.dag.decorators._inputs import BaseInput
+from tiledb.cloud.dag.decorators._inputs import TaskGraphInput
+from tiledb.cloud.dag.decorators._inputs import UDFInput
+from tiledb.cloud.dag.decorators._taskgraph import taskgraph
+from tiledb.cloud.dag.decorators._udf import udf
+
+__all__ = ["udf", "taskgraph", "BaseInput", "UDFInput", "TaskGraphInput"]

--- a/src/tiledb/cloud/dag/decorators/_context.py
+++ b/src/tiledb/cloud/dag/decorators/_context.py
@@ -1,0 +1,9 @@
+"""Shared context variables for DAG decorators."""
+
+from contextvars import ContextVar
+from typing import Optional
+
+from tiledb.cloud.dag import DAG
+
+# context variable to hold the active (and potentially nested) DAG contexts.
+_dag_context: ContextVar[Optional[DAG]] = ContextVar("current_dag")

--- a/src/tiledb/cloud/dag/decorators/_inputs.py
+++ b/src/tiledb/cloud/dag/decorators/_inputs.py
@@ -1,0 +1,58 @@
+"""Configuration classes for DAG decorators."""
+
+import enum
+from dataclasses import dataclass
+from typing import Optional
+
+from tiledb.cloud.dag import Mode
+from tiledb.cloud.dag.decorators._resources import Resources
+from tiledb.cloud.utilities.logging import get_logger
+
+logger = get_logger()
+
+
+@dataclass(frozen=False)
+class BaseInput:
+    """Base input class with common parameters for UDF and TaskGraph."""
+
+    name: Optional[str] = None
+    mode: enum.Enum = Mode.REALTIME
+    namespace: Optional[str] = None
+    retry_limit: int = 0
+    timeout: Optional[int] = None
+    wait: bool = True
+
+    def sub_private(self, **kwargs):
+        for k in kwargs:
+            if k.startswith("_"):
+                if k[1:] in self.__dict__:
+                    logger.info(f"{k} detected. Override {k[1:]} with {kwargs[k]}")
+                    setattr(self, k[1:], kwargs[k])
+
+            # only relevant in UDFInput subclass
+            if k in ["_resource_class", "_cpu", "_memory_gb"]:
+                try:
+                    setattr(self.resources, k[1:], kwargs[k])
+                except AttributeError:
+                    logger.debug(
+                        "Resources object not found due to wrongly included in"
+                        f" task graph. Skipping {k}."
+                    )
+
+
+@dataclass(frozen=False)
+class UDFInput(BaseInput):
+    """Input configuration for UDF decorator execution."""
+
+    acn: Optional[str] = None
+    resources: Optional[Resources] = None
+    expand: Optional[str] = None
+    image_name: Optional[str] = None
+
+
+@dataclass(frozen=False)
+class TaskGraphInput(BaseInput):
+    """Input configuration for TaskGraph decorator execution."""
+
+    max_workers: Optional[int] = None
+    return_dag: bool = False

--- a/src/tiledb/cloud/dag/decorators/_log.py
+++ b/src/tiledb/cloud/dag/decorators/_log.py
@@ -1,0 +1,16 @@
+from tiledb.cloud.utilities.logging import get_logger
+
+logger = get_logger()
+
+
+def log_submission(
+    namespace: str,
+    server_graph_uuid: str,
+    log_url: str = "https://cloud.tiledb.com/activity/taskgraphs/{}/{}",
+) -> str:
+    """Log submission of task graph."""
+
+    task_uri = log_url.format(namespace, server_graph_uuid)
+    logger.info(f"Task graph submitted - {task_uri}")
+
+    return task_uri

--- a/src/tiledb/cloud/dag/decorators/_log.py
+++ b/src/tiledb/cloud/dag/decorators/_log.py
@@ -1,9 +1,12 @@
+from typing import Any, Mapping, Sequence, Union
+
+from tiledb.cloud.dag import DAG
 from tiledb.cloud.utilities.logging import get_logger
 
 logger = get_logger()
 
 
-def log_submission(
+def log_tg_submission(
     namespace: str,
     server_graph_uuid: str,
     log_url: str = "https://cloud.tiledb.com/activity/taskgraphs/{}/{}",
@@ -14,3 +17,18 @@ def log_submission(
     logger.info(f"Task graph submitted - {task_uri}")
 
     return task_uri
+
+
+def log_node_submission(
+    name: str,
+    dag: DAG,
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+    resources: Union[str, Mapping[str, str]],
+) -> None:
+    """Log submission of node."""
+
+    logger.info(f"> Submit UDF {name} to {dag}")
+    logger.info(f"|---args = {args}")
+    logger.info(f"|---kwargs = {kwargs}")
+    logger.info(f"|---resources = {resources}")

--- a/src/tiledb/cloud/dag/decorators/_resources.py
+++ b/src/tiledb/cloud/dag/decorators/_resources.py
@@ -1,0 +1,103 @@
+"""Handle resourcing for task graphs."""
+
+import enum
+from dataclasses import dataclass
+from dataclasses import field
+from typing import List, Optional, Sequence
+
+import toml
+from importlib_resources import files
+
+from tiledb.cloud.dag import Mode
+from tiledb.cloud.utilities.logging import get_logger
+
+logger = get_logger()
+
+
+def load_defaults(
+    file: str,
+    toml_key: str,
+    config: str = "tiledb.cloud.dag.decorators.configs",
+) -> List[str]:
+    return toml.loads(files(config).joinpath(file).read_text())[toml_key]
+
+
+@dataclass(frozen=False)
+class Resources:
+    """Resources container."""
+
+    resource_class: Optional[str] = None
+    """Realtime resource class."""
+    cpu: Optional[int] = None
+    """CPUs."""
+    memory_gb: Optional[int] = None
+    """Memory in GiB."""
+    mode: enum.Enum = Mode.REALTIME
+    """Execution mode."""
+    validate_on_init: bool = True
+    """Whether to validate resources on init. Rarely should be set to False."""
+    resource_opts: Sequence[str] = field(
+        default_factory=lambda: load_defaults(
+            file="resources.toml",
+            toml_key="resource_options",
+        )
+    )
+    """Valid resource classes."""
+
+    def __post_init__(self) -> None:
+        # self.mode = self.mode.lower()
+
+        if self.validate_on_init:
+            if self.mode == Mode.LOCAL:
+                logger.debug("Resource validation skipped when running locally.")
+            else:
+                self.validate()
+
+    def translate_to_resource_class(self) -> str:
+        """Translate as best as possible from custom resources to
+        resource class.
+
+        standard - 2 cpu, 2Gi memory
+        large - 8 cpu, 8Gi memory
+
+        :return: Resource class.
+        """
+
+        if self.cpu <= 2 and self.memory_gb <= 2:
+            size = "standard"
+        else:
+            size = "large"
+
+        logger.debug(f"Setting resource class to {size} based on cpu + memory_gb.")
+        return size
+
+    def validate(self) -> None:
+        """Validate resources based on input and mode requirements."""
+
+        if not self.cpu and not self.memory_gb and not self.resource_class:
+            if self.mode == Mode.REALTIME:
+                # default first value in rersource opts
+                self.resource_class = self.resource_opts[0]
+            elif self.mode == Mode.BATCH:
+                self.cpu = 2
+                self.memory_gb = 2
+
+        if self.resource_class:
+            self.resource_class = self.resource_class.lower()
+
+        # when one not set, force a default
+        if self.cpu or self.memory_gb:
+            self.cpu = self.cpu or 2
+            self.memory_gb = self.memory_gb or 2
+
+        if self.resource_class and self.resource_class not in self.resource_opts:
+            raise ValueError(
+                f"Invalid resource class: {self.resource_class}. "
+                f"Must be one of {self.resource_opts}."
+            )
+
+        if self.resource_class and (self.cpu or self.memory_gb):
+            raise ValueError("Cannot specify both resource_class and cpu + memory_gb.")
+
+        if self.mode == Mode.REALTIME and (self.cpu or self.memory_gb):
+            self.resource_class = self.translate_to_resource_class()

--- a/src/tiledb/cloud/dag/decorators/_resources.py
+++ b/src/tiledb/cloud/dag/decorators/_resources.py
@@ -32,9 +32,6 @@ class Resources:
     """CPUs."""
     memory_gb: Optional[int] = None
     """Memory in GiB."""
-    # mode: enum.Enum = Mode.REALTIME
-    """Execution mode."""
-    # validate_on_init: bool = True
     """Whether to validate resources on init. Rarely should be set to False."""
     resource_opts: Sequence[str] = field(
         default_factory=lambda: load_defaults(

--- a/src/tiledb/cloud/dag/decorators/_taskgraph.py
+++ b/src/tiledb/cloud/dag/decorators/_taskgraph.py
@@ -1,0 +1,178 @@
+"""Task graph and udf decorators."""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+from typing import Callable, Optional, Union
+
+import tiledb.cloud
+from tiledb.cloud.utilities.logging import get_logger
+
+logger = get_logger()
+
+MODES = ["local", "realtime", "batch"]
+
+
+# Context variable to hold the active (and potentially nested) DAG contexts.
+_dag_context: ContextVar[tiledb.cloud.dag.DAG] = ContextVar("current_dag")
+
+
+# TODO: add timeout, result_format, retry_strategy, deadline
+
+
+@contextmanager
+def taskgraph_context(
+    acn: Optional[str] = None,
+    max_workers: Optional[int] = None,
+    mode: str = "realtime",
+    name: Optional[str] = None,
+    namespace: Optional[str] = None,
+):
+    """
+    Context manager for task graphs, which creates a DAG with the specified parameters
+    and pushes the DAG onto the context stack.
+
+    :param acn: TileDB access credentials name, defaults to None
+    :param max_workers: max parallel workers, defaults to None
+    :param mode: task graph mode, "realtime"|"batch"|"local", defaults to None
+    :param name: task graph name, defaults to None
+    :param namespace: TileDB namespace, defaults to None
+    :yield: the DAG
+    """
+
+    # Validate user input and set the mode.
+    if mode == "realtime" or mode == "local":
+        mode_enum = tiledb.cloud.dag.Mode.REALTIME
+    elif mode == "batch":
+        mode_enum = tiledb.cloud.dag.Mode.BATCH
+    else:
+        raise ValueError(f"Invalid mode: {mode}")
+
+    # Create the DAG.
+    dag = tiledb.cloud.dag.DAG(
+        max_workers=max_workers,
+        mode=mode_enum,
+        name=name,
+        namespace=namespace,
+    )
+
+    # Add state used when submitting tasks.
+    dag._acn = acn if mode == "batch" else None
+    dag._is_realtime = mode == "realtime"
+    dag._is_local = mode == "local"
+    dag._is_batch = mode == "batch"
+
+    # Add the DAG to the context variable.
+    token = _dag_context.set(dag)
+    try:
+        logger.info(f"Create DAG: {name}, mode={mode}, namespace={namespace}")
+        yield dag
+    finally:
+        logger.info(f"Destroy DAG: {name}")
+        # Remove the DAG from the context variable.
+        _dag_context.reset(token)
+
+
+def taskgraph(
+    func: Optional[Union[Callable, str]] = None,
+    acn: Optional[str] = None,
+    max_workers: Optional[int] = None,
+    mode: str = "realtime",
+    name: Optional[str] = None,
+    namespace: Optional[str] = None,
+    wait: bool = True,
+    return_dag: bool = False,
+):
+    """Function decorator for a TileDB task graph. When a function wrapped
+    with this decorator is executed:
+
+        1. A new DAG is created.
+        2. Calls to @task wrapped functions are submitted to the DAG.
+        3. The DAG is executed.
+        4. Optionally wait for the DAG to complete.
+        5. Return the results and optionally the DAG.
+
+    Kwargs to the wrapped function can override kwargs in the original
+        decorator following the convention of prepending the arg name
+        with an underscore. For example:
+
+        ```python
+        @taskgraph(mode="realtime")
+        def compute_taskgraph(a):
+            # Do some work.
+            pass
+
+        # Override the original task graph mode
+        compute_taskgraph(16, _mode="local")
+        ```
+
+    :param acn: TileDB access credentials name, defaults to None
+    :param max_workers: max parallel workers, defaults to None
+    :param mode: task graph mode, "realtime"|"batch"|"local", defaults to None
+    :param name: task graph name, defaults to None
+    :param namespace: TileDB namespace, defaults to None
+    :param wait: wait for the task graph to complete, defaults to True
+    :param return_dag: return the DAG object with the result, defaults to False
+    """
+
+    def decorator(func):
+        """Return a function wrapper configured with the decorator arguments."""
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Optionally override decorator args with function kwargs.
+            _acn = kwargs.pop("_acn", acn)
+            _max_workers = kwargs.pop("_max_workers", max_workers)
+            _mode = kwargs.pop("_mode", mode)
+            _name = kwargs.pop("_name", name or func.__name__)
+            _namespace = kwargs.pop("_namespace", namespace)
+            _wait = kwargs.pop("_wait", wait)
+            _return_dag = kwargs.pop("_return_dag", return_dag)
+
+            # Validate user input.
+            if _mode not in MODES:
+                raise ValueError(f"Invalid mode: {_mode}")
+
+            # Create the DAG with the context manager.
+            with taskgraph_context(
+                acn=_acn,
+                max_workers=_max_workers,
+                mode=_mode,
+                name=_name,
+                namespace=_namespace,
+            ) as dag:
+                # Run the wrapped function, which submits tasks to the task graph.
+                result = func(*args, **kwargs)
+
+                # Execute the DAG.
+                dag.compute()
+
+                # Optionally wait for the DAG to complete.
+                if _wait:
+                    dag.wait()
+
+                    # Get the result from the Node, if needed.
+                    if isinstance(result, tiledb.cloud.dag.Node):
+                        result = result.result()
+
+                # Return the DAG and result, if requested.
+                if _return_dag:
+                    return dag, result
+
+                return result
+
+        return wrapper
+
+    # when no args passed to decorator
+    if callable(func):
+        return decorator(func)
+    elif isinstance(func, str):
+        raise ValueError("Calling registered UDF not yet supported.")
+    else:
+        return decorator
+
+
+def get_arg_index(fn, arg_name):
+    """Get the index of a functions arg by name."""
+    # TODO: implement for expand
+    pass

--- a/src/tiledb/cloud/dag/decorators/_taskgraph.py
+++ b/src/tiledb/cloud/dag/decorators/_taskgraph.py
@@ -34,7 +34,8 @@ def taskgraph_context(input: TaskGraphInput):
     token = _dag_context.set(dag)
     logger.debug(f"DAG context object: {_dag_context}")
     try:
-        # TODO: once in cararra, get the default namespace and use in logging
+        # TODO: once in cararra, get the default namespace (get_self_user) and
+        # use in logging
         logger.info(
             "Initialize DAG: "
             f"name={input.name}, mode={str(input.mode)}, namespace={input.namespace}"

--- a/src/tiledb/cloud/dag/decorators/_taskgraph.py
+++ b/src/tiledb/cloud/dag/decorators/_taskgraph.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 import tiledb.cloud
 from tiledb.cloud.dag.decorators._context import _dag_context
 from tiledb.cloud.dag.decorators._inputs import TaskGraphInput
-from tiledb.cloud.dag.decorators._log import log_submission
+from tiledb.cloud.dag.decorators._log import log_tg_submission
 from tiledb.cloud.utilities.logging import get_logger
 
 logger = get_logger()
@@ -141,7 +141,7 @@ def taskgraph(
 
                 dag.compute()
 
-                log_submission(
+                log_tg_submission(
                     namespace=dag.namespace,
                     server_graph_uuid=dag.server_graph_uuid,
                 )

--- a/src/tiledb/cloud/dag/decorators/_udf.py
+++ b/src/tiledb/cloud/dag/decorators/_udf.py
@@ -212,7 +212,7 @@ def _udf(
     expand: Optional[str] = None,
     image_name: Optional[str] = None,
     **kwargs: Mapping[str, Any],
-):
+) -> Any:
     logger.debug(f"args: {args}")
     logger.debug(f"kwargs: {kwargs}")
 
@@ -286,14 +286,18 @@ def udf(
     retry_limit: int = 0,
     **kwargs: Mapping[str, Any],
 ) -> Any:
-    """
-    Function decorator for a TileDB task. When a function wrapped with this decorator
-    is executed:
+    """Execute or decorate a function as a TileDB UDF.
 
-    1. Get the DAG from the current DAG context.
-    2. Submit the task to the DAG using the specified parameters.
+    Example:
 
-    If the decorated function is run outside of a DAG context, it will run locally.
+        ```python
+        @udf
+        def compute_task(a):
+            return result
+
+        # Run the UDF.
+        compute_task(16)
+        ```
 
     Kwargs to the wrapped function can override kwargs in the original decorator
     following the convention of prepending the arg name with an underscore.
@@ -303,7 +307,6 @@ def udf(
         ```python
         @udf(resource_class="standard")
         def compute_task(a):
-            # Do some work.
             return result
 
         @taskgraph(mode="realtime")

--- a/src/tiledb/cloud/dag/decorators/_udf.py
+++ b/src/tiledb/cloud/dag/decorators/_udf.py
@@ -1,40 +1,20 @@
 import enum
 import webbrowser
-from contextvars import ContextVar
-from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 from attrs import define
-from attrs import field
 
 from tiledb.cloud import models
 from tiledb.cloud.dag import DAG
 from tiledb.cloud.dag import Mode
+from tiledb.cloud.dag.decorators._context import _dag_context
+from tiledb.cloud.dag.decorators._inputs import UDFInput
 from tiledb.cloud.dag.decorators._resources import Resources
-from tiledb.cloud.dag.decorators._resources import load_defaults
 from tiledb.cloud.udf import exec as udf_exec
 from tiledb.cloud.utilities.logging import get_logger
 
 logger = get_logger()
-
-# Context variable to hold the active (and potentially nested) DAG contexts.
-_dag_context: ContextVar[DAG] = ContextVar("current_dag")
-
-
-@dataclass(frozen=True)
-class UDFConfig:
-    """Configuration for UDF decorator execution."""
-
-    expand: Optional[str] = None
-    image_name: Optional[str] = None
-    name: Optional[str] = None
-    mode: enum.Enum = Mode.REALTIME
-    namespace: Optional[str] = None
-    acn: Optional[str] = None
-    retry_limit: int = 0
-    resources: Optional[Resources] = None
-    timeout: Optional[int] = None
 
 
 @define
@@ -47,21 +27,19 @@ class UDFHandler:
     """Positional arguments to pass to function."""
     kwargs: Mapping[str, Any]
     """Keyword arguments to pass to function."""
-    config: UDFConfig
-    """UDF configuration."""
-    mode_opts: Sequence[str] = field(
-        factory=lambda: load_defaults(
-            file="modes.toml",
-            toml_key="mode_options",
-        )
-    )
-    """Valid execution modes."""
+    input: UDFInput
+    """UDF input configuration."""
     log_url: str = "https://cloud.tiledb.com/activity/taskgraphs/{}/{}"
     """Task graph log URL."""
 
     def __attrs_post_init__(self) -> None:
-        if str(self.config.mode).lower() not in self.mode_opts:
-            raise ValueError(f"Invalid UDF mode: {self.config.mode}")
+        # fix name if not set
+        if self.input.name is None:
+            try:
+                self.input.name = self.func.__name__
+            except AttributeError:
+                if isinstance(self.func, str):
+                    self.input.name = self.func
 
     def exec_local(self) -> Any:
         """Exec local UDF.
@@ -80,13 +58,13 @@ class UDFHandler:
         return udf_exec(
             self.func,
             *self.args,
-            task_name=self.config.name,
-            namespace=self.config.namespace,
-            resource_class=self.config.resources.resource_class
-            if self.config.resources
+            task_name=self.input.name,
+            namespace=self.input.namespace,
+            resource_class=self.input.resources.resource_class
+            if self.input.resources
             else None,
-            image_name=self.config.image_name,
-            timeout=self.config.timeout,
+            image_name=self.input.image_name,
+            timeout=self.input.timeout,
             **self.kwargs,
         )
 
@@ -105,28 +83,28 @@ class UDFHandler:
         """
 
         graph = DAG(
-            name=f"batch->{self.config.name}",
-            namespace=self.config.namespace,
+            name=f"batch->{self.input.name}",
+            namespace=self.input.namespace,
             mode=Mode.BATCH,
             retry_strategy=models.RetryStrategy(
-                limit=self.config.retry_limit,
+                limit=self.input.retry_limit,
                 retry_policy="Always",
             ),
-            deadline=self.config.timeout,
+            deadline=self.input.timeout,
         )
 
         graph.submit(
             self.func,
             *self.args,
-            name=self.config.name,
-            access_credentials_name=self.config.acn,
+            name=self.input.name,
+            access_credentials_name=self.input.acn,
             resources={
-                "cpu": str(self.config.resources.cpu),
-                "memory": f"{self.config.resources.memory_gb}Gi",
+                "cpu": str(self.input.resources.cpu),
+                "memory": f"{self.input.resources.memory_gb}Gi",
             }
-            if self.config.resources
+            if self.input.resources
             else None,
-            image_name=self.config.image_name,
+            image_name=self.input.image_name,
             **self.kwargs,
         )
 
@@ -153,66 +131,146 @@ class UDFHandler:
         :return: Return value of function or a running DAG.
         """
 
-        if self.config.mode == "local":
+        self.input.resources.validate(self.input.mode)
+
+        if self.input.mode == "local":
             return self.exec_local()
         else:
             return (
                 self.exec_realtime()
-                if self.config.mode == Mode.REALTIME
+                if self.input.mode == Mode.REALTIME
                 else self.exec_batch()
             )
 
+    def run_in_dag(self, dag: DAG) -> Union[Any, DAG]:
+        self.input.resources.validate(self.input.mode)
 
-def exec_registered_udf(
-    func: str,
+        if self.input.mode != Mode.LOCAL:
+            # Prepare dynamic parameters
+            dyn_params = {}
+            if self.input.mode == Mode.REALTIME:
+                rkey = "resource_class"
+                if self.input.resources and self.input.resources.resource_class:
+                    dyn_params[rkey] = self.input.resources.resource_class
+                if self.input.expand:
+                    raise ValueError("'expand' is only supported in batch task graphs")
+                submit = dag.submit
+            # batch
+            else:
+                if self.input.resources:
+                    rkey = "resources"
+                    dyn_params[rkey] = {
+                        "cpu": str(self.input.resources.cpu),
+                        "memory": f"{self.input.resources.memory_gb}Gi",
+                    }
+                if self.input.expand:
+                    dyn_params["expand_node_output"] = self.input.expand
+                submit = dag.submit_udf_stage if self.input.expand else dag.submit
+
+            logger.info(f"> Submit UDF {self.input.name} to {dag}")
+            logger.info(f"|---args = {self.args}")
+            logger.info(f"|---kwargs = {self.kwargs}")
+            logger.info(f"|---resources = {dyn_params[rkey]}")
+
+            # Submit the task to the DAG with dynamic parameters
+            return submit(
+                self.func,
+                name=self.input.name,
+                image_name=self.input.image_name,
+                access_credentials_name=self.input.acn,
+                *self.args,
+                **dyn_params,
+                **self.kwargs,
+            )
+
+        else:
+            # submit = dag.submit_local
+            return dag.submit_local(
+                self.func,
+                name=self.input.name,
+                *self.args,
+                **self.kwargs,
+            )
+
+
+def _udf(
+    func: Optional[Union[Callable, str]] = None,
     *args: Any,
     name: Optional[str] = None,
-    mode: str = "realtime",
+    mode: enum.Enum = Mode.REALTIME,
     namespace: Optional[str] = None,
-    acn: Optional[str] = None,
-    resources: Optional[Resources] = None,
-    image_name: Optional[str] = None,
     retry_limit: int = 0,
+    timeout: Optional[int] = None,
+    wait: bool = True,
+    acn: Optional[str] = None,
+    resource_class: Optional[str] = None,
+    cpu: Optional[int] = None,
+    memory_gb: Optional[int] = None,
+    expand: Optional[str] = None,
+    image_name: Optional[str] = None,
     **kwargs: Mapping[str, Any],
-) -> Union[Any, DAG]:
-    """Execute a registered UDF.
+):
+    logger.debug(f"args: {args}")
+    logger.debug(f"kwargs: {kwargs}")
 
-    :param func: UDF name (e.g. namespace/udf-name).
-    :param args: Positional arguments to pass to function.
-    :param name: Task name.
-    :param mode: Execution mode.
-    :param namespace: Namespace to run registered UDF in.
-    :param acn: TileDB access credential name.
-    :param resources: Resources to apply to UDF.
-    :param image_name: UDF image name.
-    :param retry_limit: Maximum retry attempts.
-    :param kwargs: Keyword arguments to pass to function.
-    :return: Return value of function or a running DAG.
-    """
+    resources = Resources(
+        resource_class=resource_class,
+        cpu=cpu,
+        memory_gb=memory_gb,
+    )
 
-    config = UDFConfig(
+    input = UDFInput(
         name=name,
         mode=mode,
         namespace=namespace,
-        acn=acn,
-        image_name=image_name,
         retry_limit=retry_limit,
+        timeout=timeout,
+        wait=wait,
+        acn=acn,
         resources=resources,
+        expand=expand,
+        image_name=image_name,
     )
 
-    runner = UDFHandler(
+    # sub in private overrides if any
+    input.sub_private(**kwargs)
+
+    udf_runner = UDFHandler(
         func=func,
         args=args,
         kwargs=kwargs,
-        config=config,
+        input=input,
     )
 
-    return runner.run()
+    # Get the current DAG from the context variable.
+    # only applicable when udf included in @taskgraph
+    try:
+        dag = _dag_context.get()
+        logger.debug(f"DAG context found: {_dag_context}")
+    except LookupError:
+        dag = None
+        logger.debug("No DAG in context.")
+
+    # task is being run outside of a DAG context, run standalone UDF
+    if dag is None:
+        logger.debug("Running UDF in standalone")
+        return udf_runner.run()
+    else:
+        logger.debug("Running UDF within DAG context")
+
+        # inherit dag mode to override udf mode if conflict
+        if input.mode != dag.mode:
+            logger.warning(
+                f"UDF mode: {input.mode} != DAG mode: {dag.mode}. Inheriting DAG mode."
+            )
+            input.mode = dag.mode
+
+        return udf_runner.run_in_dag(dag)
 
 
 def udf(
     func: Optional[Union[Callable, str]] = None,
-    *registered_args: Any,
+    *args: Any,
     resource_class: Optional[str] = None,
     cpu: Optional[int] = None,
     memory_gb: Optional[int] = None,
@@ -220,12 +278,10 @@ def udf(
     image_name: Optional[str] = None,
     name: Optional[str] = None,
     mode: enum.Enum = Mode.REALTIME,
-    namespace: Optional[
-        str
-    ] = None,  # For UDF execution, separate from function namespace
+    namespace: Optional[str] = None,
     acn: Optional[str] = None,
     retry_limit: int = 0,
-    **registered_kwargs: Mapping[str, Any],
+    **kwargs: Mapping[str, Any],
 ) -> Any:
     """
     Function decorator for a TileDB task. When a function wrapped with this decorator
@@ -275,118 +331,66 @@ def udf(
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            logger.debug(f"args: {args}")
-            logger.debug(f"kwargs: {kwargs}")
-
-            _expand = kwargs.pop("_expand", expand)
-            _image_name = kwargs.pop("_image_name", image_name)
-            _name = kwargs.pop("_name", name or func.__name__)
-            _mode = kwargs.pop("_mode", mode)
-            _namespace = kwargs.pop("_namespace", namespace)
-            _acn = kwargs.pop("_acn", acn)
-            _retry_limit = kwargs.pop("_retry_limit", retry_limit)
-
-            # Get the current DAG from the context variable.
-            # only applicable when udf included in @taskgraph
-            dag = _dag_context.get(None)
-
-            _mode = _mode if not dag else str(dag.mode).lower()
-
-            _resources = Resources(
-                resource_class=kwargs.pop("_resource_class", resource_class),
-                cpu=kwargs.pop("_cpu", cpu),
-                memory_gb=kwargs.pop("_memory_gb", memory_gb),
-                mode=_mode,
-                validate_on_init=True,
+            return _udf(
+                func,
+                *args,
+                resource_class=resource_class,
+                cpu=cpu,
+                memory_gb=memory_gb,
+                expand=expand,
+                image_name=image_name,
+                name=name,
+                mode=mode,
+                namespace=namespace,
+                acn=acn,
+                retry_limit=retry_limit,
+                **kwargs,
             )
-
-            # Create config for UDF execution
-            config = UDFConfig(
-                expand=_expand,
-                image_name=_image_name,
-                name=_name,
-                mode=_mode,
-                namespace=_namespace,
-                acn=_acn,
-                retry_limit=_retry_limit,
-                resources=_resources,
-            )
-
-            # task is being run outside of a DAG context, run standalone UDF
-            if dag is None:
-                udf_runner = UDFHandler(
-                    func=func,
-                    args=args,
-                    kwargs=kwargs,
-                    config=config,
-                )
-
-                return udf_runner.run()
-            else:
-                if _expand is not None and _expand not in kwargs:
-                    raise ValueError(f"Expand argument '{_expand}' must be a kwarg")
-
-                logger.info(f"Running task: {_name} in '{dag}'")
-
-                # Update kwargs for the submit.
-                kwargs["name"] = _name
-                if not dag._is_local:
-                    if _image_name:
-                        kwargs["image_name"] = _image_name
-
-                    if dag._is_realtime:
-                        kwargs["resource_class"] = _resources.resource_class
-                        if _expand:
-                            raise ValueError(
-                                "Expand is only supported in batch task graphs"
-                            )
-                        submit = dag.submit
-                    # batch
-                    else:
-                        kwargs["access_credentials_name"] = dag._acn
-                        kwargs["resources"] = {
-                            "cpu": str(_resources.cpu),
-                            "memory": f"{_resources.memory_gb}Gi",
-                        }
-                        if _expand:
-                            kwargs["expand_node_output"] = kwargs.get(_expand, None)
-                            submit = dag.submit_udf_stage
-                        submit = dag.submit_udf_stage if _expand else dag.submit
-
-                else:
-                    submit = dag.submit_local
-
-                logger.info(f"Submit task: {_name}")
-                logger.info(f"  args = {args}")
-                logger.info(f"  kwargs = {kwargs}")
-
-                # Submit the task to the DAG.
-                return submit(func, *args, **kwargs)
 
         return wrapper
 
     # when no args passed to decorator
     if callable(func):
         return decorator(func)
-    # TODO: registered udf cannot inherit DAG context.
-    # can only be called standalone (e.g. udf("namespace/udf", ...))
     elif isinstance(func, str):
-        return exec_registered_udf(
-            func=func,
-            *registered_args,
-            name=name or func,
+        return _udf(
+            func,
+            *args,
+            resource_class=resource_class,
+            cpu=cpu,
+            memory_gb=memory_gb,
+            expand=expand,
+            image_name=image_name,
+            name=name,
             mode=mode,
             namespace=namespace,
             acn=acn,
-            resources=Resources(
-                resource_class=resource_class,
-                cpu=cpu,
-                memory_gb=memory_gb,
-                mode=mode,
-            ),
-            image_name=image_name,
             retry_limit=retry_limit,
-            **registered_kwargs,
+            **kwargs,
         )
     else:
         return decorator
+
+
+if __name__ == "__main__":
+
+    @udf(mode=Mode.REALTIME)
+    def a(name):
+        print(f"Hello, {name}!")
+
+        return name
+
+    o = a("ss")
+    print(o)
+
+    @udf(mode=Mode.BATCH)
+    def a(name):
+        print(f"Hello, {name}!")
+
+        return name
+
+    o = a("ss")
+    print(o)
+
+    med = udf("TileDB-Inc/my_median", vals=[1, 5])
+    print(f"med: {med}")

--- a/src/tiledb/cloud/dag/decorators/_udf.py
+++ b/src/tiledb/cloud/dag/decorators/_udf.py
@@ -10,7 +10,8 @@ from tiledb.cloud.dag import DAG
 from tiledb.cloud.dag import Mode
 from tiledb.cloud.dag.decorators._context import _dag_context
 from tiledb.cloud.dag.decorators._inputs import UDFInput
-from tiledb.cloud.dag.decorators._log import log_submission
+from tiledb.cloud.dag.decorators._log import log_node_submission
+from tiledb.cloud.dag.decorators._log import log_tg_submission
 from tiledb.cloud.dag.decorators._resources import Resources
 from tiledb.cloud.udf import exec as udf_exec
 from tiledb.cloud.utilities.logging import get_logger
@@ -111,7 +112,7 @@ class UDFHandler:
 
         graph.compute()
 
-        task_uri = log_submission(
+        task_uri = log_tg_submission(
             namespace=graph.namespace,
             server_graph_uuid=graph.server_graph_uuid,
         )
@@ -166,10 +167,13 @@ class UDFHandler:
                     dyn_params["expand_node_output"] = self.input.expand
                 submit = dag.submit_udf_stage if self.input.expand else dag.submit
 
-            logger.info(f"> Submit UDF {self.input.name} to {dag}")
-            logger.info(f"|---args = {self.args}")
-            logger.info(f"|---kwargs = {self.kwargs}")
-            logger.info(f"|---resources = {dyn_params[rkey]}")
+            log_node_submission(
+                name=self.input.name,
+                dag=dag,
+                args=self.args,
+                kwargs=self.kwargs,
+                resources=dyn_params[rkey],
+            )
 
             # Submit the task to the DAG with dynamic parameters
             return submit(

--- a/src/tiledb/cloud/dag/decorators/_udf.py
+++ b/src/tiledb/cloud/dag/decorators/_udf.py
@@ -1,0 +1,392 @@
+import enum
+import webbrowser
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
+
+from attrs import define
+from attrs import field
+
+from tiledb.cloud import models
+from tiledb.cloud.dag import DAG
+from tiledb.cloud.dag import Mode
+from tiledb.cloud.dag.decorators._resources import Resources
+from tiledb.cloud.dag.decorators._resources import load_defaults
+from tiledb.cloud.udf import exec as udf_exec
+from tiledb.cloud.utilities.logging import get_logger
+
+logger = get_logger()
+
+# Context variable to hold the active (and potentially nested) DAG contexts.
+_dag_context: ContextVar[DAG] = ContextVar("current_dag")
+
+
+@dataclass(frozen=True)
+class UDFConfig:
+    """Configuration for UDF decorator execution."""
+
+    expand: Optional[str] = None
+    image_name: Optional[str] = None
+    name: Optional[str] = None
+    mode: enum.Enum = Mode.REALTIME
+    namespace: Optional[str] = None
+    acn: Optional[str] = None
+    retry_limit: int = 0
+    resources: Optional[Resources] = None
+    timeout: Optional[int] = None
+
+
+@define
+class UDFHandler:
+    """Orchestrate UDF mode to run:"""
+
+    func: Union[callable, str]
+    """Function to execute."""
+    args: Sequence[Any]
+    """Positional arguments to pass to function."""
+    kwargs: Mapping[str, Any]
+    """Keyword arguments to pass to function."""
+    config: UDFConfig
+    """UDF configuration."""
+    mode_opts: Sequence[str] = field(
+        factory=lambda: load_defaults(
+            file="modes.toml",
+            toml_key="mode_options",
+        )
+    )
+    """Valid execution modes."""
+    log_url: str = "https://cloud.tiledb.com/activity/taskgraphs/{}/{}"
+    """Task graph log URL."""
+
+    def __attrs_post_init__(self) -> None:
+        if str(self.config.mode).lower() not in self.mode_opts:
+            raise ValueError(f"Invalid UDF mode: {self.config.mode}")
+
+    def exec_local(self) -> Any:
+        """Exec local UDF.
+
+        :return: Return value of function.
+        """
+
+        self.func(*self.args, **self.kwargs)
+
+    def exec_realtime(self) -> Any:
+        """Exec realtime UDF.
+
+        :return: Return value of function.
+        """
+
+        return udf_exec(
+            self.func,
+            *self.args,
+            task_name=self.config.name,
+            namespace=self.config.namespace,
+            resource_class=self.config.resources.resource_class
+            if self.config.resources
+            else None,
+            image_name=self.config.image_name,
+            timeout=self.config.timeout,
+            **self.kwargs,
+        )
+
+    def exec_batch(
+        self,
+        open_browser: bool = False,
+    ) -> DAG:
+        """Exec batch UDF.
+
+        Async execution, obtain results from DAG.
+
+        `open_browser` is not yet wired from caller. TBD if this feature is suitable.
+
+        :param open_browser: Whether to open browser to batch UDF logs.
+        :return: Running DAG object.
+        """
+
+        graph = DAG(
+            name=f"batch->{self.config.name}",
+            namespace=self.config.namespace,
+            mode=Mode.BATCH,
+            retry_strategy=models.RetryStrategy(
+                limit=self.config.retry_limit,
+                retry_policy="Always",
+            ),
+            deadline=self.config.timeout,
+        )
+
+        graph.submit(
+            self.func,
+            *self.args,
+            name=self.config.name,
+            access_credentials_name=self.config.acn,
+            resources={
+                "cpu": str(self.config.resources.cpu),
+                "memory": f"{self.config.resources.memory_gb}Gi",
+            }
+            if self.config.resources
+            else None,
+            image_name=self.config.image_name,
+            **self.kwargs,
+        )
+
+        graph.compute()
+
+        task_uri = self.log_url.format(
+            graph.namespace,
+            graph.server_graph_uuid,
+        )
+
+        logger.info(f"TileDB Cloud task submitted - {task_uri}")
+
+        if open_browser:
+            try:
+                webbrowser.open_new_tab(task_uri)
+            except webbrowser.Error:
+                logger.debug("Unable to access webrowser.")
+
+        return graph
+
+    def run(self) -> Union[Any, DAG]:
+        """Run UDF.
+
+        :return: Return value of function or a running DAG.
+        """
+
+        if self.config.mode == "local":
+            return self.exec_local()
+        else:
+            return (
+                self.exec_realtime()
+                if self.config.mode == Mode.REALTIME
+                else self.exec_batch()
+            )
+
+
+def exec_registered_udf(
+    func: str,
+    *args: Any,
+    name: Optional[str] = None,
+    mode: str = "realtime",
+    namespace: Optional[str] = None,
+    acn: Optional[str] = None,
+    resources: Optional[Resources] = None,
+    image_name: Optional[str] = None,
+    retry_limit: int = 0,
+    **kwargs: Mapping[str, Any],
+) -> Union[Any, DAG]:
+    """Execute a registered UDF.
+
+    :param func: UDF name (e.g. namespace/udf-name).
+    :param args: Positional arguments to pass to function.
+    :param name: Task name.
+    :param mode: Execution mode.
+    :param namespace: Namespace to run registered UDF in.
+    :param acn: TileDB access credential name.
+    :param resources: Resources to apply to UDF.
+    :param image_name: UDF image name.
+    :param retry_limit: Maximum retry attempts.
+    :param kwargs: Keyword arguments to pass to function.
+    :return: Return value of function or a running DAG.
+    """
+
+    config = UDFConfig(
+        name=name,
+        mode=mode,
+        namespace=namespace,
+        acn=acn,
+        image_name=image_name,
+        retry_limit=retry_limit,
+        resources=resources,
+    )
+
+    runner = UDFHandler(
+        func=func,
+        args=args,
+        kwargs=kwargs,
+        config=config,
+    )
+
+    return runner.run()
+
+
+def udf(
+    func: Optional[Union[Callable, str]] = None,
+    *registered_args: Any,
+    resource_class: Optional[str] = None,
+    cpu: Optional[int] = None,
+    memory_gb: Optional[int] = None,
+    expand: Optional[str] = None,
+    image_name: Optional[str] = None,
+    name: Optional[str] = None,
+    mode: enum.Enum = Mode.REALTIME,
+    namespace: Optional[
+        str
+    ] = None,  # For UDF execution, separate from function namespace
+    acn: Optional[str] = None,
+    retry_limit: int = 0,
+    **registered_kwargs: Mapping[str, Any],
+) -> Any:
+    """
+    Function decorator for a TileDB task. When a function wrapped with this decorator
+    is executed:
+
+    1. Get the DAG from the current DAG context.
+    2. Submit the task to the DAG using the specified parameters.
+
+    If the decorated function is run outside of a DAG context, it will run locally.
+
+    Kwargs to the wrapped function can override kwargs in the original decorator
+    following the convention of prepending the arg name with an underscore.
+
+    For example:
+
+        ```python
+        @udf(resource_class="standard")
+        def compute_task(a):
+            # Do some work.
+            return result
+
+        @taskgraph(mode="realtime")
+        def compute_taskgraph(a):
+            # Override the original resource class.
+            return compute_task(a, _resource_class="large")
+
+        # Run the task graph.
+        compute_taskgraph(16)
+        ```
+
+    :param resource_class: TileDB resource class, "standard"|"large", defaults to None
+    :param cpu: number of vCPUs required, defaults to None
+    :param memory_gb: GiB of memory required, defaults to None
+    :param expand: name of the argument to expand and create multiple tasks dynamically,
+        defaults to None
+    :param image_name: TileDB UDF image name, defaults to None
+    :param name: the task name in TileDB logs, defaults to None, which uses the function
+        name
+    :param mode: execution mode when running as a single UDF,
+        Mode.REALTIME|Mode.BATCH|Mode.LOCAL. defaults to Mode.REALTIME
+    :param namespace: TileDB namespace when running as a single UDF, defaults to None
+    :param acn: TileDB access credential name to authenticate batch UDF
+        to access underingly storage backend. Not applicable to realtime mode.
+    :param retry_limit: Maximum retry attempts for batch UDF.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger.debug(f"args: {args}")
+            logger.debug(f"kwargs: {kwargs}")
+
+            _expand = kwargs.pop("_expand", expand)
+            _image_name = kwargs.pop("_image_name", image_name)
+            _name = kwargs.pop("_name", name or func.__name__)
+            _mode = kwargs.pop("_mode", mode)
+            _namespace = kwargs.pop("_namespace", namespace)
+            _acn = kwargs.pop("_acn", acn)
+            _retry_limit = kwargs.pop("_retry_limit", retry_limit)
+
+            # Get the current DAG from the context variable.
+            # only applicable when udf included in @taskgraph
+            dag = _dag_context.get(None)
+
+            _mode = _mode if not dag else str(dag.mode).lower()
+
+            _resources = Resources(
+                resource_class=kwargs.pop("_resource_class", resource_class),
+                cpu=kwargs.pop("_cpu", cpu),
+                memory_gb=kwargs.pop("_memory_gb", memory_gb),
+                mode=_mode,
+                validate_on_init=True,
+            )
+
+            # Create config for UDF execution
+            config = UDFConfig(
+                expand=_expand,
+                image_name=_image_name,
+                name=_name,
+                mode=_mode,
+                namespace=_namespace,
+                acn=_acn,
+                retry_limit=_retry_limit,
+                resources=_resources,
+            )
+
+            # task is being run outside of a DAG context, run standalone UDF
+            if dag is None:
+                udf_runner = UDFHandler(
+                    func=func,
+                    args=args,
+                    kwargs=kwargs,
+                    config=config,
+                )
+
+                return udf_runner.run()
+            else:
+                if _expand is not None and _expand not in kwargs:
+                    raise ValueError(f"Expand argument '{_expand}' must be a kwarg")
+
+                logger.info(f"Running task: {_name} in '{dag}'")
+
+                # Update kwargs for the submit.
+                kwargs["name"] = _name
+                if not dag._is_local:
+                    if _image_name:
+                        kwargs["image_name"] = _image_name
+
+                    if dag._is_realtime:
+                        kwargs["resource_class"] = _resources.resource_class
+                        if _expand:
+                            raise ValueError(
+                                "Expand is only supported in batch task graphs"
+                            )
+                        submit = dag.submit
+                    # batch
+                    else:
+                        kwargs["access_credentials_name"] = dag._acn
+                        kwargs["resources"] = {
+                            "cpu": str(_resources.cpu),
+                            "memory": f"{_resources.memory_gb}Gi",
+                        }
+                        if _expand:
+                            kwargs["expand_node_output"] = kwargs.get(_expand, None)
+                            submit = dag.submit_udf_stage
+                        submit = dag.submit_udf_stage if _expand else dag.submit
+
+                else:
+                    submit = dag.submit_local
+
+                logger.info(f"Submit task: {_name}")
+                logger.info(f"  args = {args}")
+                logger.info(f"  kwargs = {kwargs}")
+
+                # Submit the task to the DAG.
+                return submit(func, *args, **kwargs)
+
+        return wrapper
+
+    # when no args passed to decorator
+    if callable(func):
+        return decorator(func)
+    # TODO: registered udf cannot inherit DAG context.
+    # can only be called standalone (e.g. udf("namespace/udf", ...))
+    elif isinstance(func, str):
+        return exec_registered_udf(
+            func=func,
+            *registered_args,
+            name=name or func,
+            mode=mode,
+            namespace=namespace,
+            acn=acn,
+            resources=Resources(
+                resource_class=resource_class,
+                cpu=cpu,
+                memory_gb=memory_gb,
+                mode=mode,
+            ),
+            image_name=image_name,
+            retry_limit=retry_limit,
+            **registered_kwargs,
+        )
+    else:
+        return decorator

--- a/src/tiledb/cloud/dag/decorators/_udf.py
+++ b/src/tiledb/cloud/dag/decorators/_udf.py
@@ -10,6 +10,7 @@ from tiledb.cloud.dag import DAG
 from tiledb.cloud.dag import Mode
 from tiledb.cloud.dag.decorators._context import _dag_context
 from tiledb.cloud.dag.decorators._inputs import UDFInput
+from tiledb.cloud.dag.decorators._log import log_submission
 from tiledb.cloud.dag.decorators._resources import Resources
 from tiledb.cloud.udf import exec as udf_exec
 from tiledb.cloud.utilities.logging import get_logger
@@ -110,12 +111,10 @@ class UDFHandler:
 
         graph.compute()
 
-        task_uri = self.log_url.format(
-            graph.namespace,
-            graph.server_graph_uuid,
+        task_uri = log_submission(
+            namespace=graph.namespace,
+            server_graph_uuid=graph.server_graph_uuid,
         )
-
-        logger.info(f"TileDB Cloud task submitted - {task_uri}")
 
         if open_browser:
             try:
@@ -370,27 +369,3 @@ def udf(
         )
     else:
         return decorator
-
-
-if __name__ == "__main__":
-
-    @udf(mode=Mode.REALTIME)
-    def a(name):
-        print(f"Hello, {name}!")
-
-        return name
-
-    o = a("ss")
-    print(o)
-
-    @udf(mode=Mode.BATCH)
-    def a(name):
-        print(f"Hello, {name}!")
-
-        return name
-
-    o = a("ss")
-    print(o)
-
-    med = udf("TileDB-Inc/my_median", vals=[1, 5])
-    print(f"med: {med}")

--- a/src/tiledb/cloud/dag/decorators/configs/modes.toml
+++ b/src/tiledb/cloud/dag/decorators/configs/modes.toml
@@ -1,6 +1,0 @@
-
-mode_options = [
-    "local",
-    "realtime",
-    "batch"
-]

--- a/src/tiledb/cloud/dag/decorators/configs/modes.toml
+++ b/src/tiledb/cloud/dag/decorators/configs/modes.toml
@@ -1,0 +1,6 @@
+
+mode_options = [
+    "local",
+    "realtime",
+    "batch"
+]

--- a/src/tiledb/cloud/dag/decorators/configs/resources.toml
+++ b/src/tiledb/cloud/dag/decorators/configs/resources.toml
@@ -1,0 +1,5 @@
+
+resource_options = [
+    "standard",
+    "large"
+]


### PR DESCRIPTION
Put in place the general structure of `@udf` and `@taskgraph` with most core functionality worked out. I made large changes to original rough draft to be a lot more modular.

@sgillies I need you to review the general design before I invest in the unit testing and below "remaining items". From my taskgraph usage, this has already been exciting for me to be able to use these.

Added a lot of logging that I think will be welcomed, for example a taskgraph run:

```python
from tiledb.cloud.dag import Mode
from tiledb.cloud.dag.decorators import udf, taskgraph

@udf(mode=Mode.REALTIME)
def a(number):
    print(f"Received {number} from tg start")

    return number

@udf(mode=Mode.BATCH)
def b(number):
    print(f"Received {number} from a")

    return number

@taskgraph(mode=Mode.BATCH, wait=False)
def tg(number):
    o = a(number)
    o2 = b(o)
    med = udf("TileDB-Inc/my_median", vals=[o2, 10])
    return med

result = tg(1)
print(result)
```

Will result in:
```
[2025-08-20 16:24:50,896] [_taskgraph] [taskgraph_context] [INFO] Initialize DAG: name=tg, mode=Batch, namespace=None
[2025-08-20 16:24:50,904] [_udf] [_udf] [WARNING] UDF mode: Realtime != DAG mode: Batch. Inheriting DAG mode.
[2025-08-20 16:24:50,904] [_udf] [run_in_dag] [INFO] > Submit UDF a to <tiledb.cloud.dag.dag.DAG object at 0x12ff345e0>
[2025-08-20 16:24:50,904] [_udf] [run_in_dag] [INFO] |---args = (1,)
[2025-08-20 16:24:50,904] [_udf] [run_in_dag] [INFO] |---kwargs = {}
[2025-08-20 16:24:50,904] [_udf] [run_in_dag] [INFO] |---resources = {'cpu': '2', 'memory': '2Gi'}
[2025-08-20 16:24:50,905] [_udf] [run_in_dag] [INFO] > Submit UDF b to <tiledb.cloud.dag.dag.DAG object at 0x12ff345e0>
[2025-08-20 16:24:50,905] [_udf] [run_in_dag] [INFO] |---args = (<tiledb.cloud.dag.dag.Node object at 0x12ffaf820>,)
[2025-08-20 16:24:50,905] [_udf] [run_in_dag] [INFO] |---kwargs = {}
[2025-08-20 16:24:50,906] [_udf] [run_in_dag] [INFO] |---resources = {'cpu': '2', 'memory': '2Gi'}
[2025-08-20 16:24:50,906] [_udf] [_udf] [WARNING] UDF mode: Realtime != DAG mode: Batch. Inheriting DAG mode.
[2025-08-20 16:24:50,906] [_udf] [run_in_dag] [INFO] > Submit UDF TileDB-Inc/my_median to <tiledb.cloud.dag.dag.DAG object at 0x12ff345e0>
[2025-08-20 16:24:50,906] [_udf] [run_in_dag] [INFO] |---args = ()
[2025-08-20 16:24:50,906] [_udf] [run_in_dag] [INFO] |---kwargs = {'vals': [<tiledb.cloud.dag.dag.Node object at 0x12ffaa070>, 10]}
[2025-08-20 16:24:50,906] [_udf] [run_in_dag] [INFO] |---resources = {'cpu': '2', 'memory': '2Gi'}
[2025-08-20 16:24:53,441] [_log] [log_submission] [INFO] Task graph submitted - https://cloud.tiledb.com/activity/taskgraphs/TileDB-Inc/6084903a-3139-45c4-8a35-ab592134e9c8
<tiledb.cloud.dag.dag.Node object at 0x12ffb68b0>
```

Udfs functioning standalone nicely as well:

```python
from tiledb.cloud.dag import Mode
from tiledb.cloud.dag.decorators import udf

@udf(mode=Mode.REALTIME)
def a(name):
    print(f"Hello, {name}!")

    return name

o = a("ss")
print(o)

@udf(mode=Mode.BATCH)
def a(name):
    print(f"Hello, {name}!")

    return name

o = a("ss")
print(o)

med = udf("TileDB-Inc/my_median", vals=[1, 5])
print(f"med: {med}")
```

### Remaining items
* Test dynamic output expansion with `udf(expand)`
* Vet more complex scenarios
* Vet resources flexibility
* Vet private (`_arg`) override of existing args (partially tested)
* unittests
* Registration of taskgraph and udf funcs (may need to wait for next tiledb major release)
* Calling of registered taskgraph (may need to wait for next tiledb major release)