### PR TITLE
manual override for group_fragments

### DIFF
--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -140,6 +140,7 @@ def consolidate_fragments(
     graph: Optional[dag.DAG] = None,
     dependencies: Optional[Sequence[dag.Node]] = None,
     consolidate_resources: Optional[Mapping[str, str]] = None,
+    group_fragments_resources: Optional[Mapping[str, str]] = None,
     namespace: Optional[str] = None,
     max_fragment_size: int = MAX_FRAGMENT_SIZE_BYTES,
 ) -> None:
@@ -165,6 +166,7 @@ def consolidate_fragments(
     :param graph: graph to submit nodes to, defaults to None
     :param dependencies: list of nodes in the graph to depend on, defaults to None
     :param consolidate_resources: resources for the consolidate node, defaults to None
+    :param group_fragments_resource: resources for the group_fragments node, defaults to None
     :param namespace: TileDB Cloud namespace, defaults to the user's default namespace
     :param max_fragment_size: max size of consolidated fragments,
         defaults to MAX_FRAGMENT_SIZE_BYTES
@@ -197,6 +199,12 @@ def consolidate_fragments(
         "memory": "16Gi",
     }
 
+    # Set resources for the group fragments node, if not provided.
+    group_fragments_resources = group_fragments_resources or {
+        "cpu": "2",
+        "memory": "16Gi",
+    }
+
     name = basename(array_uri)
 
     fragment_groups = graph.submit(
@@ -206,10 +214,7 @@ def consolidate_fragments(
         group_by_first_dim=group_by_first_dim,
         name=f"Groups Fragments - {name}",
         access_credentials_name=acn,
-        resources={
-            "cpu": "1",
-            "memory": "1Gi",
-        },
+        resources=group_fragments_resources,
     )
 
     if dependencies:

--- a/src/tiledb/cloud/utilities/consolidate.py
+++ b/src/tiledb/cloud/utilities/consolidate.py
@@ -165,8 +165,10 @@ def consolidate_fragments(
     :param group_by_first_dim: group fragment by first dimension, defaults to True
     :param graph: graph to submit nodes to, defaults to None
     :param dependencies: list of nodes in the graph to depend on, defaults to None
-    :param consolidate_resources: resources for the consolidate node, defaults to None
-    :param group_fragments_resource: resources for the group_fragments node, defaults to None
+    :param consolidate_resources: resources for the consolidate node,
+        defaults to None
+    :param group_fragments_resources: resources for the group_fragments node,
+        defaults to None
     :param namespace: TileDB Cloud namespace, defaults to the user's default namespace
     :param max_fragment_size: max size of consolidated fragments,
         defaults to MAX_FRAGMENT_SIZE_BYTES

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -68,7 +68,7 @@ FILTER_SAMPLES_RESOURCES = {
 GROUP_FRAGMENTS_RESOURCES = {
     "cpu": "2",
     "memory": "16Gi",
-} 
+}
 
 
 class Contigs(enum.Enum):
@@ -274,7 +274,8 @@ def register_dataset_udf(
                 )
 
         except Exception:
-            # tiledb.object_type raises an exception if the namespace does not exist
+            # tiledb.object_type raises an exception if the namespace does not
+            # exist
             logger.error(
                 "Error checking if %r is registered. Bad namespace?", tiledb_uri
             )
@@ -908,7 +909,8 @@ def consolidate_dataset_udf(
                 if (exclude and name in exclude) or (include and name not in include):
                     continue
 
-                # NOTE: REST currently only supports fragment_meta, commits, metadata
+                # NOTE: REST currently only supports fragment_meta, commits,
+                # metadata
                 modes = ["commits", "fragment_meta"]
 
                 # Consolidate fragments for selected arrays
@@ -996,7 +998,8 @@ def ingest_manifest_dag(
         defaults to CONSOLIDATE_RESOURCES
     :param manifest_resources: manual override for manifest UDF resources,
         defaults to MANIFEST_RESOURCES
-    :param create_resources: manual override for create UDF resources, defaults to None
+    :param create_resources: manual override for create UDF resources,
+        defaults to None
     :param read_vcf_uris_resources: manual override for read VCF UDF resources,
         defaults to None
     :param filter_uri_resources: manual override for filter VCF UDF resources,
@@ -1125,10 +1128,10 @@ def ingest_manifest_dag(
                 config=config,
                 exclude=None,
                 include=[MANIFEST_ARRAY, LOG_ARRAY],
-                id=f"manifest-consol-{i//workers}",
+                id=f"manifest-consol-{i // workers}",
                 verbose=verbose,
                 resources=consolidate_resources,
-                name=f"Consolidate VCF Manifest {i//workers + 1}/{num_consolidates}",
+                name=f"Consolidate VCF Manifest {i // workers + 1}/{num_consolidates}",
                 access_credentials_name=acn,
             )
 
@@ -1140,7 +1143,7 @@ def ingest_manifest_dag(
             verbose=verbose,
             id=f"manifest-ingest-{i}",
             resources=manifest_resources,
-            name=f"Ingest VCF Manifest {i+1}/{num_partitions}",
+            name=f"Ingest VCF Manifest {i + 1}/{num_partitions}",
             access_credentials_name=acn,
         )
         if prev_consolidate:
@@ -1202,12 +1205,14 @@ def ingest_samples_dag(
     :param use_remote_tmp: use remote tmp space if VCFs need to be bgzipped,
         defaults to False (preferred for small VCFs)
     :param sample_list_uri: URI with a list of VCF URIs, defaults to None
-    :param ingest_resources: manual override for ingest UDF resources, defaults to None
+    :param ingest_resources: manual override for ingest UDF resources,
+        defaults to None
     :param consolidate_resources: manual override for consolidate UDF resources,
-        defaults to None
+        defaults to CONSOLIDATE_RESOURCES
     :param filter_samples_resources: manual override for filter samples UDF resources,
-        defaults to None
-    :param group_fragments_resources: resources for the group_fragments node, defaults to None
+        defaults to FILTER_SAMPLES_RESOURCES
+    :param group_fragments_resources: resources for the group_fragments node,
+        defaults to GROUP_FRAGMENTS_RESOURCES
     """
 
     logger = get_logger_wrapper(verbose)
@@ -1253,7 +1258,7 @@ def ingest_samples_dag(
         sample_uris = sample_uris[:max_samples]
 
     contig_fragment_merging = True
-    if type(contigs) == list:
+    if isinstance(contigs, list):
         contig_mode = "separate"
         contigs_to_keep_separate = contigs
     else:
@@ -1308,10 +1313,10 @@ def ingest_samples_dag(
                 consolidate_dataset_udf,
                 dataset_uri,
                 config=config,
-                id=f"vcf-consol-{i//workers}",
+                id=f"vcf-consol-{i // workers}",
                 verbose=verbose,
                 resources=consolidate_resources,
-                name=f"Consolidate VCF {i//workers + 1}/{num_consolidates}",
+                name=f"Consolidate VCF {i // workers + 1}/{num_consolidates}",
                 access_credentials_name=acn,
             )
 
@@ -1333,7 +1338,7 @@ def ingest_samples_dag(
             create_index=create_index,
             trace_id=trace_id,
             resources=ingest_resources,
-            name=f"Ingest VCF {i+1}/{num_partitions}",
+            name=f"Ingest VCF {i + 1}/{num_partitions}",
             access_credentials_name=acn,
         )
 
@@ -1425,7 +1430,7 @@ def ingest_vcf_annotations(
     :param verbose: verbose logging, defaults to False
     :param ingest_resources: manual override for ingest UDF resources, defaults to None
     :param consolidate_resources: manual override for consolidate UDF resources,
-        defaults to None
+        defaults to CONSOLIDATE_RESOURCES
     :param find_uris_resources: manual override for find VCF UDF resources,
         defaults to None
     :param create_resources: manual override for create UDF resources, defaults to None
@@ -1529,7 +1534,7 @@ def ingest_vcf_annotations(
             create_index=create_index,
             verbose=verbose,
             resources=ingest_resources,
-            name=f"Ingest annotations {i+1}/{len(vcf_uris)}",
+            name=f"Ingest annotations {i + 1}/{len(vcf_uris)}",
             access_credentials_name=acn,
         )
 
@@ -1663,7 +1668,8 @@ def ingest_vcf(
         defaults to None
     :param filter_samples_resources: manual override for filter samples UDF resources,
         defaults to FILTER_SAMPLES_RESOURCES
-    :param group_fragments_resources: resources for the group_fragments node, defaults to None
+    :param group_fragments_resources: resources for the group_fragments node,
+        defaults to GROUP_FRAGMENTS_RESOURCES
     """
 
     # Validate user input

--- a/src/tiledb/cloud/vcf/ingestion.py
+++ b/src/tiledb/cloud/vcf/ingestion.py
@@ -64,6 +64,12 @@ FILTER_SAMPLES_RESOURCES = {
     "memory": "8Gi",
 }
 
+# Group fragments task resources
+GROUP_FRAGMENTS_RESOURCES = {
+    "cpu": "2",
+    "memory": "16Gi",
+} 
+
 
 class Contigs(enum.Enum):
     """
@@ -1168,6 +1174,7 @@ def ingest_samples_dag(
     ingest_resources: Optional[Mapping[str, str]] = None,
     consolidate_resources: Optional[Mapping[str, str]] = CONSOLIDATE_RESOURCES,
     filter_samples_resources: Optional[Mapping[str, str]] = FILTER_SAMPLES_RESOURCES,
+    group_fragments_resources: Optional[Mapping[str, str]] = GROUP_FRAGMENTS_RESOURCES,
 ) -> None:
     """
     Create a DAG to ingest samples into the dataset.
@@ -1200,6 +1207,7 @@ def ingest_samples_dag(
         defaults to None
     :param filter_samples_resources: manual override for filter samples UDF resources,
         defaults to None
+    :param group_fragments_resources: resources for the group_fragments node, defaults to None
     """
 
     logger = get_logger_wrapper(verbose)
@@ -1358,6 +1366,8 @@ def ingest_samples_dag(
                     group_by_first_dim=True,
                     graph=graph,
                     dependencies=[consolidate],
+                    consolidate_resources=consolidate_resources,
+                    group_fragments_resources=group_fragments_resources,
                 )
 
     logger.info("Ingesting %d samples.", len(sample_uris))
@@ -1592,6 +1602,7 @@ def ingest_vcf(
     read_vcf_uris_resources: Optional[Mapping[str, str]] = None,
     filter_uri_resources: Optional[Mapping[str, str]] = None,
     filter_samples_resources: Optional[Mapping[str, str]] = FILTER_SAMPLES_RESOURCES,
+    group_fragments_resources: Optional[Mapping[str, str]] = GROUP_FRAGMENTS_RESOURCES,
 ) -> None:
     """
     Ingest samples into a dataset.
@@ -1652,6 +1663,7 @@ def ingest_vcf(
         defaults to None
     :param filter_samples_resources: manual override for filter samples UDF resources,
         defaults to FILTER_SAMPLES_RESOURCES
+    :param group_fragments_resources: resources for the group_fragments node, defaults to None
     """
 
     # Validate user input
@@ -1726,6 +1738,7 @@ def ingest_vcf(
         sample_list_uri=sample_list_uri if disable_manifest else None,
         consolidate_resources=consolidate_resources,
         filter_samples_resources=filter_samples_resources,
+        group_fragments_resources=group_fragments_resources,
     )
 
     # Register the dataset on TileDB Cloud


### PR DESCRIPTION
Provide a manual override for the `from tiledb.cloud.utilities import consolidate_fragments` which is currently failing (OOM) for AZ to vacuum and consolidate variant stats and allele count arrays. 
 